### PR TITLE
KUBE-447: Support multiple target groups per node configuration

### DIFF
--- a/castai/resource_node_configuration_test.go
+++ b/castai/resource_node_configuration_test.go
@@ -36,6 +36,10 @@ func Test_resourceNodeConfigurationCreate(t *testing.T) {
 								map[string]interface{}{
 									"arn": "test",
 								},
+								map[string]interface{}{
+									"arn":  "test2",
+									"port": 80,
+								},
 							},
 						},
 					},
@@ -43,9 +47,15 @@ func Test_resourceNodeConfigurationCreate(t *testing.T) {
 				tuneMock: func(m *mock_sdk.MockClientInterface) {
 					m.EXPECT().NodeConfigurationAPICreateConfiguration(gomock.Any(), gomock.Any(), sdk.NodeconfigV1NewNodeConfiguration{
 						Eks: &sdk.NodeconfigV1EKSConfig{
-							TargetGroup: &sdk.NodeconfigV1TargetGroup{
-								Arn:  toPtr("test"),
-								Port: nil,
+							TargetGroups: &[]sdk.NodeconfigV1TargetGroup{
+								{
+									Arn:  toPtr("test"),
+									Port: nil,
+								},
+								{
+									Arn:  toPtr("test2"),
+									Port: toPtr(int32(80)),
+								},
 							},
 							ImdsHopLimit: toPtr(int32(0)),
 							ImdsV1:       toPtr(false),
@@ -163,9 +173,14 @@ func Test_NodeConfiguration_UpdateContext(t *testing.T) {
 			name: "success",
 			args: args{
 				updated: &sdk.NodeconfigV1EKSConfig{
-					TargetGroup: &sdk.NodeconfigV1TargetGroup{
-						Arn:  toPtr("test2"),
-						Port: toPtr(int32(80)),
+					TargetGroups: &[]sdk.NodeconfigV1TargetGroup{
+						{
+							Arn:  toPtr("test2"),
+							Port: toPtr(int32(80)),
+						},
+						{
+							Arn: toPtr("test"),
+						},
 					},
 				},
 				tuneMock: func(m *mock_sdk.MockClientInterface) {
@@ -173,9 +188,14 @@ func Test_NodeConfiguration_UpdateContext(t *testing.T) {
 						"765fdc7b-2577-4ae8-a6b8-e3b60afbc33a",
 						sdk.NodeconfigV1NodeConfigurationUpdate{
 							Eks: &sdk.NodeconfigV1EKSConfig{
-								TargetGroup: &sdk.NodeconfigV1TargetGroup{
-									Arn:  toPtr("test2"),
-									Port: toPtr(int32(80)),
+								TargetGroups: &[]sdk.NodeconfigV1TargetGroup{
+									{
+										Arn:  toPtr("test2"),
+										Port: toPtr(int32(80)),
+									},
+									{
+										Arn: toPtr("test"),
+									},
 								},
 								ImdsHopLimit: toPtr(int32(0)),
 								ImdsV1:       toPtr(false),
@@ -189,28 +209,31 @@ func Test_NodeConfiguration_UpdateContext(t *testing.T) {
 								StatusCode: 200,
 								Header:     map[string][]string{"Content-Type": {"json"}},
 								Body: io.NopCloser(bytes.NewReader([]byte(`{
-  "id": "765fdc7b-2577-4ae8-a6b8-e3b60afbc33a",
-  "name": "test4"
-}
-`))),
+						  "id": "765fdc7b-2577-4ae8-a6b8-e3b60afbc33a",
+						  "name": "test4"
+						}
+						`))),
 							}, nil)
+
 					m.EXPECT().NodeConfigurationAPIGetConfiguration(gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(
 							&http.Response{
 								StatusCode: 200,
 								Header:     map[string][]string{"Content-Type": {"json"}},
 								Body: io.NopCloser(bytes.NewReader([]byte(`{
-  "id": "765fdc7b-2577-4ae8-a6b8-e3b60afbc33a",
-  "name": "test4",
-  "tags": {},
-  "eks": {
-    "targetGroup": {
-      "arn": "test2",
-      "port": 80
-    }
-  }
-}
-`))),
+						  "id": "765fdc7b-2577-4ae8-a6b8-e3b60afbc33a",
+						  "name": "test4",
+						  "tags": {},
+						  "eks": {
+							"targetGroups": [
+							{
+							  "arn": "test2",
+							  "port": 80
+							}
+							]
+						  }
+						}
+						`))),
 							}, nil)
 				},
 			},

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -787,6 +787,9 @@ type CastaiInventoryV1beta1NetworkInfo struct {
 	// Burst bandwidth in Mbps. It's equal to base bandwidth if not specified.
 	BurstBandwidthMbps *int32 `json:"burstBandwidthMbps,omitempty"`
 
+	// Indicates if the AWS instance type supports EFA (Elastic Fabric Adapter).
+	EfaSupported *bool `json:"efaSupported,omitempty"`
+
 	// The maximum number of IPv4 addresses per network interface.
 	Ipv4AddressesPerInterface *int32 `json:"ipv4AddressesPerInterface,omitempty"`
 
@@ -1399,9 +1402,8 @@ type ExternalclusterV1Cluster struct {
 	Status *string `json:"status,omitempty"`
 
 	// Cluster subnets.
-	Subnets     *[]ExternalclusterV1Subnet     `json:"subnets,omitempty"`
-	Tags        *ExternalclusterV1Cluster_Tags `json:"tags,omitempty"`
-	WorkspaceId *string                        `json:"workspaceId,omitempty"`
+	Subnets *[]ExternalclusterV1Subnet     `json:"subnets,omitempty"`
+	Tags    *ExternalclusterV1Cluster_Tags `json:"tags,omitempty"`
 
 	// Cluster zones.
 	Zones *[]ExternalclusterV1Zone `json:"zones,omitempty"`
@@ -1849,9 +1851,6 @@ type ExternalclusterV1RegisterClusterRequest struct {
 
 	// Organization of the cluster.
 	OrganizationId *string `json:"organizationId,omitempty"`
-
-	// Workspace id of the cluster.
-	WorkspaceId *string `json:"workspaceId,omitempty"`
 }
 
 // ExternalclusterV1Resources defines model for externalcluster.v1.Resources.
@@ -1977,6 +1976,9 @@ type NodeconfigV1EKSConfig struct {
 	// Cluster's security groups configuration.
 	SecurityGroups *[]string                `json:"securityGroups,omitempty"`
 	TargetGroup    *NodeconfigV1TargetGroup `json:"targetGroup,omitempty"`
+
+	// TargetGroups defines a list of load balancer target groups to register cluster instances into.
+	TargetGroups *[]NodeconfigV1TargetGroup `json:"targetGroups,omitempty"`
 
 	// EBS volume IOPS value to be used for provisioned nodes.
 	VolumeIops      *int32  `json:"volumeIops"`

--- a/docs/resources/node_configuration.md
+++ b/docs/resources/node_configuration.md
@@ -108,7 +108,7 @@ Optional:
 - `ips_per_prefix` (Number) Number of IPs per prefix to be used for calculating max pods.
 - `key_pair_id` (String) AWS key pair ID to be used for CAST provisioned nodes. Has priority over ssh_public_key
 - `max_pods_per_node_formula` (String) Formula to calculate the maximum number of pods that can be run on a node.
-- `target_group` (Block List, Max: 1) AWS target group configuration for CAST provisioned nodes (see [below for nested schema](#nestedblock--eks--target_group))
+- `target_group` (Block List) AWS target groups configuration for CAST provisioned nodes (see [below for nested schema](#nestedblock--eks--target_group))
 - `volume_iops` (Number) AWS EBS volume IOPS to be used for CAST provisioned nodes
 - `volume_kms_key_arn` (String) AWS KMS key ARN for encrypting EBS volume attached to the node
 - `volume_throughput` (Number) AWS EBS volume throughput in MiB/s to be used for CAST provisioned nodes


### PR DESCRIPTION
In TF state remains the same but we remove the 1 item restriction. 

Old TF version uses old field (backend ensures it is appended to new field on post). 
New TF version uses only new field.

Note that using an old TF version and new version to edit the same config will result in data overwrite and will not be supported. 