### PR TITLE
KUBE-328: Support setting image family on node configuration 

### DIFF
--- a/castai/resource_node_configuration_eks_test.go
+++ b/castai/resource_node_configuration_eks_test.go
@@ -50,6 +50,7 @@ func TestAccResourceNodeConfiguration_eks(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "eks.0.target_group.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "eks.0.max_pods_per_node_formula", "NUM_IP_PER_PREFIX-NUM_MAX_NET_INTERFACES"),
 					resource.TestCheckResourceAttr(resourceName, "eks.0.ips_per_prefix", "4"),
+					resource.TestCheckResourceAttr(resourceName, "eks.0.image_family", "al2023"),
 					resource.TestCheckResourceAttr(resourceName, "eks.0.target_group.0.arn", "arn:aws:test"),
 					resource.TestCheckResourceAttr(resourceName, "aks.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "kops.#", "0"),
@@ -138,6 +139,7 @@ resource "castai_node_configuration" "test" {
 	imds_hop_limit       = 3
     max_pods_per_node_formula = "NUM_IP_PER_PREFIX-NUM_MAX_NET_INTERFACES"
 	ips_per_prefix = 4
+	eks_image_family = al2023
 	target_group 	     {
 	   arn = "arn:aws:test"
     }

--- a/castai/resource_node_configuration_eks_test.go
+++ b/castai/resource_node_configuration_eks_test.go
@@ -50,7 +50,7 @@ func TestAccResourceNodeConfiguration_eks(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "eks.0.target_group.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "eks.0.max_pods_per_node_formula", "NUM_IP_PER_PREFIX-NUM_MAX_NET_INTERFACES"),
 					resource.TestCheckResourceAttr(resourceName, "eks.0.ips_per_prefix", "4"),
-					resource.TestCheckResourceAttr(resourceName, "eks.0.image_family", "al2023"),
+					resource.TestCheckResourceAttr(resourceName, "eks.0.eks_image_family", "al2023"),
 					resource.TestCheckResourceAttr(resourceName, "eks.0.target_group.0.arn", "arn:aws:test"),
 					resource.TestCheckResourceAttr(resourceName, "aks.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "kops.#", "0"),
@@ -83,6 +83,7 @@ func TestAccResourceNodeConfiguration_eks(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "eks.0.volume_throughput", "130"),
 					resource.TestCheckResourceAttr(resourceName, "eks.0.max_pods_per_node_formula", "NUM_IP_PER_PREFIX+NUM_MAX_NET_INTERFACES"),
 					resource.TestCheckResourceAttr(resourceName, "eks.0.ips_per_prefix", "3"),
+					resource.TestCheckResourceAttr(resourceName, "eks.0.eks_image_family", "al2"),
 					resource.TestCheckResourceAttr(resourceName, "eks.0.target_group.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "eks.0.target_group.0.arn", "arn:aws:test2"),
 					resource.TestCheckResourceAttr(resourceName, "eks.0.target_group.0.port", "80"),
@@ -139,7 +140,7 @@ resource "castai_node_configuration" "test" {
 	imds_hop_limit       = 3
     max_pods_per_node_formula = "NUM_IP_PER_PREFIX-NUM_MAX_NET_INTERFACES"
 	ips_per_prefix = 4
-	eks_image_family = al2023
+	eks_image_family = "al2023"
 	target_group 	     {
 	   arn = "arn:aws:test"
     }
@@ -171,6 +172,7 @@ resource "castai_node_configuration" "test" {
     volume_throughput 	 = 130
     max_pods_per_node_formula = "NUM_IP_PER_PREFIX+NUM_MAX_NET_INTERFACES"
 	ips_per_prefix = 3
+	eks_image_family = "al2"
     target_group 	     {
 	   arn = "arn:aws:test2"
        port = 80

--- a/docs/resources/node_configuration.md
+++ b/docs/resources/node_configuration.md
@@ -69,7 +69,8 @@ resource "castai_node_configuration" "default" {
 - `drain_timeout_sec` (Number) Timeout in seconds for draining the node. Defaults to 0
 - `eks` (Block List, Max: 1) (see [below for nested schema](#nestedblock--eks))
 - `gke` (Block List, Max: 1) (see [below for nested schema](#nestedblock--gke))
-- `image` (String) Image to be used while provisioning the node. If nothing is provided will be resolved to latest available image based on Kubernetes version if possible
+- `image` (String) Image to be used while provisioning the node. If nothing is provided will be resolved to latest available image based on Image family, Kubernetes version and node architecture if possible. See Cast.ai documentation for details.
+- `image_family` (String) Image OS Family to use when provisioning node. If both image and family are provided, the system will use provided image and provisioning logic for given family. If only image family is provided, the system will attempt to resolve the latest image from that family based on kubernetes version and node architecture. If image family is omitted, a default family (based on cloud provider) will be used. See Cast.ai documentation for details.
 - `init_script` (String) Init script to be run on your instance at launch. Should not contain any sensitive data. Value should be base64 encoded
 - `kops` (Block List, Max: 1) (see [below for nested schema](#nestedblock--kops))
 - `kubelet_config` (String) Optional kubelet configuration properties in JSON format. Provide only properties that you want to override. Applicable for EKS only. [Available values](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)

--- a/docs/resources/node_configuration.md
+++ b/docs/resources/node_configuration.md
@@ -70,7 +70,6 @@ resource "castai_node_configuration" "default" {
 - `eks` (Block List, Max: 1) (see [below for nested schema](#nestedblock--eks))
 - `gke` (Block List, Max: 1) (see [below for nested schema](#nestedblock--gke))
 - `image` (String) Image to be used while provisioning the node. If nothing is provided will be resolved to latest available image based on Image family, Kubernetes version and node architecture if possible. See Cast.ai documentation for details.
-- `image_family` (String) Image OS Family to use when provisioning node. If both image and family are provided, the system will use provided image and provisioning logic for given family. If only image family is provided, the system will attempt to resolve the latest image from that family based on kubernetes version and node architecture. If image family is omitted, a default family (based on cloud provider) will be used. See Cast.ai documentation for details.
 - `init_script` (String) Init script to be run on your instance at launch. Should not contain any sensitive data. Value should be base64 encoded
 - `kops` (Block List, Max: 1) (see [below for nested schema](#nestedblock--kops))
 - `kubelet_config` (String) Optional kubelet configuration properties in JSON format. Provide only properties that you want to override. Applicable for EKS only. [Available values](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)
@@ -103,6 +102,7 @@ Required:
 Optional:
 
 - `dns_cluster_ip` (String) IP address to use for DNS queries within the cluster
+- `eks_image_family` (String) Image OS Family to use when provisioning node. If both image and family are provided, the system will use provided image and provisioning logic for given family. If only image family is provided, the system will attempt to resolve the latest image from that family based on kubernetes version and node architecture. If image family is omitted, a default family (based on cloud provider) will be used. See Cast.ai documentation for details.
 - `imds_hop_limit` (Number) Allow configure the IMDSv2 hop limit, the default is 2
 - `imds_v1` (Boolean) When the value is true both IMDSv1 and IMDSv2 are enabled. Setting the value to false disables permanently IMDSv1 and might affect legacy workloads running on the node created with this configuration. The default is true if the flag isn't provided
 - `ips_per_prefix` (Number) Number of IPs per prefix to be used for calculating max pods.


### PR DESCRIPTION
Allows user to select a family of images that determines bootstrap logic and (potentially) VM image choice 