### PR TITLE
chore: update modules in gke_cluster_autoscaler_policies

### DIFF
--- a/examples/gke/gke_cluster_autoscaler_policies/gke.tf
+++ b/examples/gke/gke_cluster_autoscaler_policies/gke.tf
@@ -2,7 +2,7 @@
 
 module "gke" {
   source                     = "terraform-google-modules/kubernetes-engine/google"
-  version                    = "24.1.0"
+  version                    = "33.1.0"
   project_id                 = var.project_id
   name                       = var.cluster_name
   region                     = var.cluster_region
@@ -21,7 +21,7 @@ module "gke" {
       name               = "default-node-pool"
       machine_type       = "e2-standard-2"
       min_count          = 0
-      max_count          = 10
+      max_count          = 1
       local_ssd_count    = 0
       disk_size_gb       = 100
       disk_type          = "pd-standard"
@@ -29,7 +29,7 @@ module "gke" {
       auto_repair        = true
       auto_upgrade       = true
       preemptible        = false
-      initial_node_count = 2 # has to be >=2 to successfully deploy CAST AI controller
+      initial_node_count = 1 # has to be >=2 to successfully deploy CAST AI controller
     },
   ]
 }

--- a/examples/gke/gke_cluster_autoscaler_policies/gke.tf
+++ b/examples/gke/gke_cluster_autoscaler_policies/gke.tf
@@ -21,7 +21,7 @@ module "gke" {
       name               = "default-node-pool"
       machine_type       = "e2-standard-2"
       min_count          = 0
-      max_count          = 1
+      max_count          = 10
       local_ssd_count    = 0
       disk_size_gb       = 100
       disk_type          = "pd-standard"
@@ -29,7 +29,7 @@ module "gke" {
       auto_repair        = true
       auto_upgrade       = true
       preemptible        = false
-      initial_node_count = 1 # has to be >=2 to successfully deploy CAST AI controller
+      initial_node_count = 2 # has to be >=2 to successfully deploy CAST AI controller
     },
   ]
 }

--- a/examples/gke/gke_cluster_autoscaler_policies/variables.tf
+++ b/examples/gke/gke_cluster_autoscaler_policies/variables.tf
@@ -12,6 +12,7 @@ variable "cluster_region" {
 variable "cluster_zones" {
   type        = list(string)
   description = "The zones to create the cluster."
+  default     = []
 }
 
 variable "project_id" {

--- a/examples/gke/gke_cluster_autoscaler_policies/vpc.tf
+++ b/examples/gke/gke_cluster_autoscaler_policies/vpc.tf
@@ -8,7 +8,7 @@ locals {
 
 module "vpc" {
   source       = "terraform-google-modules/network/google"
-  version      = "6.0.0"
+  version      = "9.3.0"
   project_id   = var.project_id
   network_name = var.cluster_name
   subnets = [


### PR DESCRIPTION
Also set default `cluster_zones = []`, so if none provided, all in the region will be used.