### PR TITLE
Docs: Provider configuration requires api_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ terraform {
 }
 
 provider "castai" {
-  api_key = "<<your-castai-api-key>>"
+  api_token = "<<your-castai-api-key>>"
 }
 ```
 


### PR DESCRIPTION
...not api_key