### PR TITLE
Update readme to use cluster token for gitops

### DIFF
--- a/examples/aks/aks_cluster_gitops/README.md
+++ b/examples/aks/aks_cluster_gitops/README.md
@@ -17,9 +17,17 @@ Helm Managed ==>  All Castware components such as `castai-agent`, `castai-cluste
                                                   2. Terraform Init & Apply| 
                                                 +-------------------------+
                                                             | 
+                                                            | 
+                                                            | TERRAFORM OUTPUT
+                                                +-------------------------+
+                                                |  3. Execute terraform output command
+                                                | terraform output cluster_id  
+                                                  terraform output cluster_token
+                                                +-------------------------+
+                                                            | 
                                                             |GITOPS
                                                 +-------------------------+
-                                                | 3. Deploy Helm chart of castai-agent castai-cluster-controller`, `castai-evictor`, `castai-spot-handler`, `castai-kvisor`, `castai-workload-autoscaler`, `castai-pod-pinner`
+                                                | 4. Deploy Helm chart of castai-agent castai-cluster-controller`, `castai-evictor`, `castai-spot-handler`, `castai-kvisor`, `castai-workload-autoscaler`, `castai-pod-pinner`
                                                 +-------------------------+         
                                                             | 
                                                             | 
@@ -34,17 +42,21 @@ Prerequisites:
 
 
 ### Step 1 & 2: Update TF vars & TF Init, plan & apply
-After successful apply, CAST Console UI will be in `Connecting` state. \
-Note generated 'CASTAI_CLUSTER_ID' from outputs
+After successful apply, CAST Console UI will be in `Connecting` state.
 
+### Step 3: Execute TF output command & save the below output values
+terraform output cluster_id  
+terraform output cluster_token
 
-### Step 3: Deploy Helm chart of CAST Components
+Obtained values are needed for next step
+
+### Step 4: Deploy Helm chart of CAST Components
 Coponents: `castai-cluster-controller`,`castai-evictor`, `castai-spot-handler`, `castai-kvisor`, `castai-workload-autoscaler`, `castai-pod-pinner` \
 After all CAST AI components are installed in the cluster its status in CAST AI console would change from `Connecting` to `Connected` which means that cluster onboarding process completed successfully.
 
 ```
-CASTAI_API_KEY=""
-CASTAI_CLUSTER_ID=""
+CASTAI_API_KEY="<Replace cluster_token>"
+CASTAI_CLUSTER_ID="<Replace cluster_id>"
 CAST_CONFIG_SOURCE="castai-cluster-controller"
 
 #### Mandatory Component: Castai-agent

--- a/examples/eks/eks_cluster_gitops/README.md
+++ b/examples/eks/eks_cluster_gitops/README.md
@@ -42,9 +42,16 @@ Helm Managed ==>  All Castware components such as `castai-agent`, `castai-cluste
                                                   4. Terraform Init & Apply| 
                                                 +-------------------------+
                                                             | 
+                                                            | TERRAFORM OUTPUT
+                                                +-------------------------+
+                                                |  5. Execute terraform output command
+                                                | terraform output cluster_id  
+                                                  terraform output cluster_token
+                                                +-------------------------+
+                                                            | 
                                                             |GITOPS
                                                 +-------------------------+
-                                                | 5. Deploy Helm chart of castai-agent castai-cluster-controller`, `castai-evictor`, `castai-spot-handler`, `castai-kvisor`, `castai-workload-autoscaler`, `castai-pod-pinner`
+                                                | 6. Deploy Helm chart of castai-agent castai-cluster-controller`, `castai-evictor`, `castai-spot-handler`, `castai-kvisor`, `castai-workload-autoscaler`, `castai-pod-pinner`
                                                 +-------------------------+         
                                                             | 
                                                             | 
@@ -55,7 +62,7 @@ Helm Managed ==>  All Castware components such as `castai-agent`, `castai-cluste
 
 Prerequisites:
 - CAST AI account
-- Obtained CAST AI [API Access key](https://docs.cast.ai/docs/authentication#obtaining-api-access-key) with Full Access
+- Obtained CAST AI Key [API Access key](https://docs.cast.ai/docs/authentication#obtaining-api-access-key) with Full Access
 
 
 ### Step 0: Set Profile in AWS CLI
@@ -93,14 +100,19 @@ metadata:
 After successful apply, CAST Console UI will be in `Connecting` state. \
 Note generated 'CASTAI_CLUSTER_ID' from outputs
 
+### Step 5: Execute TF output command & save the below output values
+terraform output cluster_id  
+terraform output cluster_token
 
-### Step 5: Deploy Helm chart of CAST Components
+Obtained values are needed for next step
+
+### Step 6: Deploy Helm chart of CAST Components
 Coponents: `castai-cluster-controller`,`castai-evictor`, `castai-spot-handler`, `castai-kvisor`, `castai-workload-autoscaler`, `castai-pod-pinner` \
 After all CAST AI components are installed in the cluster its status in CAST AI console would change from `Connecting` to `Connected` which means that cluster onboarding process completed successfully.
 
 ```
-CASTAI_API_KEY=""
-CASTAI_CLUSTER_ID=""
+CASTAI_API_KEY="<Replace cluster_token>"
+CASTAI_CLUSTER_ID="<Replace cluster_id>"
 CAST_CONFIG_SOURCE="castai-cluster-controller"
 
 #### Mandatory Component: Castai-agent

--- a/examples/eks/eks_cluster_gitops/outputs.tf
+++ b/examples/eks/eks_cluster_gitops/outputs.tf
@@ -3,6 +3,12 @@ output "cluster_id" {
   description = "CAST AI cluster ID"
 }
 
+output "cluster_token" {
+  value       = castai_eks_cluster.my_castai_cluster.cluster_token
+  description = "CAST AI cluster token used by Castware to authenticate to Mothership"
+  sensitive   = true
+}
+
 output "instance_profile_role_arn" {
   description = "Arn of created cast instance role"
   value       = module.castai-eks-role-iam.instance_profile_role_arn

--- a/examples/gke/gke_cluster_gitops/README.md
+++ b/examples/gke/gke_cluster_gitops/README.md
@@ -17,6 +17,13 @@ Helm Managed ==>  All Castware components such as `castai-agent`, `castai-cluste
                                                   2. Terraform Init & Apply| 
                                                 +-------------------------+
                                                             | 
+                                                            | TERRAFORM OUTPUT
+                                                +-------------------------+
+                                                |  3. Execute terraform output command
+                                                | terraform output cluster_id  
+                                                  terraform output cluster_token
+                                                +-------------------------+
+                                                            | 
                                                             |GITOPS
                                                 +-------------------------+
                                                 | 3. Deploy Helm chart of castai-agent castai-cluster-controller`, `castai-evictor`, `castai-spot-handler`, `castai-kvisor`, `castai-workload-autoscaler`, `castai-pod-pinner`
@@ -37,14 +44,19 @@ Prerequisites:
 After successful apply, CAST Console UI will be in `Connecting` state. \
 Note generated 'CASTAI_CLUSTER_ID' from outputs
 
+### Step 3: Execute TF output command & save the below output values
+terraform output cluster_id  
+terraform output cluster_token
 
-### Step 3: Deploy Helm chart of CAST Components
+Obtained values are needed for next step
+
+### Step 4: Deploy Helm chart of CAST Components
 Coponents: `castai-cluster-controller`,`castai-evictor`, `castai-spot-handler`, `castai-kvisor`, `castai-workload-autoscaler`, `castai-pod-pinner` \
 After all CAST AI components are installed in the cluster its status in CAST AI console would change from `Connecting` to `Connected` which means that cluster onboarding process completed successfully.
 
 ```
-CASTAI_API_KEY=""
-CASTAI_CLUSTER_ID=""
+CASTAI_API_KEY="<Replace cluster_token>"
+CASTAI_CLUSTER_ID="<Replace cluster_id>"
 CAST_CONFIG_SOURCE="castai-cluster-controller"
 
 #### Mandatory Component: Castai-agent


### PR DESCRIPTION
Note:
cluster token output (examples/eks/eks_cluster_gitops/outputs.tf) will not display token during TF apply.
Its needed to collect token & pass it to deploy via agrocd in gitops approach
