### PR TITLE
Add depreciated field for backward compatibility

### DIFF
--- a/examples/eks/eks_cluster_gitops/README.md
+++ b/examples/eks/eks_cluster_gitops/README.md
@@ -67,7 +67,7 @@ echo "Authentication mode is $current_auth_mode"
 apiVersion: v1
 data:
   mapRoles: |
-    - rolearn: arn:aws:iam::028075177508:role/castai-eks-<clustername>
+    - rolearn: arn:aws:iam::028075177508:role/castai-eks-instance-<clustername>
       username: system:node:{{EC2PrivateDNSName}}
       groups:
       - system:bootstrappers

--- a/examples/gke/gke_cluster_existing/castai.tf
+++ b/examples/gke/gke_cluster_existing/castai.tf
@@ -103,7 +103,8 @@ module "castai-gke-cluster" {
     node_templates_partial_matching_enabled = false
 
     unschedulable_pods = {
-      enabled = false
+      enabled                  = false
+      custom_instances_enabled = true
     }
 
     node_downscaler = {

--- a/examples/gke/gke_cluster_existing/castai.tf
+++ b/examples/gke/gke_cluster_existing/castai.tf
@@ -46,12 +46,11 @@ module "castai-gke-cluster" {
   }
   node_templates = {
     default_by_castai = {
-      name                     = "default-by-castai"
-      configuration_id         = module.castai-gke-cluster.castai_node_configurations["default"]
-      is_default               = true
-      is_enabled               = true
-      should_taint             = false
-      custom_instances_enabled = true
+      name             = "default-by-castai"
+      configuration_id = module.castai-gke-cluster.castai_node_configurations["default"]
+      is_default       = true
+      is_enabled       = true
+      should_taint     = false
 
       constraints = {
         on_demand = true
@@ -62,7 +61,7 @@ module "castai-gke-cluster" {
       configuration_id         = module.castai-gke-cluster.castai_node_configurations["default"]
       is_enabled               = true
       should_taint             = true
-      custom_instances_enabled = true
+      custom_instances_enabled = false # custom_instances_enabled should be set to same value(true or false) at Node templates & unschedulable_pods policy for backward compatability
 
       custom_labels = {
         custom-label-key-1 = "custom-label-value-1"
@@ -104,7 +103,7 @@ module "castai-gke-cluster" {
 
     unschedulable_pods = {
       enabled                  = false
-      custom_instances_enabled = true
+      custom_instances_enabled = false # custom_instances_enabled should be set to same value(true or false) at Node templates & unschedulable_pods policy for backward compatability
     }
 
     node_downscaler = {

--- a/examples/gke/gke_cluster_gitops/castai.tf
+++ b/examples/gke/gke_cluster_gitops/castai.tf
@@ -95,7 +95,8 @@ resource "castai_autoscaler" "castai_autoscaler_policy" {
     node_templates_partial_matching_enabled = false
 
     unschedulable_pods {
-      enabled = true
+      enabled                  = true
+      custom_instances_enabled = true
     }
 
     cluster_limits {

--- a/examples/gke/gke_cluster_gitops/castai.tf
+++ b/examples/gke/gke_cluster_gitops/castai.tf
@@ -49,7 +49,7 @@ resource "castai_node_template" "example_spot_template" {
   is_enabled               = true
   configuration_id         = castai_node_configuration.default.id
   should_taint             = true
-  custom_instances_enabled = true # gke specific
+  custom_instances_enabled = false # custom_instances_enabled should be set to same value(true or false) at Node templates & unschedulable_pods policy for backward compatability
 
   custom_labels = {
     type = "spot"
@@ -96,7 +96,7 @@ resource "castai_autoscaler" "castai_autoscaler_policy" {
 
     unschedulable_pods {
       enabled                  = true
-      custom_instances_enabled = true
+      custom_instances_enabled = false # custom_instances_enabled should be set to same value(true or false) at Node templates & unschedulable_pods policy for backward compatability
     }
 
     cluster_limits {


### PR DESCRIPTION
Summary:

1. custom_instances_enabled = true needs to be added in unschedulable_pods policy
2. Readme instance profile name fix