### PR TITLE
Handle the creation of default scaling policies

### DIFF
--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -206,20 +206,6 @@ const (
 	NodeconfigV1AKSConfigImageFamilyFamilyWindows2022 NodeconfigV1AKSConfigImageFamily = "family_windows_2022"
 )
 
-// Defines values for NodeconfigV1AKSConfigOsDiskEphemeralCacheType.
-const (
-	NodeconfigV1AKSConfigOsDiskEphemeralCacheTypeREADONLY    NodeconfigV1AKSConfigOsDiskEphemeralCacheType = "READ_ONLY"
-	NodeconfigV1AKSConfigOsDiskEphemeralCacheTypeREADWRITE   NodeconfigV1AKSConfigOsDiskEphemeralCacheType = "READ_WRITE"
-	NodeconfigV1AKSConfigOsDiskEphemeralCacheTypeUNSPECIFIED NodeconfigV1AKSConfigOsDiskEphemeralCacheType = "UNSPECIFIED"
-)
-
-// Defines values for NodeconfigV1AKSConfigOsDiskEphemeralPlacement.
-const (
-	PLACEMENTCACHEDISK    NodeconfigV1AKSConfigOsDiskEphemeralPlacement = "PLACEMENT_CACHE_DISK"
-	PLACEMENTRESOURCEDISK NodeconfigV1AKSConfigOsDiskEphemeralPlacement = "PLACEMENT_RESOURCE_DISK"
-	PLACEMENTUNSPECIFIED  NodeconfigV1AKSConfigOsDiskEphemeralPlacement = "PLACEMENT_UNSPECIFIED"
-)
-
 // Defines values for NodeconfigV1AKSConfigOsDiskType.
 const (
 	OSDISKTYPEPREMIUMSSD  NodeconfigV1AKSConfigOsDiskType = "OS_DISK_TYPE_PREMIUM_SSD"
@@ -361,9 +347,9 @@ const (
 
 // Defines values for WorkloadoptimizationV1ManagementOption.
 const (
-	WorkloadoptimizationV1ManagementOptionMANAGED   WorkloadoptimizationV1ManagementOption = "MANAGED"
-	WorkloadoptimizationV1ManagementOptionREADONLY  WorkloadoptimizationV1ManagementOption = "READ_ONLY"
-	WorkloadoptimizationV1ManagementOptionUNDEFINED WorkloadoptimizationV1ManagementOption = "UNDEFINED"
+	MANAGED   WorkloadoptimizationV1ManagementOption = "MANAGED"
+	READONLY  WorkloadoptimizationV1ManagementOption = "READ_ONLY"
+	UNDEFINED WorkloadoptimizationV1ManagementOption = "UNDEFINED"
 )
 
 // Defines values for WorkloadoptimizationV1RecommendationEventType.
@@ -2255,14 +2241,13 @@ type CastaiUsersV1beta1UserOrganization struct {
 
 	// name of the organization.
 	Name string `json:"name"`
+
+	// user role in the organization.
 	Role string `json:"role"`
 }
 
 // AKSClusterParams defines AKS-specific arguments.
 type ExternalclusterV1AKSClusterParams struct {
-	// HttpProxyConfig holds settings when HTTP/S communication is required.
-	HttpProxyConfig *ExternalclusterV1HttpProxyConfig `json:"httpProxyConfig,omitempty"`
-
 	// Deprecated. This field is no longer updatable and node configuration equivalent should be used.
 	MaxPodsPerNode *int32 `json:"maxPodsPerNode,omitempty"`
 
@@ -2446,9 +2431,6 @@ type ExternalclusterV1ClusterReconcileInfoReconcileStatus string
 
 // ExternalclusterV1ClusterUpdate defines model for externalcluster.v1.ClusterUpdate.
 type ExternalclusterV1ClusterUpdate struct {
-	// UpdateAKSClusterParams defines updatable AKS cluster configuration.
-	Aks *ExternalclusterV1UpdateAKSClusterParams `json:"aks,omitempty"`
-
 	// JSON encoded cluster credentials string.
 	Credentials *string `json:"credentials,omitempty"`
 
@@ -2613,13 +2595,6 @@ type ExternalclusterV1GetListNodesFiltersResponse struct {
 
 // HandleCloudEventResponse is the result of HandleCloudEventRequest.
 type ExternalclusterV1HandleCloudEventResponse = map[string]interface{}
-
-// HttpProxyConfig holds settings when HTTP/S communication is required.
-type ExternalclusterV1HttpProxyConfig struct {
-	HttpProxy  *string   `json:"httpProxy,omitempty"`
-	HttpsProxy *string   `json:"httpsProxy,omitempty"`
-	NoProxy    *[]string `json:"noProxy,omitempty"`
-}
 
 // KOPSClusterParams defines KOPS-specific arguments.
 type ExternalclusterV1KOPSClusterParams struct {
@@ -2935,12 +2910,6 @@ type ExternalclusterV1TriggerResumeClusterResponse struct {
 	OperationId string `json:"operationId"`
 }
 
-// UpdateAKSClusterParams defines updatable AKS cluster configuration.
-type ExternalclusterV1UpdateAKSClusterParams struct {
-	// HttpProxyConfig holds settings when HTTP/S communication is required.
-	HttpProxyConfig *ExternalclusterV1HttpProxyConfig `json:"httpProxyConfig,omitempty"`
-}
-
 // UpdateClusterTagsResponse result of cluster tags update.
 type ExternalclusterV1UpdateClusterTagsResponse = map[string]interface{}
 
@@ -3000,8 +2969,7 @@ type NodeconfigV1AKSConfig struct {
 	// Maximum number of pods that can be run on a node, which affects how many IP addresses you will need for each node.
 	// Defaults to 30. Values between 10 and 250 are allowed.
 	// Setting values above 110 will require specific CNI configuration. Please refer to Microsoft documentation for additional guidance.
-	MaxPodsPerNode  *int32                                `json:"maxPodsPerNode,omitempty"`
-	OsDiskEphemeral *NodeconfigV1AKSConfigOsDiskEphemeral `json:"osDiskEphemeral,omitempty"`
+	MaxPodsPerNode *int32 `json:"maxPodsPerNode,omitempty"`
 
 	// OsDiskType represent possible values for AKS node os disk type(this is subset of all available Azure disk types).
 	OsDiskType *NodeconfigV1AKSConfigOsDiskType `json:"osDiskType,omitempty"`
@@ -3039,21 +3007,6 @@ type NodeconfigV1AKSConfigLoadBalancersNICBasedBackendPool struct {
 	// Name of the backend pool as defined in Azure. Backend pools must have unique names within the load balancer.
 	Name *string `json:"name,omitempty"`
 }
-
-// NodeconfigV1AKSConfigOsDiskEphemeral defines model for nodeconfig.v1.AKSConfig.OsDiskEphemeral.
-type NodeconfigV1AKSConfigOsDiskEphemeral struct {
-	// Type of cache to use for the ephemeral OS disk. Default is READ_ONLY.
-	CacheType *NodeconfigV1AKSConfigOsDiskEphemeralCacheType `json:"cacheType,omitempty"`
-
-	// Placement of the ephemeral OS disk. Default is PLACEMENT_CACHE_DISk.
-	Placement *NodeconfigV1AKSConfigOsDiskEphemeralPlacement `json:"placement,omitempty"`
-}
-
-// Type of cache to use for the ephemeral OS disk. Default is READ_ONLY.
-type NodeconfigV1AKSConfigOsDiskEphemeralCacheType string
-
-// Placement of the ephemeral OS disk. Default is PLACEMENT_CACHE_DISk.
-type NodeconfigV1AKSConfigOsDiskEphemeralPlacement string
 
 // OsDiskType represent possible values for AKS node os disk type(this is subset of all available Azure disk types).
 type NodeconfigV1AKSConfigOsDiskType string
@@ -3985,12 +3938,6 @@ type PoliciesV1UnschedulablePodsPolicy struct {
 	PodPinner *PoliciesV1PodPinner `json:"podPinner,omitempty"`
 }
 
-// ScheduledrebalancingV1AggressiveModeConfig defines model for scheduledrebalancing.v1.AggressiveModeConfig.
-type ScheduledrebalancingV1AggressiveModeConfig struct {
-	// Rebalance workloads using local-path Persistent Volumes. THIS WILL RESULT IN DATA LOSS.
-	IgnoreLocalPersistentVolumes *bool `json:"ignoreLocalPersistentVolumes,omitempty"`
-}
-
 // ScheduledrebalancingV1DeleteRebalancingJobResponse defines model for scheduledrebalancing.v1.DeleteRebalancingJobResponse.
 type ScheduledrebalancingV1DeleteRebalancingJobResponse = map[string]interface{}
 
@@ -4091,8 +4038,7 @@ type ScheduledrebalancingV1RebalancingJob struct {
 // ScheduledrebalancingV1RebalancingOptions defines model for scheduledrebalancing.v1.RebalancingOptions.
 type ScheduledrebalancingV1RebalancingOptions struct {
 	// When enabled will also consider rebalancing problematic pods (pods without controller, job pods, pods with removal-disabled annotation).
-	AggressiveMode       *bool                                       `json:"aggressiveMode"`
-	AggressiveModeConfig *ScheduledrebalancingV1AggressiveModeConfig `json:"aggressiveModeConfig,omitempty"`
+	AggressiveMode *bool `json:"aggressiveMode"`
 
 	// Defines whether the nodes that failed to get drained until a predefined timeout, will be kept with a
 	// rebalancing.cast.ai/status=drain-failed annotation instead of forcefully drained.
@@ -4494,9 +4440,8 @@ type WorkloadoptimizationV1RecommendationPolicies struct {
 
 // WorkloadoptimizationV1RecommendedPodCountChangedEvent defines model for workloadoptimization.v1.RecommendedPodCountChangedEvent.
 type WorkloadoptimizationV1RecommendedPodCountChangedEvent struct {
-	Current   int32                   `json:"current"`
-	DebugData *map[string]interface{} `json:"debugData,omitempty"`
-	Previous  int32                   `json:"previous"`
+	Current  int32 `json:"current"`
+	Previous int32 `json:"previous"`
 }
 
 // WorkloadoptimizationV1RecommendedRequestsChangedEvent defines model for workloadoptimization.v1.RecommendedRequestsChangedEvent.

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -206,6 +206,20 @@ const (
 	NodeconfigV1AKSConfigImageFamilyFamilyWindows2022 NodeconfigV1AKSConfigImageFamily = "family_windows_2022"
 )
 
+// Defines values for NodeconfigV1AKSConfigOsDiskEphemeralCacheType.
+const (
+	NodeconfigV1AKSConfigOsDiskEphemeralCacheTypeREADONLY    NodeconfigV1AKSConfigOsDiskEphemeralCacheType = "READ_ONLY"
+	NodeconfigV1AKSConfigOsDiskEphemeralCacheTypeREADWRITE   NodeconfigV1AKSConfigOsDiskEphemeralCacheType = "READ_WRITE"
+	NodeconfigV1AKSConfigOsDiskEphemeralCacheTypeUNSPECIFIED NodeconfigV1AKSConfigOsDiskEphemeralCacheType = "UNSPECIFIED"
+)
+
+// Defines values for NodeconfigV1AKSConfigOsDiskEphemeralPlacement.
+const (
+	PLACEMENTCACHEDISK    NodeconfigV1AKSConfigOsDiskEphemeralPlacement = "PLACEMENT_CACHE_DISK"
+	PLACEMENTRESOURCEDISK NodeconfigV1AKSConfigOsDiskEphemeralPlacement = "PLACEMENT_RESOURCE_DISK"
+	PLACEMENTUNSPECIFIED  NodeconfigV1AKSConfigOsDiskEphemeralPlacement = "PLACEMENT_UNSPECIFIED"
+)
+
 // Defines values for NodeconfigV1AKSConfigOsDiskType.
 const (
 	OSDISKTYPEPREMIUMSSD  NodeconfigV1AKSConfigOsDiskType = "OS_DISK_TYPE_PREMIUM_SSD"
@@ -347,9 +361,9 @@ const (
 
 // Defines values for WorkloadoptimizationV1ManagementOption.
 const (
-	MANAGED   WorkloadoptimizationV1ManagementOption = "MANAGED"
-	READONLY  WorkloadoptimizationV1ManagementOption = "READ_ONLY"
-	UNDEFINED WorkloadoptimizationV1ManagementOption = "UNDEFINED"
+	WorkloadoptimizationV1ManagementOptionMANAGED   WorkloadoptimizationV1ManagementOption = "MANAGED"
+	WorkloadoptimizationV1ManagementOptionREADONLY  WorkloadoptimizationV1ManagementOption = "READ_ONLY"
+	WorkloadoptimizationV1ManagementOptionUNDEFINED WorkloadoptimizationV1ManagementOption = "UNDEFINED"
 )
 
 // Defines values for WorkloadoptimizationV1RecommendationEventType.
@@ -2241,13 +2255,14 @@ type CastaiUsersV1beta1UserOrganization struct {
 
 	// name of the organization.
 	Name string `json:"name"`
-
-	// user role in the organization.
 	Role string `json:"role"`
 }
 
 // AKSClusterParams defines AKS-specific arguments.
 type ExternalclusterV1AKSClusterParams struct {
+	// HttpProxyConfig holds settings when HTTP/S communication is required.
+	HttpProxyConfig *ExternalclusterV1HttpProxyConfig `json:"httpProxyConfig,omitempty"`
+
 	// Deprecated. This field is no longer updatable and node configuration equivalent should be used.
 	MaxPodsPerNode *int32 `json:"maxPodsPerNode,omitempty"`
 
@@ -2431,6 +2446,9 @@ type ExternalclusterV1ClusterReconcileInfoReconcileStatus string
 
 // ExternalclusterV1ClusterUpdate defines model for externalcluster.v1.ClusterUpdate.
 type ExternalclusterV1ClusterUpdate struct {
+	// UpdateAKSClusterParams defines updatable AKS cluster configuration.
+	Aks *ExternalclusterV1UpdateAKSClusterParams `json:"aks,omitempty"`
+
 	// JSON encoded cluster credentials string.
 	Credentials *string `json:"credentials,omitempty"`
 
@@ -2595,6 +2613,13 @@ type ExternalclusterV1GetListNodesFiltersResponse struct {
 
 // HandleCloudEventResponse is the result of HandleCloudEventRequest.
 type ExternalclusterV1HandleCloudEventResponse = map[string]interface{}
+
+// HttpProxyConfig holds settings when HTTP/S communication is required.
+type ExternalclusterV1HttpProxyConfig struct {
+	HttpProxy  *string   `json:"httpProxy,omitempty"`
+	HttpsProxy *string   `json:"httpsProxy,omitempty"`
+	NoProxy    *[]string `json:"noProxy,omitempty"`
+}
 
 // KOPSClusterParams defines KOPS-specific arguments.
 type ExternalclusterV1KOPSClusterParams struct {
@@ -2910,6 +2935,12 @@ type ExternalclusterV1TriggerResumeClusterResponse struct {
 	OperationId string `json:"operationId"`
 }
 
+// UpdateAKSClusterParams defines updatable AKS cluster configuration.
+type ExternalclusterV1UpdateAKSClusterParams struct {
+	// HttpProxyConfig holds settings when HTTP/S communication is required.
+	HttpProxyConfig *ExternalclusterV1HttpProxyConfig `json:"httpProxyConfig,omitempty"`
+}
+
 // UpdateClusterTagsResponse result of cluster tags update.
 type ExternalclusterV1UpdateClusterTagsResponse = map[string]interface{}
 
@@ -2969,7 +3000,8 @@ type NodeconfigV1AKSConfig struct {
 	// Maximum number of pods that can be run on a node, which affects how many IP addresses you will need for each node.
 	// Defaults to 30. Values between 10 and 250 are allowed.
 	// Setting values above 110 will require specific CNI configuration. Please refer to Microsoft documentation for additional guidance.
-	MaxPodsPerNode *int32 `json:"maxPodsPerNode,omitempty"`
+	MaxPodsPerNode  *int32                                `json:"maxPodsPerNode,omitempty"`
+	OsDiskEphemeral *NodeconfigV1AKSConfigOsDiskEphemeral `json:"osDiskEphemeral,omitempty"`
 
 	// OsDiskType represent possible values for AKS node os disk type(this is subset of all available Azure disk types).
 	OsDiskType *NodeconfigV1AKSConfigOsDiskType `json:"osDiskType,omitempty"`
@@ -3007,6 +3039,21 @@ type NodeconfigV1AKSConfigLoadBalancersNICBasedBackendPool struct {
 	// Name of the backend pool as defined in Azure. Backend pools must have unique names within the load balancer.
 	Name *string `json:"name,omitempty"`
 }
+
+// NodeconfigV1AKSConfigOsDiskEphemeral defines model for nodeconfig.v1.AKSConfig.OsDiskEphemeral.
+type NodeconfigV1AKSConfigOsDiskEphemeral struct {
+	// Type of cache to use for the ephemeral OS disk. Default is READ_ONLY.
+	CacheType *NodeconfigV1AKSConfigOsDiskEphemeralCacheType `json:"cacheType,omitempty"`
+
+	// Placement of the ephemeral OS disk. Default is PLACEMENT_CACHE_DISk.
+	Placement *NodeconfigV1AKSConfigOsDiskEphemeralPlacement `json:"placement,omitempty"`
+}
+
+// Type of cache to use for the ephemeral OS disk. Default is READ_ONLY.
+type NodeconfigV1AKSConfigOsDiskEphemeralCacheType string
+
+// Placement of the ephemeral OS disk. Default is PLACEMENT_CACHE_DISk.
+type NodeconfigV1AKSConfigOsDiskEphemeralPlacement string
 
 // OsDiskType represent possible values for AKS node os disk type(this is subset of all available Azure disk types).
 type NodeconfigV1AKSConfigOsDiskType string
@@ -3938,6 +3985,12 @@ type PoliciesV1UnschedulablePodsPolicy struct {
 	PodPinner *PoliciesV1PodPinner `json:"podPinner,omitempty"`
 }
 
+// ScheduledrebalancingV1AggressiveModeConfig defines model for scheduledrebalancing.v1.AggressiveModeConfig.
+type ScheduledrebalancingV1AggressiveModeConfig struct {
+	// Rebalance workloads using local-path Persistent Volumes. THIS WILL RESULT IN DATA LOSS.
+	IgnoreLocalPersistentVolumes *bool `json:"ignoreLocalPersistentVolumes,omitempty"`
+}
+
 // ScheduledrebalancingV1DeleteRebalancingJobResponse defines model for scheduledrebalancing.v1.DeleteRebalancingJobResponse.
 type ScheduledrebalancingV1DeleteRebalancingJobResponse = map[string]interface{}
 
@@ -4038,7 +4091,8 @@ type ScheduledrebalancingV1RebalancingJob struct {
 // ScheduledrebalancingV1RebalancingOptions defines model for scheduledrebalancing.v1.RebalancingOptions.
 type ScheduledrebalancingV1RebalancingOptions struct {
 	// When enabled will also consider rebalancing problematic pods (pods without controller, job pods, pods with removal-disabled annotation).
-	AggressiveMode *bool `json:"aggressiveMode"`
+	AggressiveMode       *bool                                       `json:"aggressiveMode"`
+	AggressiveModeConfig *ScheduledrebalancingV1AggressiveModeConfig `json:"aggressiveModeConfig,omitempty"`
 
 	// Defines whether the nodes that failed to get drained until a predefined timeout, will be kept with a
 	// rebalancing.cast.ai/status=drain-failed annotation instead of forcefully drained.
@@ -4440,8 +4494,9 @@ type WorkloadoptimizationV1RecommendationPolicies struct {
 
 // WorkloadoptimizationV1RecommendedPodCountChangedEvent defines model for workloadoptimization.v1.RecommendedPodCountChangedEvent.
 type WorkloadoptimizationV1RecommendedPodCountChangedEvent struct {
-	Current  int32 `json:"current"`
-	Previous int32 `json:"previous"`
+	Current   int32                   `json:"current"`
+	DebugData *map[string]interface{} `json:"debugData,omitempty"`
+	Previous  int32                   `json:"previous"`
 }
 
 // WorkloadoptimizationV1RecommendedRequestsChangedEvent defines model for workloadoptimization.v1.RecommendedRequestsChangedEvent.

--- a/docs/resources/workload_scaling_policy.md
+++ b/docs/resources/workload_scaling_policy.md
@@ -228,7 +228,7 @@ Optional:
 ## Importing
 
 For each connected cluster, a default scaling policy is created. An existing scaling policy can be imported into the
-Terraform state using the `terraform import` command or the [`import`](https://developer.hashicorp.com/terraform/language/import#syntax) block.
+Terraform state using the `terraform import` command or the [`import`](https://developer.hashicorp.com/terraform/language/import#syntax) block (recommended for Terraform 1.5.0+).
 
 Using the `import` block is a simpler and more convenient way of importing resources.
 
@@ -250,8 +250,14 @@ Using the `import` block is a simpler and more convenient way of importing resou
    terraform plan -out=import.plan -var-file=tf.vars -generate-config-out=generated.tf
    ```
 
-3. Review the `generated.tf` file and ensure that the imported scaling policy is correct. Terraform sets zero values,
-	 e.g., for `look_back_period_seconds`. All such properties can be removed to use the defaults.
+3. Review the `generated.tf` file and ensure the imported scaling policy is correct. Terraform will generate this file by setting values equal to zero for certain configuration parameters.
+
+   For example:
+
+   ```hcl
+   cpu {
+     look_back_period_seconds = 0
+   }
 
 4. Apply the import plan:
 
@@ -323,7 +329,7 @@ can [import a single policy](#import-a-single-scaling-policy) and then use it as
    terraform apply "import.plan"
    ```
 
-### Import using `terraform import` command
+### Import using the `terraform import` command
 
 You can use the `terraform import` command to import existing scaling policy to Terraform state.
 
@@ -349,5 +355,5 @@ $ terraform import 'module.castai-eks-cluster.castai_workload_scaling_policy.thi
 ## Upsert scaling policy
 
 The recommended way is to [import](#importing) the scaling policy and then apply the changes to the policy.
-However, if that’s not possible, you can define the default policy resource yourself. The CAST AI Terraform provider,
+However, if that’s not possible, you can define the default policy resource yourself. The CAST AI Terraform provider
 will update the existing policy instead of returning an error.

--- a/docs/resources/workload_scaling_policy.md
+++ b/docs/resources/workload_scaling_policy.md
@@ -230,10 +230,11 @@ Optional:
 For each connected cluster, a default scaling policy is created. An existing scaling policy can be imported into the
 Terraform state using the `terraform import` command or the [`import`](https://developer.hashicorp.com/terraform/language/import#syntax) block.
 
-This section describes how to import a scaling policy using the `import` block, as it is a simpler and more convenient
-way of importing resources.
+Using the `import` block is a simpler and more convenient way of importing resources.
 
-### Import a single scaling policy
+### Import using `import` block
+
+#### Import a single scaling policy
 
 1. Create an `import.tf` file with the following content:
    ```tf
@@ -258,7 +259,7 @@ way of importing resources.
    terraform apply "import.plan"
    ```
 
-### Import multiple scaling policies
+#### Import multiple scaling policies
 
 To import multiple scaling policies, you need to know the cluster IDs and the policy names. The `for_each` cannot be
 used when generating configuration. As a result, you need to define the policy properties yourself, or you
@@ -322,8 +323,31 @@ can [import a single policy](#import-a-single-scaling-policy) and then use it as
    terraform apply "import.plan"
    ```
 
-### Upsert scaling policy
+### Import using `terraform import` command
 
-The recommended way is to use the `import` block to import the scaling policy and then apply the changes to the policy.
+You can use the `terraform import` command to import existing scaling policy to Terraform state.
+
+To import a resource, first write a resource block for it in your configuration, establishing the name by which
+it will be known to Terraform:
+
+```hcl
+resource "castai_workload_scaling_policy" "services" {
+  # ...
+}
+```
+
+Now terraform import can be run to attach an existing scaling policy to this resource:
+```shell
+$ terraform import castai_workload_scaling_policy.services <cluster_id>/services
+```
+
+If you are using CAST AI Terraform modules, import command will be slightly different:
+```shell
+$ terraform import 'module.castai-eks-cluster.castai_workload_scaling_policy.this["services"]' <cluster_id>/services
+```
+
+## Upsert scaling policy
+
+The recommended way is to [import](#importing) the scaling policy and then apply the changes to the policy.
 However, if that’s not possible, you can define the default policy resource yourself. The CAST AI Terraform provider,
 will update the existing policy instead of returning an error.

--- a/docs/resources/workload_scaling_policy.md
+++ b/docs/resources/workload_scaling_policy.md
@@ -225,24 +225,105 @@ Optional:
 - `read` (String)
 - `update` (String)
 
-
 ## Importing
-You can use the `terraform import` command to import existing scaling policy to Terraform state.
 
-To import a resource, first write a resource block for it in your configuration, establishing the name by which
-it will be known to Terraform:
-```hcl
-resource "castai_workload_scaling_policy" "services" {
-  # ...
-}
-```
+For each connected cluster, a default scaling policy is created. An existing scaling policy can be imported into the
+Terraform state using the `terraform import` command or the [`import`](https://developer.hashicorp.com/terraform/language/import#syntax) block.
 
-Now terraform import can be run to attach an existing scaling policy to this resource:
-```shell
-$ terraform import castai_workload_scaling_policy.services <cluster_id>/services
-```
+This section describes how to import a scaling policy using the `import` block, as it is a simpler and more convenient
+way of importing resources.
 
-If you are using CAST AI Terraform modules, import command will be slightly different:
-```shell
-$ terraform import 'module.castai-eks-cluster.castai_workload_scaling_policy.this["services"]' <cluster_id>/services
-```
+### Import a single scaling policy
+
+1. Create an `import.tf` file with the following content:
+   ```tf
+   import {
+   	 to       = castai_workload_scaling_policy.default
+   	 id       = "<cluster_id>/<policy_id_or_name>" # e.g. "ff4c2211-3511-4d95-b6de-2919fc3287a3/default"
+   }
+   ```
+
+2. Run the `terraform import` command:
+
+   ```shell
+   terraform plan -out=import.plan -var-file=tf.vars -generate-config-out=generated.tf
+   ```
+
+3. Review the `generated.tf` file and ensure that the imported scaling policy is correct. Terraform sets zero values,
+	 e.g., for `look_back_period_seconds`. All such properties can be removed to use the defaults.
+
+4. Apply the import plan:
+
+   ```shell
+   terraform apply "import.plan"
+   ```
+
+### Import multiple scaling policies
+
+To import multiple scaling policies, you need to know the cluster IDs and the policy names. The `for_each` cannot be
+used when generating configuration. As a result, you need to define the policy properties yourself, or you
+can [import a single policy](#import-a-single-scaling-policy) and then use it as a template for other policies.
+
+> [!NOTE]
+> The below example assumes that you want to import the "default" scaling policy for multiple clusters. If you want to
+> import
+> scaling policies with different names, you need to adjust the `id` parameter in the `import` block accordingly.
+
+1. Create the `import.tf` file with the following content:
+
+   ```tf
+   locals {
+   	 policies = {
+   		 "<cluster_name>" = "<cluster_id>"
+   		 "<cluster_name>" = "<cluster_id>"
+   		 "<cluster_name>" = "<cluster_id>"
+   	 }
+   }
+
+   import {
+   	 for_each = local.policies
+   	 to       = castai_workload_scaling_policy.default[each.key]
+   	 id       = "${each.value}/default"
+   }
+
+   resource "castai_workload_scaling_policy" "default" {
+   	 for_each          = local.policies
+   	 cluster_id        = each.value
+   	 apply_type        = "IMMEDIATE"
+   	 management_option = "READ_ONLY"
+   	 name              = "default"
+   	 cpu {
+   		 apply_threshold          = 0.1
+   		 args = ["0.80"]
+   		 function                 = "QUANTILE"
+   		 look_back_period_seconds = 86400
+   		 min                      = 0.01
+   	 }
+   	 memory {
+   		 apply_threshold          = 0.1
+   		 args = []
+   		 function                 = "MAX"
+   		 look_back_period_seconds = 86400
+   		 min                      = 10
+   		 overhead                 = 0.1
+   	 }
+   }
+   ```
+
+2. Run the `terraform import` command and review the import plan:
+
+   ```shell
+   terraform plan -out=import.plan -var-file=tf.vars
+   ```
+
+3. Apply the import plan:
+
+   ```shell
+   terraform apply "import.plan"
+   ```
+
+### Upsert scaling policy
+
+The recommended way is to use the `import` block to import the scaling policy and then apply the changes to the policy.
+However, if that’s not possible, you can define the default policy resource yourself. The CAST AI Terraform provider,
+will update the existing policy instead of returning an error.

--- a/templates/resources/workload_scaling_policy.md.tmpl
+++ b/templates/resources/workload_scaling_policy.md.tmpl
@@ -23,10 +23,11 @@ simultaneously or create custom policies with different settings and apply them 
 For each connected cluster, a default scaling policy is created. An existing scaling policy can be imported into the
 Terraform state using the `terraform import` command or the [`import`](https://developer.hashicorp.com/terraform/language/import#syntax) block.
 
-This section describes how to import a scaling policy using the `import` block, as it is a simpler and more convenient
-way of importing resources.
+Using the `import` block is a simpler and more convenient way of importing resources.
 
-### Import a single scaling policy
+### Import using `import` block
+
+#### Import a single scaling policy
 
 1. Create an `import.tf` file with the following content:
    ```tf
@@ -51,7 +52,7 @@ way of importing resources.
    terraform apply "import.plan"
    ```
 
-### Import multiple scaling policies
+#### Import multiple scaling policies
 
 To import multiple scaling policies, you need to know the cluster IDs and the policy names. The `for_each` cannot be
 used when generating configuration. As a result, you need to define the policy properties yourself, or you
@@ -115,8 +116,31 @@ can [import a single policy](#import-a-single-scaling-policy) and then use it as
    terraform apply "import.plan"
    ```
 
-### Upsert scaling policy
+### Import using `terraform import` command
 
-The recommended way is to use the `import` block to import the scaling policy and then apply the changes to the policy.
+You can use the `terraform import` command to import existing scaling policy to Terraform state.
+
+To import a resource, first write a resource block for it in your configuration, establishing the name by which
+it will be known to Terraform:
+
+```hcl
+resource "castai_workload_scaling_policy" "services" {
+  # ...
+}
+```
+
+Now terraform import can be run to attach an existing scaling policy to this resource:
+```shell
+$ terraform import castai_workload_scaling_policy.services <cluster_id>/services
+```
+
+If you are using CAST AI Terraform modules, import command will be slightly different:
+```shell
+$ terraform import 'module.castai-eks-cluster.castai_workload_scaling_policy.this["services"]' <cluster_id>/services
+```
+
+## Upsert scaling policy
+
+The recommended way is to [import](#importing) the scaling policy and then apply the changes to the policy.
 However, if that’s not possible, you can define the default policy resource yourself. The CAST AI Terraform provider,
 will update the existing policy instead of returning an error.

--- a/templates/resources/workload_scaling_policy.md.tmpl
+++ b/templates/resources/workload_scaling_policy.md.tmpl
@@ -18,24 +18,105 @@ simultaneously or create custom policies with different settings and apply them 
 
 {{ .SchemaMarkdown | trimspace }}
 
-
 ## Importing
-You can use the `terraform import` command to import existing scaling policy to Terraform state.
 
-To import a resource, first write a resource block for it in your configuration, establishing the name by which
-it will be known to Terraform:
-```hcl
-resource "castai_workload_scaling_policy" "services" {
-  # ...
-}
-```
+For each connected cluster, a default scaling policy is created. An existing scaling policy can be imported into the
+Terraform state using the `terraform import` command or the [`import`](https://developer.hashicorp.com/terraform/language/import#syntax) block.
 
-Now terraform import can be run to attach an existing scaling policy to this resource:
-```shell
-$ terraform import castai_workload_scaling_policy.services <cluster_id>/services
-```
+This section describes how to import a scaling policy using the `import` block, as it is a simpler and more convenient
+way of importing resources.
 
-If you are using CAST AI Terraform modules, import command will be slightly different:
-```shell
-$ terraform import 'module.castai-eks-cluster.castai_workload_scaling_policy.this["services"]' <cluster_id>/services
-```
+### Import a single scaling policy
+
+1. Create an `import.tf` file with the following content:
+   ```tf
+   import {
+   	 to       = castai_workload_scaling_policy.default
+   	 id       = "<cluster_id>/<policy_id_or_name>" # e.g. "ff4c2211-3511-4d95-b6de-2919fc3287a3/default"
+   }
+   ```
+
+2. Run the `terraform import` command:
+
+   ```shell
+   terraform plan -out=import.plan -var-file=tf.vars -generate-config-out=generated.tf
+   ```
+
+3. Review the `generated.tf` file and ensure that the imported scaling policy is correct. Terraform sets zero values,
+	 e.g., for `look_back_period_seconds`. All such properties can be removed to use the defaults.
+
+4. Apply the import plan:
+
+   ```shell
+   terraform apply "import.plan"
+   ```
+
+### Import multiple scaling policies
+
+To import multiple scaling policies, you need to know the cluster IDs and the policy names. The `for_each` cannot be
+used when generating configuration. As a result, you need to define the policy properties yourself, or you
+can [import a single policy](#import-a-single-scaling-policy) and then use it as a template for other policies.
+
+> [!NOTE]
+> The below example assumes that you want to import the "default" scaling policy for multiple clusters. If you want to
+> import
+> scaling policies with different names, you need to adjust the `id` parameter in the `import` block accordingly.
+
+1. Create the `import.tf` file with the following content:
+
+   ```tf
+   locals {
+   	 policies = {
+   		 "<cluster_name>" = "<cluster_id>"
+   		 "<cluster_name>" = "<cluster_id>"
+   		 "<cluster_name>" = "<cluster_id>"
+   	 }
+   }
+
+   import {
+   	 for_each = local.policies
+   	 to       = castai_workload_scaling_policy.default[each.key]
+   	 id       = "${each.value}/default"
+   }
+
+   resource "castai_workload_scaling_policy" "default" {
+   	 for_each          = local.policies
+   	 cluster_id        = each.value
+   	 apply_type        = "IMMEDIATE"
+   	 management_option = "READ_ONLY"
+   	 name              = "default"
+   	 cpu {
+   		 apply_threshold          = 0.1
+   		 args = ["0.80"]
+   		 function                 = "QUANTILE"
+   		 look_back_period_seconds = 86400
+   		 min                      = 0.01
+   	 }
+   	 memory {
+   		 apply_threshold          = 0.1
+   		 args = []
+   		 function                 = "MAX"
+   		 look_back_period_seconds = 86400
+   		 min                      = 10
+   		 overhead                 = 0.1
+   	 }
+   }
+   ```
+
+2. Run the `terraform import` command and review the import plan:
+
+   ```shell
+   terraform plan -out=import.plan -var-file=tf.vars
+   ```
+
+3. Apply the import plan:
+
+   ```shell
+   terraform apply "import.plan"
+   ```
+
+### Upsert scaling policy
+
+The recommended way is to use the `import` block to import the scaling policy and then apply the changes to the policy.
+However, if that’s not possible, you can define the default policy resource yourself. The CAST AI Terraform provider,
+will update the existing policy instead of returning an error.

--- a/templates/resources/workload_scaling_policy.md.tmpl
+++ b/templates/resources/workload_scaling_policy.md.tmpl
@@ -43,9 +43,9 @@ Using the `import` block is a simpler and more convenient way of importing resou
    terraform plan -out=import.plan -var-file=tf.vars -generate-config-out=generated.tf
    ```
 
-3. Review the `generated.tf` file and ensure the imported scaling policy is correct. Terraform will generate this file by setting values equal to zero for certain configuration parameters. 
+3. Review the `generated.tf` file and ensure the imported scaling policy is correct. Terraform will generate this file by setting values equal to zero for certain configuration parameters.
 
-For example:
+   For example:
 
    ```hcl
    cpu {

--- a/templates/resources/workload_scaling_policy.md.tmpl
+++ b/templates/resources/workload_scaling_policy.md.tmpl
@@ -21,7 +21,7 @@ simultaneously or create custom policies with different settings and apply them 
 ## Importing
 
 For each connected cluster, a default scaling policy is created. An existing scaling policy can be imported into the
-Terraform state using the `terraform import` command or the [`import`](https://developer.hashicorp.com/terraform/language/import#syntax) block.
+Terraform state using the `terraform import` command or the [`import`](https://developer.hashicorp.com/terraform/language/import#syntax) block (recommended for Terraform 1.5.0+).
 
 Using the `import` block is a simpler and more convenient way of importing resources.
 
@@ -43,8 +43,14 @@ Using the `import` block is a simpler and more convenient way of importing resou
    terraform plan -out=import.plan -var-file=tf.vars -generate-config-out=generated.tf
    ```
 
-3. Review the `generated.tf` file and ensure that the imported scaling policy is correct. Terraform sets zero values,
-	 e.g., for `look_back_period_seconds`. All such properties can be removed to use the defaults.
+3. Review the `generated.tf` file and ensure the imported scaling policy is correct. Terraform will generate this file by setting values equal to zero for certain configuration parameters. 
+
+For example:
+
+   ```hcl
+   cpu {
+     look_back_period_seconds = 0
+   }
 
 4. Apply the import plan:
 
@@ -116,7 +122,7 @@ can [import a single policy](#import-a-single-scaling-policy) and then use it as
    terraform apply "import.plan"
    ```
 
-### Import using `terraform import` command
+### Import using the `terraform import` command
 
 You can use the `terraform import` command to import existing scaling policy to Terraform state.
 
@@ -142,5 +148,5 @@ $ terraform import 'module.castai-eks-cluster.castai_workload_scaling_policy.thi
 ## Upsert scaling policy
 
 The recommended way is to [import](#importing) the scaling policy and then apply the changes to the policy.
-However, if that’s not possible, you can define the default policy resource yourself. The CAST AI Terraform provider,
+However, if that’s not possible, you can define the default policy resource yourself. The CAST AI Terraform provider
 will update the existing policy instead of returning an error.


### PR DESCRIPTION
**Description**


This PR allows to manage default scaling policies without importing them. If there is create operation against the default scaling policy, it's changed to update.

Without this PR, the following error is thrown:
```tf
   ╷
   │ Error: expected status code 200, received: status=409 body={"message":"scaling policy with the same name already exists", "fieldViolations":[]}
   │
   │   with castai_workload_scaling_policy.default["staging"],
   │   on import.tf line 8, in resource "castai_workload_scaling_policy" "default":
   │    8: resource "castai_workload_scaling_policy" "default" {
   ╵
```

I also update the import section to describe easier way of doing that.

**Limitations**
1. Default policies are created in the context of a given cluster ID. As a result, you need to collect and provide all the cluster IDs where you want to change the default policy.
2. Most of the props are required anyway so if they want to update only a few props, they are still required to provide all of them.
