### PR TITLE
fix: goreleaser warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist --config=.github/.goreleaser.yml
+          args: release --clean --config=.github/.goreleaser.yml
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
fix warnings in release build log:

```
GoReleaser latest installed successfully
/opt/hostedtoolcache/goreleaser-action/1.24.0/x64/goreleaser release --rm-dist --config=.github/.goreleaser.yml
Flag --rm-dist has been deprecated, please use --clean instead
  • starting release...
  • loading                                          path=.github/.goreleaser.yml
  • DEPRECATED: --rm-dist was deprecated in favor of --clean, check https://goreleaser.com/deprecations#-rm-dist for more details
```