### PR TITLE
fix: list invitations response check

### DIFF
--- a/castai/resource_organization_members.go
+++ b/castai/resource_organization_members.go
@@ -165,7 +165,8 @@ func resourceOrganizationMembersRead(ctx context.Context, data *schema.ResourceD
 		invitationsResp, err := client.UsersAPIListInvitationsWithResponse(ctx, &sdk.UsersAPIListInvitationsParams{
 			PageCursor: &nextCursor,
 		})
-		if err := sdk.CheckOKResponse(usersResp, err); err != nil {
+
+		if err := sdk.CheckOKResponse(invitationsResp, err); err != nil {
 			return diag.FromErr(fmt.Errorf("retrieving pending invitations: %w", err))
 		}
 

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -282,15 +282,15 @@ const (
 
 // Defines values for WorkloadoptimizationV1EventType.
 const (
-	EVENTTYPECONFIGURATIONCHANGED       WorkloadoptimizationV1EventType = "EVENT_TYPE_CONFIGURATION_CHANGED"
 	EVENTTYPECONFIGURATIONCHANGEDV2     WorkloadoptimizationV1EventType = "EVENT_TYPE_CONFIGURATION_CHANGEDV2"
 	EVENTTYPEINVALID                    WorkloadoptimizationV1EventType = "EVENT_TYPE_INVALID"
 	EVENTTYPEOOMKILL                    WorkloadoptimizationV1EventType = "EVENT_TYPE_OOM_KILL"
-	EVENTTYPERECOMMENDATIONAPPLIED      WorkloadoptimizationV1EventType = "EVENT_TYPE_RECOMMENDATION_APPLIED"
 	EVENTTYPERECOMMENDEDPODCOUNTCHANGED WorkloadoptimizationV1EventType = "EVENT_TYPE_RECOMMENDED_POD_COUNT_CHANGED"
 	EVENTTYPERECOMMENDEDREQUESTSCHANGED WorkloadoptimizationV1EventType = "EVENT_TYPE_RECOMMENDED_REQUESTS_CHANGED"
+	EVENTTYPESCALINGPOLICYASSIGNED      WorkloadoptimizationV1EventType = "EVENT_TYPE_SCALING_POLICY_ASSIGNED"
 	EVENTTYPESCALINGPOLICYCREATED       WorkloadoptimizationV1EventType = "EVENT_TYPE_SCALING_POLICY_CREATED"
 	EVENTTYPESCALINGPOLICYDELETED       WorkloadoptimizationV1EventType = "EVENT_TYPE_SCALING_POLICY_DELETED"
+	EVENTTYPESCALINGPOLICYUPDATED       WorkloadoptimizationV1EventType = "EVENT_TYPE_SCALING_POLICY_UPDATED"
 	EVENTTYPESURGE                      WorkloadoptimizationV1EventType = "EVENT_TYPE_SURGE"
 )
 
@@ -925,6 +925,13 @@ type CastaiInventoryV1beta1InstanceTypeBasedUsage struct {
 	UsageDistribution *CastaiInventoryV1beta1UsageDistribution        `json:"usageDistribution,omitempty"`
 }
 
+// CastaiInventoryV1beta1InstanceTypeWithFamily defines model for castai.inventory.v1beta1.InstanceTypeWithFamily.
+type CastaiInventoryV1beta1InstanceTypeWithFamily struct {
+	CloudServiceProvider *string `json:"cloudServiceProvider,omitempty"`
+	Family               *string `json:"family,omitempty"`
+	InstanceType         *string `json:"instanceType,omitempty"`
+}
+
 // CastaiInventoryV1beta1InstanceZone defines model for castai.inventory.v1beta1.InstanceZone.
 type CastaiInventoryV1beta1InstanceZone struct {
 	// Specifies the applied discounts on the instance zone.
@@ -941,6 +948,12 @@ type CastaiInventoryV1beta1InstanceZone struct {
 	RamPrice          *string                              `json:"ramPrice,omitempty"`
 	Spot              *bool                                `json:"spot,omitempty"`
 	Unavailable       *bool                                `json:"unavailable,omitempty"`
+}
+
+// CastaiInventoryV1beta1ListInstanceTypeNamesResponse defines model for castai.inventory.v1beta1.ListInstanceTypeNamesResponse.
+type CastaiInventoryV1beta1ListInstanceTypeNamesResponse struct {
+	Items          *[]CastaiInventoryV1beta1InstanceTypeWithFamily `json:"items,omitempty"`
+	NextPageCursor *string                                         `json:"nextPageCursor,omitempty"`
 }
 
 // CastaiInventoryV1beta1ListRegionsResponse defines model for castai.inventory.v1beta1.ListRegionsResponse.
@@ -1712,6 +1725,9 @@ type ExternalclusterV1DeleteNodeResponse struct {
 	OperationId *string `json:"operationId,omitempty"`
 }
 
+// ExternalclusterV1DisableGKESAResponse defines model for externalcluster.v1.DisableGKESAResponse.
+type ExternalclusterV1DisableGKESAResponse = map[string]interface{}
+
 // ExternalclusterV1DisconnectConfig defines model for externalcluster.v1.DisconnectConfig.
 type ExternalclusterV1DisconnectConfig struct {
 	// Whether CAST provisioned nodes should be deleted.
@@ -2138,6 +2154,24 @@ type ExternalclusterV1Taint struct {
 	Value  string `json:"value"`
 }
 
+// TriggerHibernateClusterResponse is the result of HibernateClusterRequest.
+type ExternalclusterV1TriggerHibernateClusterResponse struct {
+	// The ID of the node.
+	ClusterId string `json:"clusterId"`
+
+	// Add node operation ID.
+	OperationId string `json:"operationId"`
+}
+
+// TriggerResumeClusterResponse is the result of ResumeClusterRequest.
+type ExternalclusterV1TriggerResumeClusterResponse struct {
+	// The ID of the node.
+	ClusterId string `json:"clusterId"`
+
+	// Add node operation ID.
+	OperationId string `json:"operationId"`
+}
+
 // UpdateClusterTagsResponse result of cluster tags update.
 type ExternalclusterV1UpdateClusterTagsResponse = map[string]interface{}
 
@@ -2252,6 +2286,9 @@ type NodeconfigV1EKSConfig struct {
 	// AWS key pair ID to be used for provisioned nodes. Has priority over sshPublicKey.
 	KeyPairId             *string `json:"keyPairId"`
 	MaxPodsPerNodeFormula *string `json:"maxPodsPerNodeFormula"`
+
+	// Is used to create temporary cloud native pools.
+	NodeGroupArn *string `json:"nodeGroupArn"`
 
 	// Cluster's security groups configuration.
 	SecurityGroups *[]string                `json:"securityGroups,omitempty"`
@@ -3297,15 +3334,6 @@ type WorkloadoptimizationV1ApplyType string
 // WorkloadoptimizationV1AssignScalingPolicyWorkloadsResponse defines model for workloadoptimization.v1.AssignScalingPolicyWorkloadsResponse.
 type WorkloadoptimizationV1AssignScalingPolicyWorkloadsResponse = map[string]interface{}
 
-// WorkloadoptimizationV1ConfigurationChangedEvent defines model for workloadoptimization.v1.ConfigurationChangedEvent.
-type WorkloadoptimizationV1ConfigurationChangedEvent struct {
-	// Defines possible options for workload management.
-	// READ_ONLY - workload watched (metrics collected), but no actions may be performed by CAST AI.
-	// MANAGED - workload watched (metrics collected), CAST AI may perform actions on the workload.
-	ManagementOption     WorkloadoptimizationV1ManagementOption     `json:"managementOption"`
-	RecommendationConfig WorkloadoptimizationV1RecommendationConfig `json:"recommendationConfig"`
-}
-
 // WorkloadoptimizationV1ConfigurationChangedEventV2 defines model for workloadoptimization.v1.ConfigurationChangedEventV2.
 type WorkloadoptimizationV1ConfigurationChangedEventV2 struct {
 	Current  WorkloadoptimizationV1ConfigurationChangedV2 `json:"current"`
@@ -3357,14 +3385,14 @@ type WorkloadoptimizationV1DownscalingSettings struct {
 
 // WorkloadoptimizationV1Event defines model for workloadoptimization.v1.Event.
 type WorkloadoptimizationV1Event struct {
-	ConfigurationChanged       *WorkloadoptimizationV1ConfigurationChangedEvent       `json:"configurationChanged,omitempty"`
 	ConfigurationChangedV2     *WorkloadoptimizationV1ConfigurationChangedEventV2     `json:"configurationChangedV2,omitempty"`
 	OomKill                    *WorkloadoptimizationV1OOMKillEvent                    `json:"oomKill,omitempty"`
-	RecommendationApplied      *WorkloadoptimizationV1RecommendationAppliedEvent      `json:"recommendationApplied,omitempty"`
 	RecommendedPodCountChanged *WorkloadoptimizationV1RecommendedPodCountChangedEvent `json:"recommendedPodCountChanged,omitempty"`
 	RecommendedRequestsChanged *WorkloadoptimizationV1RecommendedRequestsChangedEvent `json:"recommendedRequestsChanged,omitempty"`
+	ScalingPolicyAssigned      *WorkloadoptimizationV1ScalingPolicyAssigned           `json:"scalingPolicyAssigned,omitempty"`
 	ScalingPolicyCreated       *WorkloadoptimizationV1ScalingPolicyCreated            `json:"scalingPolicyCreated,omitempty"`
 	ScalingPolicyDeleted       *WorkloadoptimizationV1ScalingPolicyDeleted            `json:"scalingPolicyDeleted,omitempty"`
+	ScalingPolicyUpdated       *WorkloadoptimizationV1ScalingPolicyUpdated            `json:"scalingPolicyUpdated,omitempty"`
 	Surge                      *WorkloadoptimizationV1SurgeEvent                      `json:"surge,omitempty"`
 }
 
@@ -3536,24 +3564,6 @@ type WorkloadoptimizationV1PodMetrics struct {
 	PodCountMin float64                                  `json:"podCountMin"`
 }
 
-// WorkloadoptimizationV1RecommendationAppliedEvent defines model for workloadoptimization.v1.RecommendationAppliedEvent.
-type WorkloadoptimizationV1RecommendationAppliedEvent struct {
-	ApplyType WorkloadoptimizationV1ApplyType                        `json:"applyType"`
-	Current   WorkloadoptimizationV1RecommendationAppliedEventChange `json:"current"`
-	Previous  WorkloadoptimizationV1RecommendationAppliedEventChange `json:"previous"`
-}
-
-// WorkloadoptimizationV1RecommendationAppliedEventChange defines model for workloadoptimization.v1.RecommendationAppliedEvent.Change.
-type WorkloadoptimizationV1RecommendationAppliedEventChange struct {
-	Containers *[]WorkloadoptimizationV1EventContainer `json:"containers,omitempty"`
-}
-
-// WorkloadoptimizationV1RecommendationConfig defines model for workloadoptimization.v1.RecommendationConfig.
-type WorkloadoptimizationV1RecommendationConfig struct {
-	Cpu    WorkloadoptimizationV1ResourceConfig `json:"cpu"`
-	Memory WorkloadoptimizationV1ResourceConfig `json:"memory"`
-}
-
 // WorkloadoptimizationV1RecommendationEvent defines model for workloadoptimization.v1.RecommendationEvent.
 type WorkloadoptimizationV1RecommendationEvent struct {
 	// Defines possible options for recommendation events.
@@ -3702,6 +3712,11 @@ type WorkloadoptimizationV1Resources struct {
 	Requests *WorkloadoptimizationV1ResourceQuantity `json:"requests,omitempty"`
 }
 
+// WorkloadoptimizationV1ScalingPolicyAssigned defines model for workloadoptimization.v1.ScalingPolicyAssigned.
+type WorkloadoptimizationV1ScalingPolicyAssigned struct {
+	Policy WorkloadoptimizationV1WorkloadScalingPolicy `json:"policy"`
+}
+
 // WorkloadoptimizationV1ScalingPolicyConfig defines model for workloadoptimization.v1.ScalingPolicyConfig.
 type WorkloadoptimizationV1ScalingPolicyConfig struct {
 	Id   string `json:"id"`
@@ -3716,6 +3731,12 @@ type WorkloadoptimizationV1ScalingPolicyCreated struct {
 // WorkloadoptimizationV1ScalingPolicyDeleted defines model for workloadoptimization.v1.ScalingPolicyDeleted.
 type WorkloadoptimizationV1ScalingPolicyDeleted struct {
 	Policy WorkloadoptimizationV1WorkloadScalingPolicy `json:"policy"`
+}
+
+// WorkloadoptimizationV1ScalingPolicyUpdated defines model for workloadoptimization.v1.ScalingPolicyUpdated.
+type WorkloadoptimizationV1ScalingPolicyUpdated struct {
+	Current  WorkloadoptimizationV1WorkloadScalingPolicy `json:"current"`
+	Previous WorkloadoptimizationV1WorkloadScalingPolicy `json:"previous"`
 }
 
 // WorkloadoptimizationV1StartupSettings defines model for workloadoptimization.v1.StartupSettings.
@@ -3903,8 +3924,9 @@ type WorkloadoptimizationV1WorkloadEvent struct {
 	OrganizationId string                             `json:"organizationId"`
 
 	// EventType defines possible types for workload events.
-	Type     WorkloadoptimizationV1EventType              `json:"type"`
-	Workload *WorkloadoptimizationV1WorkloadEventWorkload `json:"workload,omitempty"`
+	Type      WorkloadoptimizationV1EventType                `json:"type"`
+	Workload  *WorkloadoptimizationV1WorkloadEventWorkload   `json:"workload,omitempty"`
+	Workloads *[]WorkloadoptimizationV1WorkloadEventWorkload `json:"workloads,omitempty"`
 }
 
 // WorkloadoptimizationV1WorkloadEventWorkload defines model for workloadoptimization.v1.WorkloadEvent.Workload.
@@ -3978,9 +4000,6 @@ type WorkloadoptimizationV1WorkloadScalingPolicy struct {
 type AuthTokenAPIListAuthTokensParams struct {
 	// User id to filter by, if this is set we will only return tokens that have this user id.
 	UserId *string `form:"userId,omitempty" json:"userId,omitempty"`
-
-	// Service account id to filter by, if this is set we will only return tokens that have this service account id ignoring users_id.
-	ServiceAccountId *string `form:"serviceAccountId,omitempty" json:"serviceAccountId,omitempty"`
 }
 
 // AuthTokenAPICreateAuthTokenJSONBody defines parameters for AuthTokenAPICreateAuthToken.
@@ -3988,6 +4007,16 @@ type AuthTokenAPICreateAuthTokenJSONBody = CastaiAuthtokenV1beta1AuthToken
 
 // AuthTokenAPIUpdateAuthTokenJSONBody defines parameters for AuthTokenAPIUpdateAuthToken.
 type AuthTokenAPIUpdateAuthTokenJSONBody = CastaiAuthtokenV1beta1AuthTokenUpdate
+
+// InventoryAPIListInstanceTypeNamesParams defines parameters for InventoryAPIListInstanceTypeNames.
+type InventoryAPIListInstanceTypeNamesParams struct {
+	CloudServiceProviders *[]string `form:"cloudServiceProviders,omitempty" json:"cloudServiceProviders,omitempty"`
+	PageLimit             *string   `form:"page.limit,omitempty" json:"page.limit,omitempty"`
+
+	// Cursor that defines token indicating where to start the next page.
+	// Empty value indicates to start from beginning of the dataset.
+	PageCursor *string `form:"page.cursor,omitempty" json:"page.cursor,omitempty"`
+}
 
 // UsersAPIListInvitationsParams defines parameters for UsersAPIListInvitations.
 type UsersAPIListInvitationsParams struct {
@@ -4059,15 +4088,21 @@ type ExternalClusterAPIGetCredentialsScriptParams struct {
 	// Whether NVIDIA device plugin DaemonSet should be installed during Phase 2 on-boarding.
 	NvidiaDevicePlugin *bool `form:"nvidiaDevicePlugin,omitempty" json:"nvidiaDevicePlugin,omitempty"`
 
-	// Whether CAST AI Security Insights agent should be installed
+	// Whether CAST AI Security Insights agent should be installed.
 	InstallSecurityAgent *bool `form:"installSecurityAgent,omitempty" json:"installSecurityAgent,omitempty"`
 
 	// Whether CAST AI Autoscaler components should be installed.
 	// To enable backwards compatibility, when the field is omitted, it is defaulted to true.
 	InstallAutoscalerAgent *bool `form:"installAutoscalerAgent,omitempty" json:"installAutoscalerAgent,omitempty"`
 
-	// Whether CAST AI GPU metrics exporter should be installed
+	// Whether CAST AI GPU metrics exporter should be installed.
 	InstallGpuMetricsExporter *bool `form:"installGpuMetricsExporter,omitempty" json:"installGpuMetricsExporter,omitempty"`
+
+	// Whether CAST AI AI-Optimizer Proxy should be installed.
+	InstallAiOptimizerProxy *bool `form:"installAiOptimizerProxy,omitempty" json:"installAiOptimizerProxy,omitempty"`
+
+	// Whether GCP SA Impersonate feature should be enabled.
+	GcpSaImpersonate *bool `form:"gcpSaImpersonate,omitempty" json:"gcpSaImpersonate,omitempty"`
 }
 
 // ExternalClusterAPIDisconnectClusterJSONBody defines parameters for ExternalClusterAPIDisconnectCluster.
@@ -4121,6 +4156,9 @@ type ExternalClusterAPIDeleteNodeParams struct {
 
 // ExternalClusterAPIDrainNodeJSONBody defines parameters for ExternalClusterAPIDrainNode.
 type ExternalClusterAPIDrainNodeJSONBody = ExternalclusterV1DrainConfig
+
+// ExternalClusterAPITriggerResumeClusterJSONBody defines parameters for ExternalClusterAPITriggerResumeCluster.
+type ExternalClusterAPITriggerResumeClusterJSONBody = ExternalclusterV1NodeConfig
 
 // ExternalClusterAPIUpdateClusterTagsJSONBody defines parameters for ExternalClusterAPIUpdateClusterTags.
 type ExternalClusterAPIUpdateClusterTagsJSONBody struct {
@@ -4376,6 +4414,9 @@ type ExternalClusterAPIAddNodeJSONRequestBody = ExternalClusterAPIAddNodeJSONBod
 
 // ExternalClusterAPIDrainNodeJSONRequestBody defines body for ExternalClusterAPIDrainNode for application/json ContentType.
 type ExternalClusterAPIDrainNodeJSONRequestBody = ExternalClusterAPIDrainNodeJSONBody
+
+// ExternalClusterAPITriggerResumeClusterJSONRequestBody defines body for ExternalClusterAPITriggerResumeCluster for application/json ContentType.
+type ExternalClusterAPITriggerResumeClusterJSONRequestBody = ExternalClusterAPITriggerResumeClusterJSONBody
 
 // ExternalClusterAPIUpdateClusterTagsJSONRequestBody defines body for ExternalClusterAPIUpdateClusterTags for application/json ContentType.
 type ExternalClusterAPIUpdateClusterTagsJSONRequestBody ExternalClusterAPIUpdateClusterTagsJSONBody

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -109,6 +109,9 @@ type ClientInterface interface {
 
 	AuthTokenAPIUpdateAuthToken(ctx context.Context, id string, body AuthTokenAPIUpdateAuthTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// InventoryAPIListInstanceTypeNames request
+	InventoryAPIListInstanceTypeNames(ctx context.Context, params *InventoryAPIListInstanceTypeNamesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// UsersAPIListInvitations request
 	UsersAPIListInvitations(ctx context.Context, params *UsersAPIListInvitationsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -275,6 +278,12 @@ type ClientInterface interface {
 
 	ExternalClusterAPIGKECreateSA(ctx context.Context, clusterId string, body ExternalClusterAPIGKECreateSAJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ExternalClusterAPIDisableGKESA request
+	ExternalClusterAPIDisableGKESA(ctx context.Context, clusterId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ExternalClusterAPITriggerHibernateCluster request
+	ExternalClusterAPITriggerHibernateCluster(ctx context.Context, clusterId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ExternalClusterAPIListNodes request
 	ExternalClusterAPIListNodes(ctx context.Context, clusterId string, params *ExternalClusterAPIListNodesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -296,6 +305,11 @@ type ClientInterface interface {
 
 	// ExternalClusterAPIReconcileCluster request
 	ExternalClusterAPIReconcileCluster(ctx context.Context, clusterId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ExternalClusterAPITriggerResumeCluster request with any body
+	ExternalClusterAPITriggerResumeClusterWithBody(ctx context.Context, clusterId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ExternalClusterAPITriggerResumeCluster(ctx context.Context, clusterId string, body ExternalClusterAPITriggerResumeClusterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ExternalClusterAPIUpdateClusterTags request with any body
 	ExternalClusterAPIUpdateClusterTagsWithBody(ctx context.Context, clusterId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -615,6 +629,18 @@ func (c *Client) AuthTokenAPIUpdateAuthTokenWithBody(ctx context.Context, id str
 
 func (c *Client) AuthTokenAPIUpdateAuthToken(ctx context.Context, id string, body AuthTokenAPIUpdateAuthTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewAuthTokenAPIUpdateAuthTokenRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) InventoryAPIListInstanceTypeNames(ctx context.Context, params *InventoryAPIListInstanceTypeNamesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewInventoryAPIListInstanceTypeNamesRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1357,6 +1383,30 @@ func (c *Client) ExternalClusterAPIGKECreateSA(ctx context.Context, clusterId st
 	return c.Client.Do(req)
 }
 
+func (c *Client) ExternalClusterAPIDisableGKESA(ctx context.Context, clusterId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewExternalClusterAPIDisableGKESARequest(c.Server, clusterId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ExternalClusterAPITriggerHibernateCluster(ctx context.Context, clusterId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewExternalClusterAPITriggerHibernateClusterRequest(c.Server, clusterId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ExternalClusterAPIListNodes(ctx context.Context, clusterId string, params *ExternalClusterAPIListNodesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewExternalClusterAPIListNodesRequest(c.Server, clusterId, params)
 	if err != nil {
@@ -1443,6 +1493,30 @@ func (c *Client) ExternalClusterAPIDrainNode(ctx context.Context, clusterId stri
 
 func (c *Client) ExternalClusterAPIReconcileCluster(ctx context.Context, clusterId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewExternalClusterAPIReconcileClusterRequest(c.Server, clusterId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ExternalClusterAPITriggerResumeClusterWithBody(ctx context.Context, clusterId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewExternalClusterAPITriggerResumeClusterRequestWithBody(c.Server, clusterId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ExternalClusterAPITriggerResumeCluster(ctx context.Context, clusterId string, body ExternalClusterAPITriggerResumeClusterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewExternalClusterAPITriggerResumeClusterRequest(c.Server, clusterId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2546,22 +2620,6 @@ func NewAuthTokenAPIListAuthTokensRequest(server string, params *AuthTokenAPILis
 
 	}
 
-	if params.ServiceAccountId != nil {
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "serviceAccountId", runtime.ParamLocationQuery, *params.ServiceAccountId); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-	}
-
 	queryURL.RawQuery = queryValues.Encode()
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -2723,6 +2781,85 @@ func NewAuthTokenAPIUpdateAuthTokenRequestWithBody(server string, id string, con
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewInventoryAPIListInstanceTypeNamesRequest generates requests for InventoryAPIListInstanceTypeNames
+func NewInventoryAPIListInstanceTypeNamesRequest(server string, params *InventoryAPIListInstanceTypeNamesParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/instances/types")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.CloudServiceProviders != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cloudServiceProviders", runtime.ParamLocationQuery, *params.CloudServiceProviders); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.PageLimit != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.limit", runtime.ParamLocationQuery, *params.PageLimit); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.PageCursor != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.cursor", runtime.ParamLocationQuery, *params.PageCursor); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -4481,6 +4618,38 @@ func NewExternalClusterAPIGetCredentialsScriptRequest(server string, clusterId s
 
 	}
 
+	if params.InstallAiOptimizerProxy != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "installAiOptimizerProxy", runtime.ParamLocationQuery, *params.InstallAiOptimizerProxy); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.GcpSaImpersonate != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "gcpSaImpersonate", runtime.ParamLocationQuery, *params.GcpSaImpersonate); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
 	queryURL.RawQuery = queryValues.Encode()
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -4628,6 +4797,74 @@ func NewExternalClusterAPIGKECreateSARequestWithBody(server string, clusterId st
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewExternalClusterAPIDisableGKESARequest generates requests for ExternalClusterAPIDisableGKESA
+func NewExternalClusterAPIDisableGKESARequest(server string, clusterId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "clusterId", runtime.ParamLocationPath, clusterId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/kubernetes/external-clusters/%s/gke-disable-sa", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewExternalClusterAPITriggerHibernateClusterRequest generates requests for ExternalClusterAPITriggerHibernateCluster
+func NewExternalClusterAPITriggerHibernateClusterRequest(server string, clusterId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "clusterId", runtime.ParamLocationPath, clusterId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/kubernetes/external-clusters/%s/hibernate", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -5159,6 +5396,53 @@ func NewExternalClusterAPIReconcileClusterRequest(server string, clusterId strin
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewExternalClusterAPITriggerResumeClusterRequest calls the generic ExternalClusterAPITriggerResumeCluster builder with application/json body
+func NewExternalClusterAPITriggerResumeClusterRequest(server string, clusterId string, body ExternalClusterAPITriggerResumeClusterJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewExternalClusterAPITriggerResumeClusterRequestWithBody(server, clusterId, "application/json", bodyReader)
+}
+
+// NewExternalClusterAPITriggerResumeClusterRequestWithBody generates requests for ExternalClusterAPITriggerResumeCluster with any type of body
+func NewExternalClusterAPITriggerResumeClusterRequestWithBody(server string, clusterId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "clusterId", runtime.ParamLocationPath, clusterId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/kubernetes/external-clusters/%s/resume", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -8220,6 +8504,9 @@ type ClientWithResponsesInterface interface {
 
 	AuthTokenAPIUpdateAuthTokenWithResponse(ctx context.Context, id string, body AuthTokenAPIUpdateAuthTokenJSONRequestBody) (*AuthTokenAPIUpdateAuthTokenResponse, error)
 
+	// InventoryAPIListInstanceTypeNames request
+	InventoryAPIListInstanceTypeNamesWithResponse(ctx context.Context, params *InventoryAPIListInstanceTypeNamesParams) (*InventoryAPIListInstanceTypeNamesResponse, error)
+
 	// UsersAPIListInvitations request
 	UsersAPIListInvitationsWithResponse(ctx context.Context, params *UsersAPIListInvitationsParams) (*UsersAPIListInvitationsResponse, error)
 
@@ -8386,6 +8673,12 @@ type ClientWithResponsesInterface interface {
 
 	ExternalClusterAPIGKECreateSAWithResponse(ctx context.Context, clusterId string, body ExternalClusterAPIGKECreateSAJSONRequestBody) (*ExternalClusterAPIGKECreateSAResponse, error)
 
+	// ExternalClusterAPIDisableGKESA request
+	ExternalClusterAPIDisableGKESAWithResponse(ctx context.Context, clusterId string) (*ExternalClusterAPIDisableGKESAResponse, error)
+
+	// ExternalClusterAPITriggerHibernateCluster request
+	ExternalClusterAPITriggerHibernateClusterWithResponse(ctx context.Context, clusterId string) (*ExternalClusterAPITriggerHibernateClusterResponse, error)
+
 	// ExternalClusterAPIListNodes request
 	ExternalClusterAPIListNodesWithResponse(ctx context.Context, clusterId string, params *ExternalClusterAPIListNodesParams) (*ExternalClusterAPIListNodesResponse, error)
 
@@ -8407,6 +8700,11 @@ type ClientWithResponsesInterface interface {
 
 	// ExternalClusterAPIReconcileCluster request
 	ExternalClusterAPIReconcileClusterWithResponse(ctx context.Context, clusterId string) (*ExternalClusterAPIReconcileClusterResponse, error)
+
+	// ExternalClusterAPITriggerResumeCluster request  with any body
+	ExternalClusterAPITriggerResumeClusterWithBodyWithResponse(ctx context.Context, clusterId string, contentType string, body io.Reader) (*ExternalClusterAPITriggerResumeClusterResponse, error)
+
+	ExternalClusterAPITriggerResumeClusterWithResponse(ctx context.Context, clusterId string, body ExternalClusterAPITriggerResumeClusterJSONRequestBody) (*ExternalClusterAPITriggerResumeClusterResponse, error)
 
 	// ExternalClusterAPIUpdateClusterTags request  with any body
 	ExternalClusterAPIUpdateClusterTagsWithBodyWithResponse(ctx context.Context, clusterId string, contentType string, body io.Reader) (*ExternalClusterAPIUpdateClusterTagsResponse, error)
@@ -8806,6 +9104,36 @@ func (r AuthTokenAPIUpdateAuthTokenResponse) StatusCode() int {
 // TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 // Body returns body of byte array
 func (r AuthTokenAPIUpdateAuthTokenResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
+type InventoryAPIListInstanceTypeNamesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CastaiInventoryV1beta1ListInstanceTypeNamesResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r InventoryAPIListInstanceTypeNamesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r InventoryAPIListInstanceTypeNamesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r InventoryAPIListInstanceTypeNamesResponse) GetBody() []byte {
 	return r.Body
 }
 
@@ -10130,6 +10458,66 @@ func (r ExternalClusterAPIGKECreateSAResponse) GetBody() []byte {
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
+type ExternalClusterAPIDisableGKESAResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ExternalclusterV1DisableGKESAResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ExternalClusterAPIDisableGKESAResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ExternalClusterAPIDisableGKESAResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r ExternalClusterAPIDisableGKESAResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
+type ExternalClusterAPITriggerHibernateClusterResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ExternalclusterV1TriggerHibernateClusterResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ExternalClusterAPITriggerHibernateClusterResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ExternalClusterAPITriggerHibernateClusterResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r ExternalClusterAPITriggerHibernateClusterResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
 type ExternalClusterAPIListNodesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -10305,6 +10693,36 @@ func (r ExternalClusterAPIReconcileClusterResponse) StatusCode() int {
 // TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 // Body returns body of byte array
 func (r ExternalClusterAPIReconcileClusterResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
+type ExternalClusterAPITriggerResumeClusterResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ExternalclusterV1TriggerResumeClusterResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ExternalClusterAPITriggerResumeClusterResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ExternalClusterAPITriggerResumeClusterResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r ExternalClusterAPITriggerResumeClusterResponse) GetBody() []byte {
 	return r.Body
 }
 
@@ -12377,6 +12795,15 @@ func (c *ClientWithResponses) AuthTokenAPIUpdateAuthTokenWithResponse(ctx contex
 	return ParseAuthTokenAPIUpdateAuthTokenResponse(rsp)
 }
 
+// InventoryAPIListInstanceTypeNamesWithResponse request returning *InventoryAPIListInstanceTypeNamesResponse
+func (c *ClientWithResponses) InventoryAPIListInstanceTypeNamesWithResponse(ctx context.Context, params *InventoryAPIListInstanceTypeNamesParams) (*InventoryAPIListInstanceTypeNamesResponse, error) {
+	rsp, err := c.InventoryAPIListInstanceTypeNames(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseInventoryAPIListInstanceTypeNamesResponse(rsp)
+}
+
 // UsersAPIListInvitationsWithResponse request returning *UsersAPIListInvitationsResponse
 func (c *ClientWithResponses) UsersAPIListInvitationsWithResponse(ctx context.Context, params *UsersAPIListInvitationsParams) (*UsersAPIListInvitationsResponse, error) {
 	rsp, err := c.UsersAPIListInvitations(ctx, params)
@@ -12909,6 +13336,24 @@ func (c *ClientWithResponses) ExternalClusterAPIGKECreateSAWithResponse(ctx cont
 	return ParseExternalClusterAPIGKECreateSAResponse(rsp)
 }
 
+// ExternalClusterAPIDisableGKESAWithResponse request returning *ExternalClusterAPIDisableGKESAResponse
+func (c *ClientWithResponses) ExternalClusterAPIDisableGKESAWithResponse(ctx context.Context, clusterId string) (*ExternalClusterAPIDisableGKESAResponse, error) {
+	rsp, err := c.ExternalClusterAPIDisableGKESA(ctx, clusterId)
+	if err != nil {
+		return nil, err
+	}
+	return ParseExternalClusterAPIDisableGKESAResponse(rsp)
+}
+
+// ExternalClusterAPITriggerHibernateClusterWithResponse request returning *ExternalClusterAPITriggerHibernateClusterResponse
+func (c *ClientWithResponses) ExternalClusterAPITriggerHibernateClusterWithResponse(ctx context.Context, clusterId string) (*ExternalClusterAPITriggerHibernateClusterResponse, error) {
+	rsp, err := c.ExternalClusterAPITriggerHibernateCluster(ctx, clusterId)
+	if err != nil {
+		return nil, err
+	}
+	return ParseExternalClusterAPITriggerHibernateClusterResponse(rsp)
+}
+
 // ExternalClusterAPIListNodesWithResponse request returning *ExternalClusterAPIListNodesResponse
 func (c *ClientWithResponses) ExternalClusterAPIListNodesWithResponse(ctx context.Context, clusterId string, params *ExternalClusterAPIListNodesParams) (*ExternalClusterAPIListNodesResponse, error) {
 	rsp, err := c.ExternalClusterAPIListNodes(ctx, clusterId, params)
@@ -12977,6 +13422,23 @@ func (c *ClientWithResponses) ExternalClusterAPIReconcileClusterWithResponse(ctx
 		return nil, err
 	}
 	return ParseExternalClusterAPIReconcileClusterResponse(rsp)
+}
+
+// ExternalClusterAPITriggerResumeClusterWithBodyWithResponse request with arbitrary body returning *ExternalClusterAPITriggerResumeClusterResponse
+func (c *ClientWithResponses) ExternalClusterAPITriggerResumeClusterWithBodyWithResponse(ctx context.Context, clusterId string, contentType string, body io.Reader) (*ExternalClusterAPITriggerResumeClusterResponse, error) {
+	rsp, err := c.ExternalClusterAPITriggerResumeClusterWithBody(ctx, clusterId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseExternalClusterAPITriggerResumeClusterResponse(rsp)
+}
+
+func (c *ClientWithResponses) ExternalClusterAPITriggerResumeClusterWithResponse(ctx context.Context, clusterId string, body ExternalClusterAPITriggerResumeClusterJSONRequestBody) (*ExternalClusterAPITriggerResumeClusterResponse, error) {
+	rsp, err := c.ExternalClusterAPITriggerResumeCluster(ctx, clusterId, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseExternalClusterAPITriggerResumeClusterResponse(rsp)
 }
 
 // ExternalClusterAPIUpdateClusterTagsWithBodyWithResponse request with arbitrary body returning *ExternalClusterAPIUpdateClusterTagsResponse
@@ -13870,6 +14332,32 @@ func ParseAuthTokenAPIUpdateAuthTokenResponse(rsp *http.Response) (*AuthTokenAPI
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest CastaiAuthtokenV1beta1AuthToken
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseInventoryAPIListInstanceTypeNamesResponse parses an HTTP response from a InventoryAPIListInstanceTypeNamesWithResponse call
+func ParseInventoryAPIListInstanceTypeNamesResponse(rsp *http.Response) (*InventoryAPIListInstanceTypeNamesResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &InventoryAPIListInstanceTypeNamesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CastaiInventoryV1beta1ListInstanceTypeNamesResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15014,6 +15502,58 @@ func ParseExternalClusterAPIGKECreateSAResponse(rsp *http.Response) (*ExternalCl
 	return response, nil
 }
 
+// ParseExternalClusterAPIDisableGKESAResponse parses an HTTP response from a ExternalClusterAPIDisableGKESAWithResponse call
+func ParseExternalClusterAPIDisableGKESAResponse(rsp *http.Response) (*ExternalClusterAPIDisableGKESAResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ExternalClusterAPIDisableGKESAResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ExternalclusterV1DisableGKESAResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseExternalClusterAPITriggerHibernateClusterResponse parses an HTTP response from a ExternalClusterAPITriggerHibernateClusterWithResponse call
+func ParseExternalClusterAPITriggerHibernateClusterResponse(rsp *http.Response) (*ExternalClusterAPITriggerHibernateClusterResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ExternalClusterAPITriggerHibernateClusterResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ExternalclusterV1TriggerHibernateClusterResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseExternalClusterAPIListNodesResponse parses an HTTP response from a ExternalClusterAPIListNodesWithResponse call
 func ParseExternalClusterAPIListNodesResponse(rsp *http.Response) (*ExternalClusterAPIListNodesResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -15160,6 +15700,32 @@ func ParseExternalClusterAPIReconcileClusterResponse(rsp *http.Response) (*Exter
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ExternalclusterV1ReconcileClusterResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseExternalClusterAPITriggerResumeClusterResponse parses an HTTP response from a ExternalClusterAPITriggerResumeClusterWithResponse call
+func ParseExternalClusterAPITriggerResumeClusterResponse(rsp *http.Response) (*ExternalClusterAPITriggerResumeClusterResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ExternalClusterAPITriggerResumeClusterResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ExternalclusterV1TriggerResumeClusterResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -755,6 +755,26 @@ func (mr *MockClientInterfaceMockRecorder) ExternalClusterAPIDeleteNode(ctx, clu
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPIDeleteNode", reflect.TypeOf((*MockClientInterface)(nil).ExternalClusterAPIDeleteNode), varargs...)
 }
 
+// ExternalClusterAPIDisableGKESA mocks base method.
+func (m *MockClientInterface) ExternalClusterAPIDisableGKESA(ctx context.Context, clusterId string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, clusterId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ExternalClusterAPIDisableGKESA", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExternalClusterAPIDisableGKESA indicates an expected call of ExternalClusterAPIDisableGKESA.
+func (mr *MockClientInterfaceMockRecorder) ExternalClusterAPIDisableGKESA(ctx, clusterId interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, clusterId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPIDisableGKESA", reflect.TypeOf((*MockClientInterface)(nil).ExternalClusterAPIDisableGKESA), varargs...)
+}
+
 // ExternalClusterAPIDisconnectCluster mocks base method.
 func (m *MockClientInterface) ExternalClusterAPIDisconnectCluster(ctx context.Context, clusterId string, body sdk.ExternalClusterAPIDisconnectClusterJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -1195,6 +1215,66 @@ func (mr *MockClientInterfaceMockRecorder) ExternalClusterAPIRegisterClusterWith
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPIRegisterClusterWithBody", reflect.TypeOf((*MockClientInterface)(nil).ExternalClusterAPIRegisterClusterWithBody), varargs...)
 }
 
+// ExternalClusterAPITriggerHibernateCluster mocks base method.
+func (m *MockClientInterface) ExternalClusterAPITriggerHibernateCluster(ctx context.Context, clusterId string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, clusterId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ExternalClusterAPITriggerHibernateCluster", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExternalClusterAPITriggerHibernateCluster indicates an expected call of ExternalClusterAPITriggerHibernateCluster.
+func (mr *MockClientInterfaceMockRecorder) ExternalClusterAPITriggerHibernateCluster(ctx, clusterId interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, clusterId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerHibernateCluster", reflect.TypeOf((*MockClientInterface)(nil).ExternalClusterAPITriggerHibernateCluster), varargs...)
+}
+
+// ExternalClusterAPITriggerResumeCluster mocks base method.
+func (m *MockClientInterface) ExternalClusterAPITriggerResumeCluster(ctx context.Context, clusterId string, body sdk.ExternalClusterAPITriggerResumeClusterJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, clusterId, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ExternalClusterAPITriggerResumeCluster", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExternalClusterAPITriggerResumeCluster indicates an expected call of ExternalClusterAPITriggerResumeCluster.
+func (mr *MockClientInterfaceMockRecorder) ExternalClusterAPITriggerResumeCluster(ctx, clusterId, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, clusterId, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerResumeCluster", reflect.TypeOf((*MockClientInterface)(nil).ExternalClusterAPITriggerResumeCluster), varargs...)
+}
+
+// ExternalClusterAPITriggerResumeClusterWithBody mocks base method.
+func (m *MockClientInterface) ExternalClusterAPITriggerResumeClusterWithBody(ctx context.Context, clusterId, contentType string, body io.Reader, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, clusterId, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ExternalClusterAPITriggerResumeClusterWithBody", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExternalClusterAPITriggerResumeClusterWithBody indicates an expected call of ExternalClusterAPITriggerResumeClusterWithBody.
+func (mr *MockClientInterfaceMockRecorder) ExternalClusterAPITriggerResumeClusterWithBody(ctx, clusterId, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, clusterId, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerResumeClusterWithBody", reflect.TypeOf((*MockClientInterface)(nil).ExternalClusterAPITriggerResumeClusterWithBody), varargs...)
+}
+
 // ExternalClusterAPIUpdateCluster mocks base method.
 func (m *MockClientInterface) ExternalClusterAPIUpdateCluster(ctx context.Context, clusterId string, body sdk.ExternalClusterAPIUpdateClusterJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -1413,6 +1493,26 @@ func (mr *MockClientInterfaceMockRecorder) InventoryAPIGetReservationsBalance(ct
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, organizationId}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InventoryAPIGetReservationsBalance", reflect.TypeOf((*MockClientInterface)(nil).InventoryAPIGetReservationsBalance), varargs...)
+}
+
+// InventoryAPIListInstanceTypeNames mocks base method.
+func (m *MockClientInterface) InventoryAPIListInstanceTypeNames(ctx context.Context, params *sdk.InventoryAPIListInstanceTypeNamesParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "InventoryAPIListInstanceTypeNames", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InventoryAPIListInstanceTypeNames indicates an expected call of InventoryAPIListInstanceTypeNames.
+func (mr *MockClientInterfaceMockRecorder) InventoryAPIListInstanceTypeNames(ctx, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InventoryAPIListInstanceTypeNames", reflect.TypeOf((*MockClientInterface)(nil).InventoryAPIListInstanceTypeNames), varargs...)
 }
 
 // InventoryAPIListRegions mocks base method.
@@ -3888,6 +3988,21 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPIDelete
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPIDeleteNodeWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ExternalClusterAPIDeleteNodeWithResponse), ctx, clusterId, nodeId, params)
 }
 
+// ExternalClusterAPIDisableGKESAWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) ExternalClusterAPIDisableGKESAWithResponse(ctx context.Context, clusterId string) (*sdk.ExternalClusterAPIDisableGKESAResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExternalClusterAPIDisableGKESAWithResponse", ctx, clusterId)
+	ret0, _ := ret[0].(*sdk.ExternalClusterAPIDisableGKESAResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExternalClusterAPIDisableGKESAWithResponse indicates an expected call of ExternalClusterAPIDisableGKESAWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPIDisableGKESAWithResponse(ctx, clusterId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPIDisableGKESAWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ExternalClusterAPIDisableGKESAWithResponse), ctx, clusterId)
+}
+
 // ExternalClusterAPIDisconnectClusterWithBodyWithResponse mocks base method.
 func (m *MockClientWithResponsesInterface) ExternalClusterAPIDisconnectClusterWithBodyWithResponse(ctx context.Context, clusterId, contentType string, body io.Reader) (*sdk.ExternalClusterAPIDisconnectClusterResponse, error) {
 	m.ctrl.T.Helper()
@@ -4218,6 +4333,51 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPIRegist
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPIRegisterClusterWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ExternalClusterAPIRegisterClusterWithResponse), ctx, body)
 }
 
+// ExternalClusterAPITriggerHibernateClusterWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerHibernateClusterWithResponse(ctx context.Context, clusterId string) (*sdk.ExternalClusterAPITriggerHibernateClusterResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExternalClusterAPITriggerHibernateClusterWithResponse", ctx, clusterId)
+	ret0, _ := ret[0].(*sdk.ExternalClusterAPITriggerHibernateClusterResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExternalClusterAPITriggerHibernateClusterWithResponse indicates an expected call of ExternalClusterAPITriggerHibernateClusterWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPITriggerHibernateClusterWithResponse(ctx, clusterId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerHibernateClusterWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ExternalClusterAPITriggerHibernateClusterWithResponse), ctx, clusterId)
+}
+
+// ExternalClusterAPITriggerResumeClusterWithBodyWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerResumeClusterWithBodyWithResponse(ctx context.Context, clusterId, contentType string, body io.Reader) (*sdk.ExternalClusterAPITriggerResumeClusterResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExternalClusterAPITriggerResumeClusterWithBodyWithResponse", ctx, clusterId, contentType, body)
+	ret0, _ := ret[0].(*sdk.ExternalClusterAPITriggerResumeClusterResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExternalClusterAPITriggerResumeClusterWithBodyWithResponse indicates an expected call of ExternalClusterAPITriggerResumeClusterWithBodyWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPITriggerResumeClusterWithBodyWithResponse(ctx, clusterId, contentType, body interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerResumeClusterWithBodyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ExternalClusterAPITriggerResumeClusterWithBodyWithResponse), ctx, clusterId, contentType, body)
+}
+
+// ExternalClusterAPITriggerResumeClusterWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerResumeClusterWithResponse(ctx context.Context, clusterId string, body sdk.ExternalClusterAPITriggerResumeClusterJSONRequestBody) (*sdk.ExternalClusterAPITriggerResumeClusterResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExternalClusterAPITriggerResumeClusterWithResponse", ctx, clusterId, body)
+	ret0, _ := ret[0].(*sdk.ExternalClusterAPITriggerResumeClusterResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExternalClusterAPITriggerResumeClusterWithResponse indicates an expected call of ExternalClusterAPITriggerResumeClusterWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPITriggerResumeClusterWithResponse(ctx, clusterId, body interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerResumeClusterWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ExternalClusterAPITriggerResumeClusterWithResponse), ctx, clusterId, body)
+}
+
 // ExternalClusterAPIUpdateClusterTagsWithBodyWithResponse mocks base method.
 func (m *MockClientWithResponsesInterface) ExternalClusterAPIUpdateClusterTagsWithBodyWithResponse(ctx context.Context, clusterId, contentType string, body io.Reader) (*sdk.ExternalClusterAPIUpdateClusterTagsResponse, error) {
 	m.ctrl.T.Helper()
@@ -4381,6 +4541,21 @@ func (m *MockClientWithResponsesInterface) InventoryAPIGetReservationsWithRespon
 func (mr *MockClientWithResponsesInterfaceMockRecorder) InventoryAPIGetReservationsWithResponse(ctx, organizationId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InventoryAPIGetReservationsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).InventoryAPIGetReservationsWithResponse), ctx, organizationId)
+}
+
+// InventoryAPIListInstanceTypeNamesWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) InventoryAPIListInstanceTypeNamesWithResponse(ctx context.Context, params *sdk.InventoryAPIListInstanceTypeNamesParams) (*sdk.InventoryAPIListInstanceTypeNamesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InventoryAPIListInstanceTypeNamesWithResponse", ctx, params)
+	ret0, _ := ret[0].(*sdk.InventoryAPIListInstanceTypeNamesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InventoryAPIListInstanceTypeNamesWithResponse indicates an expected call of InventoryAPIListInstanceTypeNamesWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) InventoryAPIListInstanceTypeNamesWithResponse(ctx, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InventoryAPIListInstanceTypeNamesWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).InventoryAPIListInstanceTypeNamesWithResponse), ctx, params)
 }
 
 // InventoryAPIListRegionsWithResponse mocks base method.


### PR DESCRIPTION
This PR fixes the below panic in `resource_organization_members`.
I found it while testing the provider against RBACv2 changes.
```
Stack trace from the terraform-provider-castai plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1010d8df0]

goroutine 43 [running]:
github.com/castai/terraform-provider-castai/castai.resourceOrganizationMembersRead({0x101426ea0, 0x14000254930}, 0x14000276d80, {0x1012968e0?, 0x140002bc058?})
        /Users/radosny/projects/terraform-provider-castai/castai/resource_organization_members.go:177 +0x7d0
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0x1400043db20, {0x101426df8, 0x140004d7b30}, 0x14000276d80, {0x1012968e0, 0x140002bc058})
        /Users/radosny/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/resource.go:724 +0xe4
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0x1400043db20, {0x101426df8, 0x140004d7b30}, 0x14000127520, {0x1012968e0, 0x140002bc058})
        /Users/radosny/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/resource.go:1015 +0x3ec
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0x14000417ec0, {0x101426df8?, 0x140004d7a70?}, 0x14000243040)
        /Users/radosny/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/grpc_provider.go:613 +0x3e4
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadResource(0x1400025f180, {0x101426df8?, 0x140004d70e0?}, 0x14000475c20)
        /Users/radosny/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/tf5server/server.go:748 +0x388
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler({0x1013e45c0, 0x1400025f180}, {0x101426df8, 0x140004d70e0}, 0x14000254310, 0x0)
        /Users/radosny/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:349 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x1400024a1e0, {0x10142b3a0, 0x140004524e0}, 0x140004f0240, 0x1400044e780, 0x1019d5a30, 0x0)
        /Users/radosny/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:1340 +0xa9c
google.golang.org/grpc.(*Server).handleStream(0x1400024a1e0, {0x10142b3a0, 0x140004524e0}, 0x140004f0240, 0x0)
        /Users/radosny/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:1713 +0x7ac
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        /Users/radosny/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:965 +0x80
created by google.golang.org/grpc.(*Server).serveStreams.func1 in goroutine 26
        /Users/radosny/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:963 +0x220

Error: The terraform-provider-castai plugin crashed!
```

Now, instead of panicking it returns `403` whenever no permissions are matched:
```
Plan: 1 to add, 0 to change, 0 to destroy.
╷
│ Error: retrieving pending invitations: expected status code 200, received: status=403 body=<!DOCTYPE html>
│ <html>
│   <head><title>403 Forbidden</title></head>
│   <body>403 Forbidden</body>
│ </html>
│
│
│   with castai_organization_members.dev,
│   on main.tf line 24, in resource "castai_organization_members" "dev":
│   24: resource "castai_organization_members" "dev" {
```