### PR TITLE
Change eks cluster token to api token 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ resource "helm_release" "castai_agent" {
   }
   set_sensitive {
     name  = "apiKey"
-    value = castai_eks_cluster.this.cluster_token
+    value = var.castai_api_token
   }
 
   # Required until https://github.com/castai/helm-charts/issues/135 is fixed.

--- a/examples/eks/eks_cluster_optional_readonly/castai.tf
+++ b/examples/eks/eks_cluster_optional_readonly/castai.tf
@@ -52,7 +52,7 @@ resource "helm_release" "castai_agent" {
   }
   set_sensitive {
     name  = "apiKey"
-    value = castai_eks_cluster.this.cluster_token
+    value = var.castai_api_token
   }
 
   # Required until https://github.com/castai/helm-charts/issues/135 is fixed.

--- a/examples/eks/eks_cluster_readonly/castai.tf
+++ b/examples/eks/eks_cluster_readonly/castai.tf
@@ -43,7 +43,7 @@ resource "helm_release" "castai_agent" {
   }
   set_sensitive {
     name  = "apiKey"
-    value = castai_eks_cluster.this.cluster_token
+    value = var.castai_api_token'
   }
 
   # Required until https://github.com/castai/helm-charts/issues/135 is fixed.


### PR DESCRIPTION
Prospect had issue that was caused by using the api_key override with the cluster token override since that is what we recommended in the docs. This changes that. 