### PR TITLE
Added aws profile variable when trying to install cast.ai using the eks_cluster_existing example

### DIFF
--- a/examples/eks/eks_cluster_existing/castai.tf
+++ b/examples/eks/eks_cluster_existing/castai.tf
@@ -23,7 +23,7 @@ provider "helm" {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed.
-      args = ["eks", "get-token", "--cluster-name", var.cluster_name, "--region", var.cluster_region]
+      args = ["eks", "get-token", "--cluster-name", var.cluster_name, "--region", var.cluster_region, "--profile", var.profile]
     }
   }
 }

--- a/examples/eks/eks_cluster_existing/providers.tf
+++ b/examples/eks/eks_cluster_existing/providers.tf
@@ -1,7 +1,9 @@
 # Following providers required by EKS and VPC modules.
 provider "aws" {
-  region = var.cluster_region
+  region  = var.cluster_region
+  profile = var.profile
 }
+
 
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.existing_cluster.endpoint
@@ -10,6 +12,6 @@ provider "kubernetes" {
     api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
     # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", var.cluster_name, "--region", var.cluster_region]
+    args = ["eks", "get-token", "--cluster-name", var.cluster_name, "--region", var.cluster_region, "--profile", var.profile]
   }
 }

--- a/examples/eks/eks_cluster_existing/variables.tf
+++ b/examples/eks/eks_cluster_existing/variables.tf
@@ -1,4 +1,10 @@
 # EKS module variables.
+variable "profile" {
+  type        = string
+  description = "Profile used with AWS CLI"
+  default     = "default"
+}
+
 variable "cluster_name" {
   type        = string
   description = "EKS cluster name in AWS account."


### PR DESCRIPTION
This is to give the end user the possibility to use a different AWS Profile value other than 'default' and avoiding the use of 
`export AWS_DEFAULT_PROFILE=my-profile-xyz`
Otherwise, one might get the following error: `Error: Kubernetes cluster unreachable: the server has asked for the client to provide credentials`