### PR TITLE
CO-3070: feat: add pod pinner

### DIFF
--- a/castai/resource_autoscaler.go
+++ b/castai/resource_autoscaler.go
@@ -61,6 +61,7 @@ const (
 	FieldEvictorNodeGracePeriodMinutes            = "node_grace_period_minutes"
 	FieldEvictorPodEvictionFailureBackOffInterval = "pod_eviction_failure_back_off_interval"
 	FieldEvictorIgnorePodDisruptionBudgets        = "ignore_pod_disruption_budgets"
+	FieldPodPinner                                = "pod_pinner"
 )
 
 func resourceAutoscaler() *schema.Resource {
@@ -231,6 +232,22 @@ func resourceAutoscaler() *schema.Resource {
 													Optional:    true,
 													Default:     false,
 													Description: "enable/disable node constraints policy.",
+												},
+											},
+										},
+									},
+									FieldPodPinner: {
+										Type:        schema.TypeList,
+										Optional:    true,
+										MaxItems:    1,
+										Description: "defines the Cast AI Pod Pinner components settings.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												FieldEnabled: {
+													Type:        schema.TypeBool,
+													Default:     true,
+													Optional:    true,
+													Description: "enable/disable the Pod Pinner component's automatic management in your cluster. Default: enabled.",
 												},
 											},
 										},

--- a/castai/resource_autoscaler_test.go
+++ b/castai/resource_autoscaler_test.go
@@ -73,6 +73,9 @@ func TestAutoscalerResource_PoliciesUpdateAction(t *testing.T) {
 			"nodeConstraints": {
 				"enabled": true,
 				"maxCpuCores": 96
+			},
+			"podPinner": {
+				"enabled": false
 			}
 		}
 	}`
@@ -100,7 +103,10 @@ func TestAutoscalerResource_PoliciesUpdateAction(t *testing.T) {
 		            "maxRamMib": 262144,
 		            "enabled": true
 		        },
-		        "diskGibToCpuRatio": 25
+		        "diskGibToCpuRatio": 25,
+				"podPinner": {
+					"enabled": false
+				}
 		    },
 		    "clusterLimits": {
 		        "enabled": false,
@@ -612,6 +618,15 @@ func TestAutoscalerResource_ToAutoscalerPolicy(t *testing.T) {
 											cty.ObjectVal(
 												map[string]cty.Value{
 													"enabled": cty.BoolVal(true),
+													"pod_pinner": cty.ListVal(
+														[]cty.Value{
+															cty.ObjectVal(
+																map[string]cty.Value{
+																	"enabled": cty.BoolVal(true),
+																},
+															),
+														},
+													),
 												},
 											),
 										},
@@ -626,6 +641,9 @@ func TestAutoscalerResource_ToAutoscalerPolicy(t *testing.T) {
 				Enabled: true,
 				UnschedulablePods: &types.UnschedulablePods{
 					Enabled: true,
+					PodPinner: &types.PodPinner{
+						Enabled: true,
+					},
 				},
 			},
 		},
@@ -646,7 +664,7 @@ func TestAutoscalerResource_ToAutoscalerPolicy(t *testing.T) {
 			}
 
 			r.NoError(err)
-			r.True(reflect.DeepEqual(test.expected, actual))
+			r.Equal(test.expected, actual)
 		})
 	}
 }

--- a/castai/types/autoscaler_policies.go
+++ b/castai/types/autoscaler_policies.go
@@ -16,6 +16,7 @@ type UnschedulablePods struct {
 	HeadroomSpot    *Headroom        `mapstructure:"headroom_spot" json:"headroomSpot,omitempty"`
 	NodeConstraints *NodeConstraints `mapstructure:"node_constraints" json:"nodeConstraints,omitempty"`
 	CustomInstances bool             `mapstructure:"custom_instances_enabled" json:"customInstancesEnabled"`
+	PodPinner       *PodPinner       `mapstructure:"pod_pinner" json:"podPinner,omitempty"`
 }
 
 type Headroom struct {
@@ -30,6 +31,10 @@ type NodeConstraints struct {
 	MinRAMMiB   int  `mapstructure:"min_ram_mib" json:"minRamMiB"`
 	MaxRAMMiB   int  `mapstructure:"max_ram_mib" json:"maxRamMiB"`
 	Enabled     bool `mapstructure:"enabled" json:"enabled"`
+}
+
+type PodPinner struct {
+	Enabled bool `mapstructure:"enabled" json:"enabled"`
 }
 
 type ClusterLimits struct {

--- a/docs/resources/autoscaler.md
+++ b/docs/resources/autoscaler.md
@@ -178,6 +178,7 @@ Optional:
 - `headroom` (Block List, Max: 1) additional headroom based on cluster's total available capacity for on-demand nodes. (see [below for nested schema](#nestedblock--autoscaler_settings--unschedulable_pods--headroom))
 - `headroom_spot` (Block List, Max: 1) additional headroom based on cluster's total available capacity for spot nodes. (see [below for nested schema](#nestedblock--autoscaler_settings--unschedulable_pods--headroom_spot))
 - `node_constraints` (Block List, Max: 1) defines the node constraints that will be applied when autoscaling with Unschedulable Pods policy. (see [below for nested schema](#nestedblock--autoscaler_settings--unschedulable_pods--node_constraints))
+- `pod_pinner` (Block List, Max: 1) defines the Cast AI Pod Pinner components settings. (see [below for nested schema](#nestedblock--autoscaler_settings--unschedulable_pods--pod_pinner))
 
 <a id="nestedblock--autoscaler_settings--unschedulable_pods--headroom"></a>
 ### Nested Schema for `autoscaler_settings.unschedulable_pods.headroom`
@@ -209,6 +210,14 @@ Optional:
 - `max_ram_mib` (Number) defines max RAM in MiB for the node to pick.
 - `min_cpu_cores` (Number) defines min CPU cores for the node to pick.
 - `min_ram_mib` (Number) defines min RAM in MiB for the node to pick.
+
+
+<a id="nestedblock--autoscaler_settings--unschedulable_pods--pod_pinner"></a>
+### Nested Schema for `autoscaler_settings.unschedulable_pods.pod_pinner`
+
+Optional:
+
+- `enabled` (Boolean) enable/disable the Pod Pinner component's automatic management in your cluster. Default: enabled.
 
 
 


### PR DESCRIPTION
This commit adds Pod Pinner to the provider. Since Pod Pinner is enabled (`true`) by default, and we don't care if it is not set in Terraform, It is implemented as a boolean value instead of a tri-state toggle.