### PR TITLE
CO-2326: Add the execution conditions to the scheduled rebalancing

### DIFF
--- a/castai/resource_rebalancing_job_test.go
+++ b/castai/resource_rebalancing_job_test.go
@@ -56,6 +56,10 @@ resource "castai_rebalancing_schedule" "test" {
 		savings_percentage = 15.25
 	}
 	launch_configuration {
+		execution_conditions {
+			enabled = false
+			achieved_savings_percentage = 0
+		}
 	}
 }
 

--- a/castai/resource_rebalancing_schedule_test.go
+++ b/castai/resource_rebalancing_schedule_test.go
@@ -58,6 +58,10 @@ resource "castai_rebalancing_schedule" "test" {
 		savings_percentage = 15.25
 	}
 	launch_configuration {
+		execution_conditions {
+			enabled = false
+			achieved_savings_percentage = 0
+		}
 	}
 }
 `
@@ -89,6 +93,10 @@ resource "castai_rebalancing_schedule" "test" {
 				]
 			}]
 		})
+		execution_conditions {
+			enabled = true
+			achieved_savings_percentage = 10
+		}
 	}
 }
 `

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -1388,6 +1388,16 @@ type ScheduledrebalancingV1DeleteRebalancingJobResponse = map[string]interface{}
 // ScheduledrebalancingV1DeleteRebalancingScheduleResponse defines model for scheduledrebalancing.v1.DeleteRebalancingScheduleResponse.
 type ScheduledrebalancingV1DeleteRebalancingScheduleResponse = map[string]interface{}
 
+// Defines the conditions which must be met in order to fully execute the plan.
+type ScheduledrebalancingV1ExecutionConditions struct {
+	// Identifies the minimum percentage of predicted savings that should be achieved.
+	// The rebalancing plan will not proceed after creating the nodes if the achieved savings percentage
+	// is not achieved.
+	// This field's value will not be considered if the initially predicted savings are negative.
+	AchievedSavingsPercentage *int32 `json:"achievedSavingsPercentage,omitempty"`
+	Enabled                   *bool  `json:"enabled,omitempty"`
+}
+
 // JobStatus defines rebalancing job's last execution status.
 type ScheduledrebalancingV1JobStatus string
 
@@ -1470,6 +1480,9 @@ type ScheduledrebalancingV1RebalancingJob struct {
 
 // ScheduledrebalancingV1RebalancingOptions defines model for scheduledrebalancing.v1.RebalancingOptions.
 type ScheduledrebalancingV1RebalancingOptions struct {
+	// Defines the conditions which must be met in order to fully execute the plan.
+	ExecutionConditions *ScheduledrebalancingV1ExecutionConditions `json:"executionConditions,omitempty"`
+
 	// Minimum number of nodes that should be kept in the cluster after rebalancing.
 	MinNodes *int32 `json:"minNodes,omitempty"`
 }

--- a/castai/utils.go
+++ b/castai/utils.go
@@ -64,6 +64,7 @@ func readOptionalValue[T any](d map[string]any, key string) *T {
 	if !ok {
 		return nil
 	}
+
 	return lo.ToPtr(val.(T))
 }
 
@@ -88,7 +89,7 @@ func readOptionalNumber[Storage Number, T Number](d map[string]any, key string) 
 
 func readOptionalJson[T any](d map[string]any, key string) (*T, error) {
 	val := readOptionalValue[string](d, key)
-	if val == nil {
+	if val == nil || *val == "" {
 		return nil, nil
 	}
 

--- a/docs/resources/rebalancing_schedule.md
+++ b/docs/resources/rebalancing_schedule.md
@@ -36,6 +36,10 @@ resource "castai_rebalancing_schedule" "spots" {
 				]
 			}]
 		})
+		execution_conditions {
+			enabled = true
+			achieved_savings_percentage = 10
+		}
 	}
 }
 ```

--- a/examples/eks/eks_cluster_autoscaler_polices/castai.tf
+++ b/examples/eks/eks_cluster_autoscaler_polices/castai.tf
@@ -210,6 +210,10 @@ resource "castai_rebalancing_schedule" "spots" {
 				]
 			}]
 		})
+		execution_conditions {
+			enabled = true
+			achieved_savings_percentage = 10
+		}
 	}
 }
 

--- a/examples/resources/castai_rebalancing_schedule/resource.tf
+++ b/examples/resources/castai_rebalancing_schedule/resource.tf
@@ -21,5 +21,9 @@ resource "castai_rebalancing_schedule" "spots" {
 				]
 			}]
 		})
+		execution_conditions {
+			enabled = true
+			achieved_savings_percentage = 10
+		}
 	}
 }


### PR DESCRIPTION
The execution conditions define conditions that must be met during the execution of the plan in order for it to run until the end. 

For example, if the execution conditions are enabled but the percentage of achieved savings is not met when the new nodes are created, the rebalancing plan will not proceed further and will rollback the created nodes. This is specially useful when, initially, the rebalancing plan predicts X% of savings, but due to certain constraints, that are known during the runtime, like unavailability of instance types, it creates instance types that are pricier than predicted.

In this MR, the execution conditions allow to control the minimum % of the predicted savings that must be achieved in order to continue with the rebalancing plan.