### PR TITLE
refactor: use `autoscaler_policy_overrides` in examples for eks

### DIFF
--- a/examples/eks/eks_cluster_autoscaler_policies/castai.tf
+++ b/examples/eks/eks_cluster_autoscaler_policies/castai.tf
@@ -175,40 +175,53 @@ module "castai-eks-cluster" {
     }
   }
 
-  # Configure Autoscaler policies as per API specification https://api.cast.ai/v1/spec/#/PoliciesAPI/PoliciesAPIUpsertClusterPolicies.
-  # Here:
-  #  - unschedulablePods - Unscheduled pods policy
-  #  - nodeDownscaler    - Node deletion policy
-  autoscaler_policies_json = <<-EOT
-    {
-        "enabled": true,
-        "unschedulablePods": {
-            "enabled": true
-        },
-        "nodeDownscaler": {
-            "enabled": true,
-            "emptyNodes": {
-                "enabled": true
-            },
-            "evictor": {
-                "aggressiveMode": false,
-                "cycleInterval": "5m10s",
-                "dryRun": false,
-                "enabled": true,
-                "nodeGracePeriodMinutes": 10,
-                "scopedMode": false
-            }
-        },
-        "nodeTemplatesPartialMatchingEnabled": false,
-        "clusterLimits": {
-            "cpu": {
-                "maxCores": 20,
-                "minCores": 1
-            },
-            "enabled": true
-        }
+  autoscaler_policy_overrides = {
+    enabled                                 = true
+    is_scoped_mode                          = false
+    node_templates_partial_matching_enabled = false
+
+    unschedulable_pods = {
+      enabled = true
+
+      headroom = {
+        enabled           = true
+        cpu_percentage    = 10
+        memory_percentage = 10
+      }
+
+      headroom_spot = {
+        enabled           = true
+        cpu_percentage    = 10
+        memory_percentage = 10
+      }
     }
-  EOT
+
+    node_downscaler = {
+      enabled = true
+
+      empty_nodes = {
+        enabled = true
+      }
+
+      evictor = {
+        aggressive_mode           = false
+        cycle_interval            = "5s10s"
+        dry_run                   = false
+        enabled                   = true
+        node_grace_period_minutes = 10
+        scoped_mode               = false
+      }
+    }
+
+    cluster_limits = {
+      enabled = true
+
+      cpu = {
+        max_cores = 20
+        min_cores = 1
+      }
+    }
+  }
 
   # depends_on helps Terraform with creating proper dependencies graph in case of resource creation and in this case destroy.
   # module "castai-eks-cluster" has to be destroyed before module "castai-eks-role-iam".

--- a/examples/eks/eks_cluster_autoscaler_policies/castai.tf
+++ b/examples/eks/eks_cluster_autoscaler_policies/castai.tf
@@ -205,7 +205,7 @@ module "castai-eks-cluster" {
 
       evictor = {
         aggressive_mode           = false
-        cycle_interval            = "5s10s"
+        cycle_interval            = "5m10s"
         dry_run                   = false
         enabled                   = true
         node_grace_period_minutes = 10

--- a/examples/eks/eks_cluster_existing/castai.tf
+++ b/examples/eks/eks_cluster_existing/castai.tf
@@ -101,35 +101,46 @@ module "castai-eks-cluster" {
     }
   }
 
-  # Configure Autoscaler policies as per API specification https://api.cast.ai/v1/spec/#/PoliciesAPI/PoliciesAPIUpsertClusterPolicies.
-  # Here:
-  #  - unschedulablePods - Unscheduled pods policy
-  #  - nodeDownscaler    - Node deletion policy
-  autoscaler_policies_json = <<-EOT
-  {
-  "enabled" : false,
-  "isScopedMode" : false,
-  "unschedulablePods" : {
-    "enabled" : false
-  },
-  "clusterLimits" : {
-    "enabled" : false
-  },
-  "nodeDownscaler" : {
-    "enabled" : false,
-    "emptyNodes" : {
-      "enabled" : false,
-      "delaySeconds" : 300
-    },
-    "evictor" : {
-      "enabled" : false,
-      "aggressiveMode" : false,
-      "nodeGracePeriodMinutes" : 5
+  autoscaler_policy_overrides = {
+    enabled                                 = false
+    is_scoped_mode                          = false
+    node_templates_partial_matching_enabled = false
+
+    unschedulable_pods = {
+      enabled = false
+    }
+
+    node_downscaler = {
+      enabled = false
+
+      empty_nodes = {
+        enabled = false
+      }
+
+      evictor = {
+        aggressive_mode           = false
+        cycle_interval            = "5m10s"
+        dry_run                   = false
+        enabled                   = false
+        node_grace_period_minutes = 10
+        scoped_mode               = false
+      }
+    }
+
+    cluster_limits = {
+      enabled = false
+
+      cpu = {
+        max_cores = 20
+        min_cores = 1
+      }
+
+      spot_backups = {
+        enabled                          = false
+        spot_backup_restore_rate_seconds = 1800
+      }
     }
   }
-}
-
-  EOT
 
   # depends_on helps Terraform with creating proper dependencies graph in case of resource creation and in this case destroy.
   # module "castai-eks-cluster" has to be destroyed before module "castai-eks-role-iam".

--- a/examples/eks/eks_cluster_webshop/main.tf
+++ b/examples/eks/eks_cluster_webshop/main.tf
@@ -108,21 +108,22 @@ module "castai-eks-cluster" {
 
   delete_nodes_on_disconnect = var.delete_nodes_on_disconnect
 
-  # Full schema can be found here https://api.cast.ai/v1/spec/#/PoliciesAPI/PoliciesAPIUpsertClusterPolicies
-  autoscaler_policies_json = <<-EOT
-     {
-         "enabled": true,
-         "isScopedMode": false,
-         "unschedulablePods": {
-             "enabled": true
-         },
-         "nodeDownscaler": {
-             "emptyNodes": {
-                 "enabled": true
-             }
-         }
-     }
-   EOT
+
+  autoscaler_policy_overrides = {
+    enabled                                 = true
+    is_scoped_mode                          = false
+    node_templates_partial_matching_enabled = false
+
+    unschedulable_pods = {
+      enabled = true
+    }
+
+    node_downscaler = {
+      empty_nodes = {
+        enabled = true
+      }
+    }
+  }
 
   // depends_on helps terraform with creating proper dependencies graph in case of resource creation and in this case destroy
   // module "castai-eks-cluster" has to be destroyed before module "castai-eks-role-iam"

--- a/examples/eks/eks_clusters/module/castai/castai.tf
+++ b/examples/eks/eks_clusters/module/castai/castai.tf
@@ -140,40 +140,41 @@ module "castai-eks-cluster" {
 
   node_templates = local.default_node_tmpl
 
-  # Configure Autoscaler policies as per API specification https://api.cast.ai/v1/spec/#/PoliciesAPI/PoliciesAPIUpsertClusterPolicies.
-  # Here:
-  #  - unschedulablePods - Unscheduled pods policy
-  #  - nodeDownscaler    - Node deletion policy
-  autoscaler_policies_json = <<-EOT
-    {
-        "enabled": true,
-        "unschedulablePods": {
-            "enabled": true
-        },
-        "nodeDownscaler": {
-            "enabled": true,
-            "emptyNodes": {
-                "enabled": true
-            },
-            "evictor": {
-                "aggressiveMode": false,
-                "cycleInterval": "5m10s",
-                "dryRun": false,
-                "enabled": true,
-                "nodeGracePeriodMinutes": 10,
-                "scopedMode": false
-            }
-        },
-        "nodeTemplatesPartialMatchingEnabled": false,
-        "clusterLimits": {
-            "cpu": {
-                "maxCores": 20,
-                "minCores": 1
-            },
-            "enabled": true
-        }
+  autoscaler_policy_overrides = {
+    enabled                                 = true
+    is_scoped_mode                          = false
+    node_templates_partial_matching_enabled = false
+
+    unschedulable_pods = {
+      enabled = true
     }
-  EOT
+
+    node_downscaler = {
+      enabled = true
+
+      empty_nodes = {
+        enabled = true
+      }
+
+      evictor = {
+        aggressive_mode           = false
+        cycle_interval            = "5m10s"
+        dry_run                   = false
+        enabled                   = true
+        node_grace_period_minutes = 10
+        scoped_mode               = false
+      }
+    }
+
+    cluster_limits = {
+      enabled = true
+
+      cpu = {
+        max_cores = 20
+        min_cores = 1
+      }
+    }
+  }
 
   # depends_on helps Terraform with creating proper dependencies graph in case of resource creation and in this case destroy.
   # module "castai-eks-cluster" has to be destroyed before module "castai-eks-role-iam".


### PR DESCRIPTION
Depends on https://github.com/castai/terraform-castai-eks-cluster/pull/92