### PR TITLE
Gitops to use token for access & general housekeeping

### DIFF
--- a/examples/aks/aks_cluster_existing/castai.tf
+++ b/examples/aks/aks_cluster_existing/castai.tf
@@ -11,7 +11,7 @@ module "castai-aks-cluster" {
   source = "castai/aks/castai"
 
   api_url                = var.castai_api_url
-  castai_api_token       = var.castai_api_token
+  castai_api_token       = var.castai_api_key
   grpc_url               = var.castai_grpc_url
   wait_for_cluster_ready = true
 

--- a/examples/aks/aks_cluster_existing/providers.tf
+++ b/examples/aks/aks_cluster_existing/providers.tf
@@ -10,7 +10,7 @@ provider "azuread" {
 
 provider "castai" {
   api_url   = var.castai_api_url
-  api_token = var.castai_api_token
+  api_token = var.castai_api_key
 }
 
 provider "helm" {

--- a/examples/aks/aks_cluster_existing/variables.tf
+++ b/examples/aks/aks_cluster_existing/variables.tf
@@ -26,9 +26,9 @@ variable "castai_api_url" {
 }
 
 # Variables required for connecting EKS cluster to CAST AI
-variable "castai_api_token" {
+variable "castai_api_key" {
   type        = string
-  description = "CAST AI API token created in console.cast.ai API Access keys section"
+  description = "CAST AI API Key created in console.cast.ai API Access keys section"
 }
 
 variable "castai_grpc_url" {

--- a/examples/aks/aks_cluster_gitops/providers.tf
+++ b/examples/aks/aks_cluster_gitops/providers.tf
@@ -9,5 +9,5 @@ provider "azuread" {
 
 provider "castai" {
   api_url   = var.castai_api_url
-  api_token = var.castai_api_token
+  api_token = var.castai_api_key
 }

--- a/examples/aks/aks_cluster_gitops/variables.tf
+++ b/examples/aks/aks_cluster_gitops/variables.tf
@@ -40,7 +40,7 @@ variable "castai_api_url" {
   default     = "https://api.cast.ai"
 }
 
-variable "castai_api_token" {
+variable "castai_api_key" {
   type        = string
-  description = "CAST AI API token created in console.cast.ai API Access keys section."
+  description = "CAST AI API Key created in console.cast.ai API Access keys section."
 }

--- a/examples/eks/eks_cluster_existing/castai.tf
+++ b/examples/eks/eks_cluster_existing/castai.tf
@@ -45,7 +45,7 @@ module "castai-eks-cluster" {
   source = "castai/eks-cluster/castai"
 
   api_url                = var.castai_api_url
-  castai_api_token       = var.castai_api_token
+  castai_api_token       = var.castai_api_key
   grpc_url               = var.castai_grpc_url
   wait_for_cluster_ready = true
 

--- a/examples/eks/eks_cluster_existing/providers.tf
+++ b/examples/eks/eks_cluster_existing/providers.tf
@@ -6,7 +6,7 @@ provider "aws" {
 
 provider "castai" {
   api_url   = var.castai_api_url
-  api_token = var.castai_api_token
+  api_token = var.castai_api_key
 }
 
 provider "kubernetes" {

--- a/examples/eks/eks_cluster_existing/variables.tf
+++ b/examples/eks/eks_cluster_existing/variables.tf
@@ -22,14 +22,14 @@ variable "vpc_id" {
 
 variable "castai_api_url" {
   type        = string
-  description = "URL of alternative CAST AI API to be used during development or testing"
+  description = "URL of CAST AI API"
   default     = "https://api.cast.ai"
 }
 
 # Variables required for connecting EKS cluster to CAST AI.
-variable "castai_api_token" {
+variable "castai_api_key" {
   type        = string
-  description = "CAST AI API token created in console.cast.ai API Access keys section"
+  description = "CAST AI API Key created in console.cast.ai API Access keys section"
 }
 
 variable "castai_grpc_url" {

--- a/examples/eks/eks_cluster_gitops/castai.tf
+++ b/examples/eks/eks_cluster_gitops/castai.tf
@@ -4,14 +4,14 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 data "aws_eks_cluster" "existing_cluster" {
-  name = var.aws_cluster_name
+  name = var.cluster_name
 }
 
 # Configure EKS cluster connection using CAST AI eks-cluster module.
 resource "castai_eks_clusterid" "cluster_id" {
   account_id   = data.aws_caller_identity.current.account_id
-  region       = var.aws_cluster_region
-  cluster_name = var.aws_cluster_name
+  region       = var.cluster_region
+  cluster_name = var.cluster_name
 }
 
 resource "castai_eks_user_arn" "castai_user_arn" {
@@ -19,11 +19,10 @@ resource "castai_eks_user_arn" "castai_user_arn" {
 }
 
 module "castai-eks-role-iam" {
-  source = "castai/eks-role-iam/castai"
-
+  source             = "castai/eks-role-iam/castai"
   aws_account_id     = data.aws_caller_identity.current.account_id
-  aws_cluster_region = var.aws_cluster_region
-  aws_cluster_name   = var.aws_cluster_name
+  aws_cluster_region = var.cluster_region
+  aws_cluster_name   = var.cluster_name
   aws_cluster_vpc_id = var.vpc_id
 
   castai_user_arn = castai_eks_user_arn.castai_user_arn.arn
@@ -38,7 +37,7 @@ locals {
 
 resource "aws_eks_access_entry" "access_entry" {
   count         = local.access_entry ? 1 : 0
-  cluster_name  = var.aws_cluster_name
+  cluster_name  = var.cluster_name
   principal_arn = module.castai-eks-role-iam.instance_profile_role_arn
   type          = "EC2_LINUX"
 }
@@ -46,8 +45,8 @@ resource "aws_eks_access_entry" "access_entry" {
 # Connect eks cluster to CAST AI
 resource "castai_eks_cluster" "my_castai_cluster" {
   account_id                 = var.aws_account_id
-  region                     = var.aws_cluster_region
-  name                       = var.aws_cluster_name
+  region                     = var.cluster_region
+  name                       = var.cluster_name
   delete_nodes_on_disconnect = var.delete_nodes_on_disconnect
   assume_role_arn            = module.castai-eks-role-iam.role_arn
 }

--- a/examples/eks/eks_cluster_gitops/outputs.tf
+++ b/examples/eks/eks_cluster_gitops/outputs.tf
@@ -3,6 +3,12 @@ output "cluster_id" {
   description = "CAST AI cluster ID"
 }
 
+output "cluster_token" {
+  value       = castai_eks_cluster.my_castai_cluster.cluster_token
+  description = "CAST AI cluster token used by Castware to authenticate to Mothership"
+  sensitive   = true
+}
+
 output "instance_profile_role_arn" {
   description = "Arn of created cast instance role"
   value       = module.castai-eks-role-iam.instance_profile_role_arn

--- a/examples/eks/eks_cluster_gitops/providers.tf
+++ b/examples/eks/eks_cluster_gitops/providers.tf
@@ -1,8 +1,8 @@
 provider "castai" {
   api_url   = var.castai_api_url
-  api_token = var.castai_api_token
+  api_token = var.castai_api_key
 }
 provider "aws" {
-  region  = var.aws_cluster_region
+  region  = var.cluster_region
   profile = var.profile
 }

--- a/examples/eks/eks_cluster_gitops/tf.vars.example
+++ b/examples/eks/eks_cluster_gitops/tf.vars.example
@@ -1,7 +1,7 @@
 castai_api_token    = "PLACEHOLDER"
 aws_account_id      = "PLACEHOLDER"
-aws_cluster_region  = "PLACEHOLDER"
-aws_cluster_name    = "PLACEHOLDER"
+cluster_region  = "PLACEHOLDER"
+cluster_name    = "PLACEHOLDER"
 subnets             = ["PLACEHOLDER1", "PLACEHOLDER2"]
 vpc_id                    = "PLACEHOLDER"
 cluster_security_group_id = ["PLACEHOLDER1"]

--- a/examples/eks/eks_cluster_gitops/variables.tf
+++ b/examples/eks/eks_cluster_gitops/variables.tf
@@ -5,19 +5,19 @@ variable "aws_account_id" {
   description = "ID of AWS account the cluster is located in."
 }
 
-variable "aws_cluster_region" {
+variable "cluster_region" {
   type        = string
   description = "Region of the cluster to be connected to CAST AI."
 }
 
-variable "aws_cluster_name" {
+variable "cluster_name" {
   type        = string
   description = "Name of the cluster to be connected to CAST AI."
 }
 
-variable "castai_api_token" {
+variable "castai_api_key" {
   type        = string
-  description = "CAST AI API token created in console.cast.ai API Access keys section"
+  description = "CAST AI API Key created in console.cast.ai API Access keys section"
 }
 
 variable "aws_assume_role_arn" {

--- a/examples/gke/gke_cluster_existing/castai.tf
+++ b/examples/gke/gke_cluster_existing/castai.tf
@@ -22,7 +22,7 @@ module "castai-gke-cluster" {
   source = "castai/gke-cluster/castai"
 
   api_url                = var.castai_api_url
-  castai_api_token       = var.castai_api_token
+  castai_api_token       = var.castai_api_key
   grpc_url               = var.castai_grpc_url
   wait_for_cluster_ready = true
 

--- a/examples/gke/gke_cluster_existing/providers.tf
+++ b/examples/gke/gke_cluster_existing/providers.tf
@@ -1,6 +1,6 @@
 provider "castai" {
   api_url   = var.castai_api_url
-  api_token = var.castai_api_token
+  api_token = var.castai_api_key
 }
 
 provider "helm" {

--- a/examples/gke/gke_cluster_existing/variables.tf
+++ b/examples/gke/gke_cluster_existing/variables.tf
@@ -24,9 +24,9 @@ variable "castai_api_url" {
   default     = "https://api.cast.ai"
 }
 
-variable "castai_api_token" {
+variable "castai_api_key" {
   type        = string
-  description = "CAST AI API token created in console.cast.ai API Access keys section."
+  description = "CAST AI API Key created in console.cast.ai API Access keys section."
 }
 
 variable "castai_grpc_url" {

--- a/examples/gke/gke_cluster_gitops/README.md
+++ b/examples/gke/gke_cluster_gitops/README.md
@@ -17,9 +17,16 @@ Helm Managed ==>  All Castware components such as `castai-agent`, `castai-cluste
                                                   2. Terraform Init & Apply| 
                                                 +-------------------------+
                                                             | 
+                                                            | TERRAFORM OUTPUT
+                                                +-------------------------+
+                                                |  3. Execute terraform output command
+                                                | terraform output cluster_id  
+                                                  terraform output cluster_token
+                                                +-------------------------+
+                                                            | 
                                                             |GITOPS
                                                 +-------------------------+
-                                                | 3. Deploy Helm chart of castai-agent castai-cluster-controller`, `castai-evictor`, `castai-spot-handler`, `castai-kvisor`, `castai-workload-autoscaler`, `castai-pod-pinner`
+                                                | 4. Deploy Helm chart of castai-agent castai-cluster-controller`, `castai-evictor`, `castai-spot-handler`, `castai-kvisor`, `castai-workload-autoscaler`, `castai-pod-pinner`
                                                 +-------------------------+         
                                                             | 
                                                             | 
@@ -37,25 +44,30 @@ Prerequisites:
 After successful apply, CAST Console UI will be in `Connecting` state. \
 Note generated 'CASTAI_CLUSTER_ID' from outputs
 
+### Step 3: Execute TF output command & save the below output values
+terraform output cluster_id  
+terraform output cluster_token
 
-### Step 3: Deploy Helm chart of CAST Components
+Obtained values are needed for next step
+
+### Step 4: Deploy Helm chart of CAST Components
 Coponents: `castai-cluster-controller`,`castai-evictor`, `castai-spot-handler`, `castai-kvisor`, `castai-workload-autoscaler`, `castai-pod-pinner` \
 After all CAST AI components are installed in the cluster its status in CAST AI console would change from `Connecting` to `Connected` which means that cluster onboarding process completed successfully.
 
 ```
-CASTAI_API_KEY=""
-CASTAI_CLUSTER_ID=""
+CASTAI_CLUSTER_ID="<Replace cluster_id>"
+CASTAI_CLUSTER_API_TOKEN="<Replace cluster_token>"
 CAST_CONFIG_SOURCE="castai-cluster-controller"
 
 #### Mandatory Component: Castai-agent
 helm upgrade -i castai-agent castai-helm/castai-agent -n castai-agent --create-namespace \
-  --set apiKey=$CASTAI_API_KEY \
+  --set apiKey=$CASTAI_CLUSTER_API_TOKEN \
   --set provider=gke \
   --set createNamespace=false
 
 #### Mandatory Component: castai-cluster-controller
 helm upgrade -i cluster-controller castai-helm/castai-cluster-controller -n castai-agent \
---set castai.apiKey=$CASTAI_API_KEY \
+--set castai.apiKey=$CASTAI_CLUSTER_API_TOKEN \
 --set castai.clusterID=$CASTAI_CLUSTER_ID \
 --set autoscaling.enabled=true
 
@@ -69,7 +81,7 @@ helm upgrade -i castai-evictor castai-helm/castai-evictor -n castai-agent --set 
 
 #### castai-pod-pinner
 helm upgrade -i castai-pod-pinner castai-helm/castai-pod-pinner -n castai-agent \
---set castai.apiKey=$CASTAI_API_KEY \
+--set castai.apiKey=$CASTAI_CLUSTER_API_TOKEN \
 --set castai.clusterID=$CASTAI_CLUSTER_ID \
 --set replicaCount=0
 
@@ -80,7 +92,7 @@ helm upgrade -i castai-workload-autoscaler castai-helm/castai-workload-autoscale
 
 #### castai-kvisor
 helm upgrade -i castai-kvisor castai-helm/castai-kvisor -n castai-agent \
---set castai.apiKey=$CASTAI_API_KEY \
+--set castai.apiKey=$CASTAI_CLUSTER_API_TOKEN \
 --set castai.clusterID=$CASTAI_CLUSTER_ID \
 --set controller.extraArgs.kube-linter-enabled=true \
 --set controller.extraArgs.image-scan-enabled=true \
@@ -104,3 +116,9 @@ helm upgrade -i castai-kvisor castai-helm/castai-kvisor -n castai-agent \
 This example can also be used to import GKE cluster to Terraform which is already onboarded to CAST AI console through [script](https://docs.cast.ai/docs/cluster-onboarding#how-it-works).   
 For importing existing cluster follow steps 1-3 above and change `castai_node_configuration.default` Node Configuration name.
 This would allow to manage already onboarded clusters' CAST AI Node Configurations and Node Templates through IaC.
+
+## Note: Difference between CAST API key & CAST Cluster API Token
+API Key - API key has all clusters access.
+Cluster API Token - API Token is cluster specific access.
+
+Security best practice to use Cluster API Token which has granular access.

--- a/examples/gke/gke_cluster_gitops/providers.tf
+++ b/examples/gke/gke_cluster_gitops/providers.tf
@@ -1,4 +1,4 @@
 provider "castai" {
   api_url   = var.castai_api_url
-  api_token = var.castai_api_token
+  api_token = var.castai_api_key
 }

--- a/examples/gke/gke_cluster_gitops/variables.tf
+++ b/examples/gke/gke_cluster_gitops/variables.tf
@@ -24,9 +24,9 @@ variable "delete_nodes_on_disconnect" {
   default     = false
 }
 
-variable "castai_api_token" {
+variable "castai_api_key" {
   type        = string
-  description = "CAST AI API token created in console.cast.ai API Access keys section."
+  description = "CAST AI API Key created in console.cast.ai API Access keys section."
 }
 
 variable "castai_api_url" {


### PR DESCRIPTION
Summary:
1. TF Gitops approach was using API Key instead of API token, fixed it
2. Readme updated to detail gitops approach
3. Added clear distinction between API KEY & Cluster API token
4. General housekeeping


Where do we use API KEY vs API Token

1. Use API key only to run Terraform, but not pass it to Castware helm charts.
2. Use API token to in castware helm charts

**Explanation:**

- User API key is used by Terraform to makes calls to our API to provision our platform resources such as: onboarding cluster, creating/updating node configurations/templates, etc.

- To make cluster specific operations using castware API Token should be used.

- While it is possible to use the same API access key when configuring Castware components through TF it is an antipattern. And it may cause friction and downtime for customers when deleting such API keys.
