### PR TITLE
switch to V1 path for API

### DIFF
--- a/castai/config.go
+++ b/castai/config.go
@@ -12,6 +12,8 @@ import (
 	"github.com/castai/terraform-provider-castai/castai/sdk"
 )
 
+const DefaultAPIURL = "https://api.cast.ai/v1/"
+
 type Config struct {
 	ApiUrl   string
 	ApiToken string
@@ -27,7 +29,7 @@ func (c *Config) configureProvider() (interface{}, error) {
 		return nil, err
 	}
 	if baseURL.String() == "" {
-		baseURL.Path = "https://api.cast.ai/"
+		baseURL.Path = DefaultAPIURL
 	}
 
 	httpClientOption := func(client *sdk.Client) error {

--- a/castai/config.go
+++ b/castai/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
@@ -22,10 +21,6 @@ type ProviderConfig struct {
 }
 
 func (c *Config) configureProvider() (interface{}, error) {
-	if _, err := url.Parse(c.ApiUrl); err != nil {
-		return nil, fmt.Errorf("parsing API URL: %w", err)
-	}
-
 	httpClientOption := func(client *sdk.Client) error {
 		client.Client = &http.Client{
 			Transport: logging.NewTransport("CAST.AI", http.DefaultTransport),

--- a/castai/config.go
+++ b/castai/config.go
@@ -12,8 +12,6 @@ import (
 	"github.com/castai/terraform-provider-castai/castai/sdk"
 )
 
-const DefaultAPIURL = "https://api.cast.ai/v1/"
-
 type Config struct {
 	ApiUrl   string
 	ApiToken string
@@ -24,12 +22,8 @@ type ProviderConfig struct {
 }
 
 func (c *Config) configureProvider() (interface{}, error) {
-	baseURL, err := url.Parse(c.ApiUrl)
-	if err != nil {
-		return nil, err
-	}
-	if baseURL.String() == "" {
-		baseURL.Path = DefaultAPIURL
+	if _, err := url.Parse(c.ApiUrl); err != nil {
+		return nil, fmt.Errorf("parsing API URL: %w", err)
 	}
 
 	httpClientOption := func(client *sdk.Client) error {

--- a/castai/provider.go
+++ b/castai/provider.go
@@ -13,7 +13,7 @@ func Provider() *schema.Provider {
 			"api_url": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CASTAI_API_URL", DefaultAPIURL),
+				DefaultFunc: schema.EnvDefaultFunc("CASTAI_API_URL", "https://api.cast.ai/v1"),
 				Description: "CAST.AI API url.",
 			},
 			"api_token": {

--- a/castai/provider.go
+++ b/castai/provider.go
@@ -5,16 +5,18 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func Provider() *schema.Provider {
 	p := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"api_url": {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CASTAI_API_URL", "https://api.cast.ai/v1"),
-				Description: "CAST.AI API url.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: toDiagFunc(validation.IsURLWithHTTPS),
+				DefaultFunc:      schema.EnvDefaultFunc("CASTAI_API_URL", "https://api.cast.ai/v1"),
+				Description:      "CAST.AI API url.",
 			},
 			"api_token": {
 				Type:        schema.TypeString,

--- a/castai/provider.go
+++ b/castai/provider.go
@@ -13,7 +13,7 @@ func Provider() *schema.Provider {
 			"api_url": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CASTAI_API_URL", "https://api.cast.ai"),
+				DefaultFunc: schema.EnvDefaultFunc("CASTAI_API_URL", DefaultAPIURL),
 				Description: "CAST.AI API url.",
 			},
 			"api_token": {

--- a/castai/sdk/spec.yaml
+++ b/castai/sdk/spec.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 servers:
-  - url: 'https://console.cast.api/api'
+  - url: 'https://api.cast.ai/v1'
 info:
   description: |
     cast.ai console API

--- a/examples/localdev/main.tf.sample
+++ b/examples/localdev/main.tf.sample
@@ -1,5 +1,5 @@
 provider "castai" {
-  api_url   = "https://console.dev-master.cast.ai/api/"
+  api_url   = "https://api.dev-master.cast.ai/v1/"
   api_token = ""
 }
 


### PR DESCRIPTION
V1 of API is now prefixed with `/v1` in the path, and serving API from root will be dropped in the future.