### PR TITLE
Adding IAM policy: AmazonEBSCSIDriverPolicy

### DIFF
--- a/examples/eks/eks_cluster_custom_iam/iam.tf
+++ b/examples/eks/eks_cluster_custom_iam/iam.tf
@@ -46,6 +46,7 @@ resource "aws_iam_role_policy_attachment" "instance_profile_policy" {
     "arn:${local.partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy",
     "arn:${local.partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
     "arn:${local.partition}:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:${local.partition}:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy",
   ])
 
   role       = aws_iam_instance_profile.castai_instance_profile.role


### PR DESCRIPTION
Fixing events when customer has PV to be attached on POD and need to fix manually by adding a Policy

`Error: Events:
  Type     Reason              Age                  From                     Message
  ----     ------              ----                 ----                     -------
  Warning  FailedAttachVolume  16s (x3 over 8m20s)  attachdetach-controller  AttachVolume.Attach failed for volume "pvc-49ec2452-599a-4e9c-81fb-be4d831f7863" : timed out waiting for external-attacher of ebs.csi.aws.com CSI driver to attach volume vol-0464aff67958a32ab`

