### PR TITLE
KUBE-856: Add http proxy settings for AKS 

### DIFF
--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -123,6 +123,12 @@ const (
 	Ssd     CastaiInventoryV1beta1StorageInfoDeviceType = "ssd"
 )
 
+// Defines values for CastaiRbacV1beta1Effects.
+const (
+	ALLOW CastaiRbacV1beta1Effects = "ALLOW"
+	DENY  CastaiRbacV1beta1Effects = "DENY"
+)
+
 // Defines values for CastaiRbacV1beta1Kind.
 const (
 	SERVICEACCOUNT CastaiRbacV1beta1Kind = "SERVICE_ACCOUNT"
@@ -1508,6 +1514,9 @@ type CastaiRbacV1beta1DeleteGroupResponse = map[string]interface{}
 // CastaiRbacV1beta1DeleteRoleBindingResponse defines model for castai.rbac.v1beta1.DeleteRoleBindingResponse.
 type CastaiRbacV1beta1DeleteRoleBindingResponse = map[string]interface{}
 
+// Effects represent the effect of a permission.
+type CastaiRbacV1beta1Effects string
+
 // CastaiRbacV1beta1Group defines model for castai.rbac.v1beta1.Group.
 type CastaiRbacV1beta1Group struct {
 	// CreatedAt is the timestamp when the group was created.
@@ -1553,6 +1562,22 @@ type CastaiRbacV1beta1GroupSubject struct {
 // Kind represents the type of the member.
 type CastaiRbacV1beta1Kind string
 
+// CastaiRbacV1beta1ListRoleBindingsResponse defines model for castai.rbac.v1beta1.ListRoleBindingsResponse.
+type CastaiRbacV1beta1ListRoleBindingsResponse struct {
+	// Page defines how many and which fields should be returned.
+	NextPage     CastaiPaginationV1beta1Page     `json:"nextPage"`
+	RoleBindings *[]CastaiRbacV1beta1RoleBinding `json:"roleBindings,omitempty"`
+	TotalCount   *string                         `json:"totalCount,omitempty"`
+}
+
+// CastaiRbacV1beta1ListRolesResponse defines model for castai.rbac.v1beta1.ListRolesResponse.
+type CastaiRbacV1beta1ListRolesResponse struct {
+	// Page defines how many and which fields should be returned.
+	NextPage   *CastaiPaginationV1beta1Page `json:"nextPage,omitempty"`
+	Roles      *[]CastaiRbacV1beta1Role     `json:"roles,omitempty"`
+	TotalCount *string                      `json:"totalCount,omitempty"`
+}
+
 // CastaiRbacV1beta1Member defines model for castai.rbac.v1beta1.Member.
 type CastaiRbacV1beta1Member struct {
 	// AddedAt is the timestamp when the user has been added to the group.
@@ -1577,6 +1602,14 @@ type CastaiRbacV1beta1OrganizationScope struct {
 	Id string `json:"id"`
 }
 
+// CastaiRbacV1beta1Permissions defines model for castai.rbac.v1beta1.Permissions.
+type CastaiRbacV1beta1Permissions struct {
+	// Effects represent the effect of a permission.
+	Effect    CastaiRbacV1beta1Effects `json:"effect"`
+	Endpoints *[]string                `json:"endpoints,omitempty"`
+	Groups    *[]string                `json:"groups,omitempty"`
+}
+
 // PoliciesState represents the state of the policies generation.
 //
 //   - ACCEPTED: ACCEPTED is the state when the policies async generation is ongoing.
@@ -1594,6 +1627,35 @@ type CastaiRbacV1beta1PolicyID struct {
 type CastaiRbacV1beta1ResourceScope struct {
 	// ID is the unique identifier of the resource.
 	Id string `json:"id"`
+}
+
+// CastaiRbacV1beta1Role defines model for castai.rbac.v1beta1.Role.
+type CastaiRbacV1beta1Role struct {
+	// CreatedAt is the timestamp when the role was created.
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
+
+	// Default is a flag that indicates if the role is a default role.
+	Default    *bool                           `json:"default,omitempty"`
+	Definition CastaiRbacV1beta1RoleDefinition `json:"definition"`
+
+	// Deprecated is a flag that indicates if the role is deprecated.
+	Deprecated *bool `json:"deprecated,omitempty"`
+
+	// Description is the description of the role.
+	Description *string `json:"description,omitempty"`
+	Id          *string `json:"id,omitempty"`
+
+	// Priority level of the role (higher is more important).
+	Level *int32 `json:"level,omitempty"`
+
+	// Name is the name of the role.
+	Name *string `json:"name,omitempty"`
+
+	// OrganizationID is the unique identifier of the organization.
+	OrganizationId *string `json:"organizationId,omitempty"`
+
+	// UpdatedAt is the timestamp when the role was last updated.
+	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
 }
 
 // CastaiRbacV1beta1RoleBinding defines model for castai.rbac.v1beta1.RoleBinding.
@@ -1653,6 +1715,12 @@ type CastaiRbacV1beta1RoleBindingStatus struct {
 
 	// UpdatedAt is the timestamp when the status was last updated.
 	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+}
+
+// CastaiRbacV1beta1RoleDefinition defines model for castai.rbac.v1beta1.RoleDefinition.
+type CastaiRbacV1beta1RoleDefinition struct {
+	// Permissions is a list of permissions.
+	Permissions *[]CastaiRbacV1beta1Permissions `json:"permissions,omitempty"`
 }
 
 // Scope represents the scope of the role binding.
@@ -2255,6 +2323,13 @@ type CastaiUsersV1beta1UserOrganization struct {
 
 	// name of the organization.
 	Name string `json:"name"`
+
+	// Deprecated: for RBACv2 user can be bound to multiple roles.
+	// Use https://docs.cast.ai/reference/rbacserviceapi instead.
+	// user role in the organization.
+	//
+	// TODO: cleanup once all orgs are migrated to RBACv2
+	//  https://castai.atlassian.net/browse/WIRE-954
 	Role string `json:"role"`
 }
 
@@ -5220,11 +5295,30 @@ type InventoryAPIAddReservationJSONBody = CastaiInventoryV1beta1GenericReservati
 // InventoryAPIOverwriteReservationsJSONBody defines parameters for InventoryAPIOverwriteReservations.
 type InventoryAPIOverwriteReservationsJSONBody = CastaiInventoryV1beta1GenericReservationsList
 
+// RbacServiceAPIListRoleBindingsParams defines parameters for RbacServiceAPIListRoleBindings.
+type RbacServiceAPIListRoleBindingsParams struct {
+	PageLimit *string `form:"page.limit,omitempty" json:"page.limit,omitempty"`
+
+	// Cursor that defines token indicating where to start the next page.
+	// Empty value indicates to start from beginning of the dataset.
+	PageCursor *string `form:"page.cursor,omitempty" json:"page.cursor,omitempty"`
+	RoleId     *string `form:"roleId,omitempty" json:"roleId,omitempty"`
+}
+
 // RbacServiceAPICreateRoleBindingsJSONBody defines parameters for RbacServiceAPICreateRoleBindings.
 type RbacServiceAPICreateRoleBindingsJSONBody = []CastaiRbacV1beta1CreateRoleBindingsRequestRoleBinding
 
 // RbacServiceAPIUpdateRoleBindingJSONBody defines parameters for RbacServiceAPIUpdateRoleBinding.
 type RbacServiceAPIUpdateRoleBindingJSONBody = RoleBindingIsTheRoleBindingToBeUpdated
+
+// RbacServiceAPIListRolesParams defines parameters for RbacServiceAPIListRoles.
+type RbacServiceAPIListRolesParams struct {
+	PageLimit *string `form:"page.limit,omitempty" json:"page.limit,omitempty"`
+
+	// Cursor that defines token indicating where to start the next page.
+	// Empty value indicates to start from beginning of the dataset.
+	PageCursor *string `form:"page.cursor,omitempty" json:"page.cursor,omitempty"`
+}
 
 // ServiceAccountsAPIDeleteServiceAccountsParams defines parameters for ServiceAccountsAPIDeleteServiceAccounts.
 type ServiceAccountsAPIDeleteServiceAccountsParams struct {

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -4166,9 +4166,26 @@ type WorkloadoptimizationV1AntiAffinitySettings struct {
 
 // WorkloadoptimizationV1ApplyThresholdStrategy defines model for workloadoptimization.v1.ApplyThresholdStrategy.
 type WorkloadoptimizationV1ApplyThresholdStrategy struct {
+	CustomAdaptiveThreshold  *WorkloadoptimizationV1ApplyThresholdStrategyCustomAdaptiveThreshold  `json:"customAdaptiveThreshold,omitempty"`
+	DefaultAdaptiveThreshold *WorkloadoptimizationV1ApplyThresholdStrategyDefaultAdaptiveThreshold `json:"defaultAdaptiveThreshold,omitempty"`
+
 	// PercentageThreshold is the percentage for the apply threshold strategy.
 	PercentageThreshold *WorkloadoptimizationV1ApplyThresholdStrategyPercentageThreshold `json:"percentageThreshold,omitempty"`
 }
+
+// WorkloadoptimizationV1ApplyThresholdStrategyCustomAdaptiveThreshold defines model for workloadoptimization.v1.ApplyThresholdStrategy.CustomAdaptiveThreshold.
+type WorkloadoptimizationV1ApplyThresholdStrategyCustomAdaptiveThreshold struct {
+	// If value is close or equal to 0, the threshold will be much bigger for small values.
+	// For example when numerator, exponent is 1 and denominator is 0 the threshold for 0.5 req. CPU will be 200%.
+	Denominator float64 `json:"denominator"`
+	Exponent    float64 `json:"exponent"`
+
+	// It affects vertical stretch of function - smaller number will create smaller threshold.
+	Numerator float64 `json:"numerator"`
+}
+
+// WorkloadoptimizationV1ApplyThresholdStrategyDefaultAdaptiveThreshold defines model for workloadoptimization.v1.ApplyThresholdStrategy.DefaultAdaptiveThreshold.
+type WorkloadoptimizationV1ApplyThresholdStrategyDefaultAdaptiveThreshold = map[string]interface{}
 
 // PercentageThreshold is the percentage for the apply threshold strategy.
 type WorkloadoptimizationV1ApplyThresholdStrategyPercentageThreshold struct {

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -417,6 +417,9 @@ type ClientInterface interface {
 	// InventoryAPIDeleteReservation request
 	InventoryAPIDeleteReservation(ctx context.Context, organizationId string, reservationId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// RbacServiceAPIListRoleBindings request
+	RbacServiceAPIListRoleBindings(ctx context.Context, organizationId string, params *RbacServiceAPIListRoleBindingsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// RbacServiceAPICreateRoleBindings request with any body
 	RbacServiceAPICreateRoleBindingsWithBody(ctx context.Context, organizationId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -432,6 +435,9 @@ type ClientInterface interface {
 	RbacServiceAPIUpdateRoleBindingWithBody(ctx context.Context, organizationId string, roleBindingId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	RbacServiceAPIUpdateRoleBinding(ctx context.Context, organizationId string, roleBindingId string, body RbacServiceAPIUpdateRoleBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RbacServiceAPIListRoles request
+	RbacServiceAPIListRoles(ctx context.Context, organizationId string, params *RbacServiceAPIListRolesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ServiceAccountsAPIDeleteServiceAccounts request
 	ServiceAccountsAPIDeleteServiceAccounts(ctx context.Context, organizationId string, params *ServiceAccountsAPIDeleteServiceAccountsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2087,6 +2093,18 @@ func (c *Client) InventoryAPIDeleteReservation(ctx context.Context, organization
 	return c.Client.Do(req)
 }
 
+func (c *Client) RbacServiceAPIListRoleBindings(ctx context.Context, organizationId string, params *RbacServiceAPIListRoleBindingsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRbacServiceAPIListRoleBindingsRequest(c.Server, organizationId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) RbacServiceAPICreateRoleBindingsWithBody(ctx context.Context, organizationId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRbacServiceAPICreateRoleBindingsRequestWithBody(c.Server, organizationId, contentType, body)
 	if err != nil {
@@ -2149,6 +2167,18 @@ func (c *Client) RbacServiceAPIUpdateRoleBindingWithBody(ctx context.Context, or
 
 func (c *Client) RbacServiceAPIUpdateRoleBinding(ctx context.Context, organizationId string, roleBindingId string, body RbacServiceAPIUpdateRoleBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRbacServiceAPIUpdateRoleBindingRequest(c.Server, organizationId, roleBindingId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RbacServiceAPIListRoles(ctx context.Context, organizationId string, params *RbacServiceAPIListRolesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRbacServiceAPIListRolesRequest(c.Server, organizationId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -7167,6 +7197,92 @@ func NewInventoryAPIDeleteReservationRequest(server string, organizationId strin
 	return req, nil
 }
 
+// NewRbacServiceAPIListRoleBindingsRequest generates requests for RbacServiceAPIListRoleBindings
+func NewRbacServiceAPIListRoleBindingsRequest(server string, organizationId string, params *RbacServiceAPIListRoleBindingsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "organizationId", runtime.ParamLocationPath, organizationId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/organizations/%s/role-bindings", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.PageLimit != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.limit", runtime.ParamLocationQuery, *params.PageLimit); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.PageCursor != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.cursor", runtime.ParamLocationQuery, *params.PageCursor); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.RoleId != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "roleId", runtime.ParamLocationQuery, *params.RoleId); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewRbacServiceAPICreateRoleBindingsRequest calls the generic RbacServiceAPICreateRoleBindings builder with application/json body
 func NewRbacServiceAPICreateRoleBindingsRequest(server string, organizationId string, body RbacServiceAPICreateRoleBindingsJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -7346,6 +7462,76 @@ func NewRbacServiceAPIUpdateRoleBindingRequestWithBody(server string, organizati
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewRbacServiceAPIListRolesRequest generates requests for RbacServiceAPIListRoles
+func NewRbacServiceAPIListRolesRequest(server string, organizationId string, params *RbacServiceAPIListRolesParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "organizationId", runtime.ParamLocationPath, organizationId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/organizations/%s/roles", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.PageLimit != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.limit", runtime.ParamLocationQuery, *params.PageLimit); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.PageCursor != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.cursor", runtime.ParamLocationQuery, *params.PageCursor); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -10542,6 +10728,9 @@ type ClientWithResponsesInterface interface {
 	// InventoryAPIDeleteReservation request
 	InventoryAPIDeleteReservationWithResponse(ctx context.Context, organizationId string, reservationId string) (*InventoryAPIDeleteReservationResponse, error)
 
+	// RbacServiceAPIListRoleBindings request
+	RbacServiceAPIListRoleBindingsWithResponse(ctx context.Context, organizationId string, params *RbacServiceAPIListRoleBindingsParams) (*RbacServiceAPIListRoleBindingsResponse, error)
+
 	// RbacServiceAPICreateRoleBindings request  with any body
 	RbacServiceAPICreateRoleBindingsWithBodyWithResponse(ctx context.Context, organizationId string, contentType string, body io.Reader) (*RbacServiceAPICreateRoleBindingsResponse, error)
 
@@ -10557,6 +10746,9 @@ type ClientWithResponsesInterface interface {
 	RbacServiceAPIUpdateRoleBindingWithBodyWithResponse(ctx context.Context, organizationId string, roleBindingId string, contentType string, body io.Reader) (*RbacServiceAPIUpdateRoleBindingResponse, error)
 
 	RbacServiceAPIUpdateRoleBindingWithResponse(ctx context.Context, organizationId string, roleBindingId string, body RbacServiceAPIUpdateRoleBindingJSONRequestBody) (*RbacServiceAPIUpdateRoleBindingResponse, error)
+
+	// RbacServiceAPIListRoles request
+	RbacServiceAPIListRolesWithResponse(ctx context.Context, organizationId string, params *RbacServiceAPIListRolesParams) (*RbacServiceAPIListRolesResponse, error)
 
 	// ServiceAccountsAPIDeleteServiceAccounts request
 	ServiceAccountsAPIDeleteServiceAccountsWithResponse(ctx context.Context, organizationId string, params *ServiceAccountsAPIDeleteServiceAccountsParams) (*ServiceAccountsAPIDeleteServiceAccountsResponse, error)
@@ -13389,6 +13581,36 @@ func (r InventoryAPIDeleteReservationResponse) GetBody() []byte {
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
+type RbacServiceAPIListRoleBindingsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CastaiRbacV1beta1ListRoleBindingsResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r RbacServiceAPIListRoleBindingsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RbacServiceAPIListRoleBindingsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r RbacServiceAPIListRoleBindingsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
 type RbacServiceAPICreateRoleBindingsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -13504,6 +13726,36 @@ func (r RbacServiceAPIUpdateRoleBindingResponse) StatusCode() int {
 // TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 // Body returns body of byte array
 func (r RbacServiceAPIUpdateRoleBindingResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
+type RbacServiceAPIListRolesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CastaiRbacV1beta1ListRolesResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r RbacServiceAPIListRolesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RbacServiceAPIListRolesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r RbacServiceAPIListRolesResponse) GetBody() []byte {
 	return r.Body
 }
 
@@ -16325,6 +16577,15 @@ func (c *ClientWithResponses) InventoryAPIDeleteReservationWithResponse(ctx cont
 	return ParseInventoryAPIDeleteReservationResponse(rsp)
 }
 
+// RbacServiceAPIListRoleBindingsWithResponse request returning *RbacServiceAPIListRoleBindingsResponse
+func (c *ClientWithResponses) RbacServiceAPIListRoleBindingsWithResponse(ctx context.Context, organizationId string, params *RbacServiceAPIListRoleBindingsParams) (*RbacServiceAPIListRoleBindingsResponse, error) {
+	rsp, err := c.RbacServiceAPIListRoleBindings(ctx, organizationId, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRbacServiceAPIListRoleBindingsResponse(rsp)
+}
+
 // RbacServiceAPICreateRoleBindingsWithBodyWithResponse request with arbitrary body returning *RbacServiceAPICreateRoleBindingsResponse
 func (c *ClientWithResponses) RbacServiceAPICreateRoleBindingsWithBodyWithResponse(ctx context.Context, organizationId string, contentType string, body io.Reader) (*RbacServiceAPICreateRoleBindingsResponse, error) {
 	rsp, err := c.RbacServiceAPICreateRoleBindingsWithBody(ctx, organizationId, contentType, body)
@@ -16375,6 +16636,15 @@ func (c *ClientWithResponses) RbacServiceAPIUpdateRoleBindingWithResponse(ctx co
 		return nil, err
 	}
 	return ParseRbacServiceAPIUpdateRoleBindingResponse(rsp)
+}
+
+// RbacServiceAPIListRolesWithResponse request returning *RbacServiceAPIListRolesResponse
+func (c *ClientWithResponses) RbacServiceAPIListRolesWithResponse(ctx context.Context, organizationId string, params *RbacServiceAPIListRolesParams) (*RbacServiceAPIListRolesResponse, error) {
+	rsp, err := c.RbacServiceAPIListRoles(ctx, organizationId, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRbacServiceAPIListRolesResponse(rsp)
 }
 
 // ServiceAccountsAPIDeleteServiceAccountsWithResponse request returning *ServiceAccountsAPIDeleteServiceAccountsResponse
@@ -19294,6 +19564,32 @@ func ParseInventoryAPIDeleteReservationResponse(rsp *http.Response) (*InventoryA
 	return response, nil
 }
 
+// ParseRbacServiceAPIListRoleBindingsResponse parses an HTTP response from a RbacServiceAPIListRoleBindingsWithResponse call
+func ParseRbacServiceAPIListRoleBindingsResponse(rsp *http.Response) (*RbacServiceAPIListRoleBindingsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RbacServiceAPIListRoleBindingsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CastaiRbacV1beta1ListRoleBindingsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseRbacServiceAPICreateRoleBindingsResponse parses an HTTP response from a RbacServiceAPICreateRoleBindingsWithResponse call
 func ParseRbacServiceAPICreateRoleBindingsResponse(rsp *http.Response) (*RbacServiceAPICreateRoleBindingsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -19388,6 +19684,32 @@ func ParseRbacServiceAPIUpdateRoleBindingResponse(rsp *http.Response) (*RbacServ
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest CastaiRbacV1beta1RoleBinding
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRbacServiceAPIListRolesResponse parses an HTTP response from a RbacServiceAPIListRolesWithResponse call
+func ParseRbacServiceAPIListRolesResponse(rsp *http.Response) (*RbacServiceAPIListRolesResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RbacServiceAPIListRolesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CastaiRbacV1beta1ListRolesResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -2435,6 +2435,46 @@ func (mr *MockClientInterfaceMockRecorder) RbacServiceAPIGetRoleBinding(ctx, org
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIGetRoleBinding", reflect.TypeOf((*MockClientInterface)(nil).RbacServiceAPIGetRoleBinding), varargs...)
 }
 
+// RbacServiceAPIListRoleBindings mocks base method.
+func (m *MockClientInterface) RbacServiceAPIListRoleBindings(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRoleBindingsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRoleBindings", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRoleBindings indicates an expected call of RbacServiceAPIListRoleBindings.
+func (mr *MockClientInterfaceMockRecorder) RbacServiceAPIListRoleBindings(ctx, organizationId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRoleBindings", reflect.TypeOf((*MockClientInterface)(nil).RbacServiceAPIListRoleBindings), varargs...)
+}
+
+// RbacServiceAPIListRoles mocks base method.
+func (m *MockClientInterface) RbacServiceAPIListRoles(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRolesParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRoles", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRoles indicates an expected call of RbacServiceAPIListRoles.
+func (mr *MockClientInterfaceMockRecorder) RbacServiceAPIListRoles(ctx, organizationId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRoles", reflect.TypeOf((*MockClientInterface)(nil).RbacServiceAPIListRoles), varargs...)
+}
+
 // RbacServiceAPIUpdateGroup mocks base method.
 func (m *MockClientInterface) RbacServiceAPIUpdateGroup(ctx context.Context, organizationId, groupId string, body sdk.RbacServiceAPIUpdateGroupJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -8286,6 +8326,76 @@ func (m *MockClientWithResponsesInterface) RbacServiceAPIGetRoleBindingWithRespo
 func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIGetRoleBindingWithResponse(ctx, organizationId, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIGetRoleBindingWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIGetRoleBindingWithResponse), ctx, organizationId, id)
+}
+
+// RbacServiceAPIListRoleBindings mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIListRoleBindings(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRoleBindingsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRoleBindings", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRoleBindings indicates an expected call of RbacServiceAPIListRoleBindings.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIListRoleBindings(ctx, organizationId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRoleBindings", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIListRoleBindings), varargs...)
+}
+
+// RbacServiceAPIListRoleBindingsWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIListRoleBindingsWithResponse(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRoleBindingsParams) (*sdk.RbacServiceAPIListRoleBindingsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRoleBindingsWithResponse", ctx, organizationId, params)
+	ret0, _ := ret[0].(*sdk.RbacServiceAPIListRoleBindingsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRoleBindingsWithResponse indicates an expected call of RbacServiceAPIListRoleBindingsWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIListRoleBindingsWithResponse(ctx, organizationId, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRoleBindingsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIListRoleBindingsWithResponse), ctx, organizationId, params)
+}
+
+// RbacServiceAPIListRoles mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIListRoles(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRolesParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRoles", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRoles indicates an expected call of RbacServiceAPIListRoles.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIListRoles(ctx, organizationId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRoles", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIListRoles), varargs...)
+}
+
+// RbacServiceAPIListRolesWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIListRolesWithResponse(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRolesParams) (*sdk.RbacServiceAPIListRolesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRolesWithResponse", ctx, organizationId, params)
+	ret0, _ := ret[0].(*sdk.RbacServiceAPIListRolesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRolesWithResponse indicates an expected call of RbacServiceAPIListRolesWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIListRolesWithResponse(ctx, organizationId, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRolesWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIListRolesWithResponse), ctx, organizationId, params)
 }
 
 // RbacServiceAPIUpdateGroup mocks base method.

--- a/docs/resources/aks_cluster.md
+++ b/docs/resources/aks_cluster.md
@@ -44,6 +44,7 @@ resource "castai_aks_cluster" "this" {
 ### Optional
 
 - `delete_nodes_on_disconnect` (Boolean) Should CAST AI remove nodes managed by CAST.AI on disconnect.
+- `http_proxy_config` (Block List, Max: 1) HTTP proxy configuration for Cast nodes and node components. (see [below for nested schema](#nestedblock--http_proxy_config))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -51,6 +52,16 @@ resource "castai_aks_cluster" "this" {
 - `cluster_token` (String, Sensitive) CAST AI cluster token.
 - `credentials_id` (String) CAST AI internal credentials ID
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--http_proxy_config"></a>
+### Nested Schema for `http_proxy_config`
+
+Optional:
+
+- `http_proxy` (String) Address to use for proxying HTTP requests.
+- `https_proxy` (String) Address to use for proxying HTTPS/TLS requests.
+- `no_proxy` (List of String) List of destinations that should not go through proxy.
+
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/examples/aks/aks_cluster_with_proxy/README.MD
+++ b/examples/aks/aks_cluster_with_proxy/README.MD
@@ -1,0 +1,34 @@
+# AKS and CAST AI example where nodes require egress proxy configuration
+Following example shows how to onboard AKS cluster to CAST AI, configure [Autoscaler policies](https://docs.cast.ai/reference/policiesapi_upsertclusterpolicies) and additional [Node Configurations](https://docs.cast.ai/docs/node-configuration/).
+
+The AKS cluster has the following setup:
+1. AKS cluster, a VNET and two firewalls are deployed in their own resource group.
+2. AKS cluster is set up to use one of the firewalls for egress communication. 
+3. Default communication for the cluster goes through a firewall that only allows traffic for AKS to work. No other egress traffic is allowed.
+4. A second firewall is deployed in a peered VNET to the cluster's VNET. The firewall is in explicit proxy mode. This firewall allows egress traffic to CAST AI and Google storage (required by CAST).
+5. The cluster is onboarded in CAST AI and configured so that the proxy firewall is used for egress communication. 
+
+The goal of this example is to show how to configure CAST AI components so http proxy is enforced when communicating with the platform. 
+
+Example configuration should be analysed in the following order:
+1. Create Virtual network - `vnet.tf`
+2. Create AKS cluster - `aks.tf`
+3. Create CAST AI related resources to connect AKS cluster to CAST AI, configure Autoscaler and Node Configurations - `castai.tf`
+
+# Usage
+1. Rename `tf.vars.example` to `tf.vars`
+2. Update `tf.vars` file with your cluster name, cluster region and CAST AI API token.
+3. Initialize Terraform. Under example root folder run:
+```
+terraform init
+```
+4. Run Terraform apply:
+```
+terraform apply -var-file=tf.vars
+```
+5. To destroy resources created by this example:
+```
+terraform destroy -var-file=tf.vars
+```
+
+Please refer to this guide if you run into any issues https://docs.cast.ai/docs/terraform-troubleshooting

--- a/examples/aks/aks_cluster_with_proxy/aks.tf
+++ b/examples/aks/aks_cluster_with_proxy/aks.tf
@@ -66,4 +66,10 @@ resource "azurerm_kubernetes_cluster" "aks" {
     azurerm_route_table.route_table,
     azurerm_subnet_route_table_association.route_table_association
   ]
+
+  lifecycle {
+    ignore_changes = [
+      tags["CreatedAt"]
+    ]
+  }
 }

--- a/examples/aks/aks_cluster_with_proxy/aks.tf
+++ b/examples/aks/aks_cluster_with_proxy/aks.tf
@@ -1,0 +1,69 @@
+
+resource "azurerm_resource_group" "rg" {
+  name     = var.resource_group_name
+  location = var.cluster_region
+}
+
+resource "azurerm_route_table" "route_table" {
+  name                = "aks-route-table"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  depends_on          = [azurerm_subnet.egress_firewall_subnet]
+}
+
+resource "azurerm_subnet_route_table_association" "route_table_association" {
+  subnet_id      = azurerm_subnet.aks_subnet.id
+  route_table_id = azurerm_route_table.route_table.id
+}
+
+resource "azurerm_route" "egress_route" {
+  name                   = "default-egress"
+  route_table_name       = azurerm_route_table.route_table.name
+  resource_group_name    = azurerm_resource_group.rg.name
+  address_prefix         = "0.0.0.0/0"
+  next_hop_type          = "VirtualAppliance"
+  next_hop_in_ip_address = azurerm_firewall.egress_firewall.ip_configuration[0].private_ip_address
+}
+
+resource "azurerm_route" "internet_route" {
+  name                = "internet-egress"
+  route_table_name    = azurerm_route_table.route_table.name
+  resource_group_name = azurerm_resource_group.rg.name
+  address_prefix      = "${azurerm_public_ip.firewall_public_ip.ip_address}/32"
+  next_hop_type       = "Internet"
+}
+
+resource "azurerm_kubernetes_cluster" "aks" {
+  name                = var.cluster_name
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  dns_prefix          = "aksproxy"
+
+  default_node_pool {
+    name           = "agentpool"
+    vm_size        = "Standard_DS2_v2"
+    node_count     = 2
+    vnet_subnet_id = azurerm_subnet.aks_subnet.id
+
+    upgrade_settings {
+      drain_timeout_in_minutes      = 0
+      max_surge                     = "10%"
+      node_soak_duration_in_minutes = 0
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin = "azure"
+    network_policy = "azure"
+    outbound_type  = "userDefinedRouting"
+  }
+
+  depends_on = [
+    azurerm_route_table.route_table,
+    azurerm_subnet_route_table_association.route_table_association
+  ]
+}

--- a/examples/aks/aks_cluster_with_proxy/castai.tf
+++ b/examples/aks/aks_cluster_with_proxy/castai.tf
@@ -6,8 +6,7 @@ locals {
 }
 
 module "castai-aks-cluster" {
-  # source = "castai/aks/castai"
-  source = "/Users/lachezar/Src/terraform-castai-aks"
+  source = "castai/aks/castai"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/aks/aks_cluster_with_proxy/castai.tf
+++ b/examples/aks/aks_cluster_with_proxy/castai.tf
@@ -58,4 +58,10 @@ module "castai-aks-cluster" {
       NO_PROXY: "${join(",", local.no_proxy_default)}"
     EOF
   ]
+
+  # Networking setup should be completed before trying to onboard cluster; otherwise components get stuck with no connectivity.
+  depends_on = [
+    azurerm_firewall.egress_firewall,
+    azurerm_firewall.explicit_firewall
+  ]
 }

--- a/examples/aks/aks_cluster_with_proxy/castai.tf
+++ b/examples/aks/aks_cluster_with_proxy/castai.tf
@@ -1,0 +1,61 @@
+locals {
+  http_proxy_address = "${azurerm_firewall.explicit_firewall.ip_configuration[0].private_ip_address}:${azurerm_firewall_policy.explicit_proxy_policy.explicit_proxy[0].http_port}"
+  https_proxy_address = "${azurerm_firewall.explicit_firewall.ip_configuration[0].private_ip_address}:${azurerm_firewall_policy.explicit_proxy_policy.explicit_proxy[0].https_port}"
+  no_proxy_default = concat([azurerm_kubernetes_cluster.aks.fqdn], var.fqdn_without_proxy)
+  no_proxy_agent = concat(local.no_proxy_default, ["169.254.169.254"])  # Agent requires access to local metadata endpoint as well
+}
+
+module "castai-aks-cluster" {
+  # source = "castai/aks/castai"
+  source = "/Users/lachezar/Src/terraform-castai-aks"
+
+  api_url                = var.castai_api_url
+  castai_api_token       = var.castai_api_token
+  grpc_url               = var.castai_grpc_url
+  wait_for_cluster_ready = true
+
+  aks_cluster_name    = var.cluster_name
+  aks_cluster_region  = azurerm_kubernetes_cluster.aks.location
+  node_resource_group = azurerm_kubernetes_cluster.aks.node_resource_group
+  resource_group      = azurerm_kubernetes_cluster.aks.resource_group_name
+
+  http_proxy = local.http_proxy_address
+  https_proxy = local.https_proxy_address
+  no_proxy = var.fqdn_without_proxy
+
+  delete_nodes_on_disconnect = true
+
+  subscription_id = data.azurerm_subscription.current.subscription_id
+  tenant_id       = data.azurerm_subscription.current.tenant_id
+
+  default_node_configuration = module.castai-aks-cluster.castai_node_configurations["default"]
+
+  node_configurations = {
+    default = {
+      disk_cpu_ratio = 25
+      subnets        = [azurerm_subnet.aks_subnet.id]
+    }
+  }
+
+  agent_values = [
+    <<-EOF
+    podAnnotations:
+      kubernetes.azure.com/set-kube-service-host-fqdn: "true"
+    additionalEnv:
+      HTTP_PROXY: "${local.http_proxy_address}"
+      HTTPS_PROXY: "${local.https_proxy_address}"
+      NO_PROXY: "${join(",", local.no_proxy_agent)}"
+    EOF
+  ]
+
+  cluster_controller_values = [
+    <<-EOF
+    podAnnotations:
+      kubernetes.azure.com/set-kube-service-host-fqdn: "true"
+    additionalEnv:
+      HTTP_PROXY: "${local.http_proxy_address}"
+      HTTPS_PROXY: "${local.https_proxy_address}"
+      NO_PROXY: "${join(",", local.no_proxy_default)}"
+    EOF
+  ]
+}

--- a/examples/aks/aks_cluster_with_proxy/data.tf
+++ b/examples/aks/aks_cluster_with_proxy/data.tf
@@ -1,0 +1,3 @@
+data "azuread_client_config" "current" {}
+
+data "azurerm_subscription" "current" {}

--- a/examples/aks/aks_cluster_with_proxy/egress_firewall.tf
+++ b/examples/aks/aks_cluster_with_proxy/egress_firewall.tf
@@ -1,0 +1,165 @@
+
+resource "azurerm_firewall" "egress_firewall" {
+  name                = "aks-firewall"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
+  dns_proxy_enabled   = true
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.egress_firewall_subnet.id
+    public_ip_address_id = azurerm_public_ip.firewall_public_ip.id
+  }
+}
+
+resource "azurerm_public_ip" "firewall_public_ip" {
+  name                = "firewall-public-ip"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+
+resource "azurerm_firewall_network_rule_collection" "egress_rule" {
+  name                = "egress-rule"
+  azure_firewall_name = azurerm_firewall.egress_firewall.name
+  resource_group_name = azurerm_resource_group.rg.name
+  priority            = 100
+  action              = "Allow"
+
+  rule {
+    name                  = "apiudp"
+    protocols             = ["UDP"]
+    source_addresses      = ["10.42.1.0/24"]
+    destination_addresses = ["AzureCloud.${azurerm_resource_group.rg.location}"]
+    destination_ports     = ["1194"]
+  }
+  rule {
+    name                  = "apitcp"
+    protocols             = ["TCP"]
+    source_addresses      = ["10.42.1.0/24"]
+    destination_addresses = ["AzureCloud.${azurerm_resource_group.rg.location}"]
+    destination_ports     = ["9000"]
+  }
+  rule {
+    name                  = "time"
+    protocols             = ["UDP"]
+    source_addresses      = ["10.42.1.0/24"]
+    destination_addresses = ["*"]
+    destination_ports     = ["123"]
+  }
+  rule {
+    name              = "ghcr"
+    protocols         = ["TCP"]
+    source_addresses  = ["10.42.1.0/24"]
+    destination_fqdns = ["ghcr.io", "pkg-containers.githubusercontent.com"]
+    destination_ports = ["443"]
+  }
+  rule {
+    name             = "docker"
+    protocols        = ["TCP"]
+    source_addresses = ["10.42.1.0/24"]
+    destination_fqdns = [
+      # Some registries used by system images or CAST AI images.
+      "docker.io",
+      "registry-1.docker.io",
+      "production.cloudflare.docker.com",
+      "registry.k8s.io",
+      "us-docker.pkg.dev",
+      "europe-west2-docker.pkg.dev",
+      "prod-registry-k8s-io-eu-west-1.s3.dualstack.eu-west-1.amazonaws.com"
+    ]
+    destination_ports = ["443"]
+  }
+  rule {
+    name                  = "dns"
+    source_addresses      = ["10.42.1.0/24"]
+    destination_ports     = ["53"]
+    destination_addresses = ["*"]
+    protocols = [
+      "Any"
+    ]
+  }
+
+  dynamic "rule" {
+    for_each = length(var.fqdn_without_proxy) > 0 ? [1] : []
+    content {
+      name = "allowed_fqdns"
+      protocols = ["Any"]
+      source_addresses = ["10.42.1.0/24"]
+      destination_fqdns = var.fqdn_without_proxy
+      destination_ports = ["80", "443"]
+    }
+  }
+}
+
+
+resource "azurerm_firewall_network_rule_collection" "servicetags" {
+  name                = "servicetags"
+  azure_firewall_name = azurerm_firewall.egress_firewall.name
+  resource_group_name = azurerm_resource_group.rg.name
+  priority            = 200
+  action              = "Allow"
+
+  rule {
+    name              = "allow service tags"
+    source_addresses  = ["10.42.1.0/24"]
+    destination_ports = ["*"]
+    destination_addresses = [
+      "AzureContainerRegistry.${azurerm_resource_group.rg.location}",
+      "MicrosoftContainerRegistry.${azurerm_resource_group.rg.location}",
+      "AzureActiveDirectory",
+      "AzureMonitor",
+      "AzureWebPubSub",
+      "Storage",
+      "StorageSyncService"
+    ]
+    protocols = [
+      "Any"
+    ]
+  }
+}
+
+resource "azurerm_firewall_application_rule_collection" "fw-aks-google" {
+  name                = "forbid-gcs-explicit"
+  azure_firewall_name = azurerm_firewall.egress_firewall.name
+  resource_group_name = azurerm_resource_group.rg.name
+  priority            = 300
+  action              = "Deny"
+
+  # We add this rule because allowing traffic to the AKS FQDN tag actually includes `storage.googleapis.com` as well (at least at time of writing).
+  # In order to simulate environment where this is not allowed by default (as CAST AI depends on it), we explicitly forbid it.
+  # The list of URLs behind the tag is not public and dynamic; this was found via trial and error.
+  rule {
+    name             = "forbid google storage for testing fqdn for AKS"
+    source_addresses = ["*"]
+    target_fqdns     = ["storage.googleapis.com"]
+
+    protocol {
+      port = "443"
+      type = "Https"
+    }
+
+    protocol {
+      port = "80"
+      type = "Http"
+    }
+  }
+}
+
+resource "azurerm_firewall_application_rule_collection" "fw-aks" {
+  name                = "application-rules"
+  azure_firewall_name = azurerm_firewall.egress_firewall.name
+  resource_group_name = azurerm_resource_group.rg.name
+  priority            = 400
+  action              = "Allow"
+
+  rule {
+    name             = "allow fqdn for AKS"
+    source_addresses = ["10.42.1.0/24"]
+    fqdn_tags        = ["AzureKubernetesService"]
+  }
+}

--- a/examples/aks/aks_cluster_with_proxy/egress_firewall.tf
+++ b/examples/aks/aks_cluster_with_proxy/egress_firewall.tf
@@ -12,6 +12,12 @@ resource "azurerm_firewall" "egress_firewall" {
     subnet_id            = azurerm_subnet.egress_firewall_subnet.id
     public_ip_address_id = azurerm_public_ip.firewall_public_ip.id
   }
+
+  lifecycle {
+    ignore_changes = [
+      tags["CreatedAt"]
+    ]
+  }
 }
 
 resource "azurerm_public_ip" "firewall_public_ip" {

--- a/examples/aks/aks_cluster_with_proxy/network.tf
+++ b/examples/aks/aks_cluster_with_proxy/network.tf
@@ -1,0 +1,60 @@
+resource "azurerm_virtual_network" "vnet" {
+  name                = "aks-vnet"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  address_space       = ["10.42.0.0/16"]
+}
+
+resource "azurerm_subnet" "aks_subnet" {
+  name                 = "aks-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.42.1.0/24"]
+}
+
+resource "azurerm_subnet" "egress_firewall_subnet" {
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.42.2.0/24"]
+}
+
+
+resource "azurerm_virtual_network" "proxy_vnet" {
+  name                = "proxy-vnet"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  address_space       = ["10.43.0.0/16"]
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_subnet" "explicit_firewall_subnet" {
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.proxy_vnet.name
+  address_prefixes     = ["10.43.1.0/24"]
+}
+
+resource "azurerm_virtual_network_peering" "peer_vnets" {
+  name                         = "peer-firewall-vnets"
+  resource_group_name          = azurerm_resource_group.rg.name
+  virtual_network_name         = azurerm_virtual_network.proxy_vnet.name
+  remote_virtual_network_id    = azurerm_virtual_network.vnet.id
+  allow_virtual_network_access = true
+
+  depends_on = [azurerm_virtual_network.proxy_vnet]
+}
+
+
+resource "azurerm_virtual_network_peering" "peer_vnets_reverse" {
+  name                         = "peer-firewall-vnets-reverse"
+  resource_group_name          = azurerm_resource_group.rg.name
+  virtual_network_name         = azurerm_virtual_network.vnet.name
+  remote_virtual_network_id    = azurerm_virtual_network.proxy_vnet.id
+  allow_virtual_network_access = true
+
+  depends_on = [azurerm_virtual_network.proxy_vnet]
+}
+

--- a/examples/aks/aks_cluster_with_proxy/providers.tf
+++ b/examples/aks/aks_cluster_with_proxy/providers.tf
@@ -6,3 +6,17 @@ provider "azurerm" {
 provider "azuread" {
   tenant_id = data.azurerm_subscription.current.tenant_id
 }
+
+provider "castai" {
+  api_url   = var.castai_api_url
+  api_token = var.castai_api_token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = azurerm_kubernetes_cluster.aks.kube_config.0.host
+    client_certificate     = base64decode(azurerm_kubernetes_cluster.aks.kube_config.0.client_certificate)
+    client_key             = base64decode(azurerm_kubernetes_cluster.aks.kube_config.0.client_key)
+    cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.aks.kube_config.0.cluster_ca_certificate)
+  }
+}

--- a/examples/aks/aks_cluster_with_proxy/providers.tf
+++ b/examples/aks/aks_cluster_with_proxy/providers.tf
@@ -1,0 +1,8 @@
+provider "azurerm" {
+  subscription_id = var.subscription_id
+  features {}
+}
+
+provider "azuread" {
+  tenant_id = data.azurerm_subscription.current.tenant_id
+}

--- a/examples/aks/aks_cluster_with_proxy/proxy_firewall.tf
+++ b/examples/aks/aks_cluster_with_proxy/proxy_firewall.tf
@@ -1,0 +1,99 @@
+resource "azurerm_public_ip" "explicit_firewall_ip" {
+  name                = "explicit-firewall-public-ip"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+
+resource "azurerm_firewall" "explicit_firewall" {
+  name                = "explicit-proxy-firewall"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.explicit_firewall_subnet.id
+    public_ip_address_id = azurerm_public_ip.explicit_firewall_ip.id
+  }
+
+  firewall_policy_id = azurerm_firewall_policy.explicit_proxy_policy.id
+}
+
+
+resource "azurerm_firewall_policy" "explicit_proxy_policy" {
+  name                = "explicit-proxy-policy"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+
+  explicit_proxy {
+    enabled = true
+
+    http_port  = 3128
+    https_port = 3129
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+
+resource "azurerm_firewall_policy_rule_collection_group" "explicit_proxy_rules" {
+  name               = "allow-any-traffic"
+  firewall_policy_id = azurerm_firewall_policy.explicit_proxy_policy.id
+  priority           = 100
+
+  network_rule_collection {
+    name     = "allow-all"
+    action   = "Allow"
+    priority = 100
+
+    rule {
+      name                  = "allow-all"
+      protocols             = ["Any"]
+      source_addresses      = ["*"]
+      destination_addresses = ["*"]
+      destination_ports     = ["80", "443"]
+    }
+  }
+
+  application_rule_collection {
+    name = "allow-traffic"
+    action = "Allow"
+    priority =  200
+
+    rule {
+      name = "allow-cast"
+      protocols {
+        port = "80"
+        type = "Http"
+      }
+      protocols {
+        port = "443"
+        type = "Https"
+      }
+      source_addresses = ["*"]
+      destination_fqdns = [ "api.cast.ai", "cast.ai", "storage.googleapis.com" ]
+    }
+
+    # Uncomment to allow all traffic
+    # rule {
+    #   name = "allow-all"
+    #   protocols {
+    #     port = "80"
+    #     type = "Http"
+    #   }
+    #   protocols {
+    #     port = "443"
+    #     type = "Https"
+    #   }
+    #   source_addresses = ["*"]
+    #   destination_fqdns = [ "*" ]
+    # }
+  }
+}
+

--- a/examples/aks/aks_cluster_with_proxy/tf.vars.example
+++ b/examples/aks/aks_cluster_with_proxy/tf.vars.example
@@ -1,0 +1,4 @@
+cluster_name     = "EXAMPLE"
+cluster_region   = "EXAMPLE"
+castai_api_token = "EXAMPLE"
+subscription_id  = "<place-holder>"

--- a/examples/aks/aks_cluster_with_proxy/tf.vars.example
+++ b/examples/aks/aks_cluster_with_proxy/tf.vars.example
@@ -2,3 +2,4 @@ cluster_name     = "EXAMPLE"
 cluster_region   = "EXAMPLE"
 castai_api_token = "EXAMPLE"
 subscription_id  = "<place-holder>"
+fqdn_without_proxy = [fqdn1", "fqdn2"]

--- a/examples/aks/aks_cluster_with_proxy/variables.tf
+++ b/examples/aks/aks_cluster_with_proxy/variables.tf
@@ -24,6 +24,12 @@ variable "castai_api_token" {
   description = "CAST AI API token created in console.cast.ai API Access keys section."
 }
 
+variable "castai_grpc_url" {
+  type        = string
+  description = "CAST AI gRPC URL"
+  default     = "grpc.cast.ai:443"
+}
+
 variable "subscription_id" {
   type        = string
   description = "Azure subscription ID"

--- a/examples/aks/aks_cluster_with_proxy/variables.tf
+++ b/examples/aks/aks_cluster_with_proxy/variables.tf
@@ -1,0 +1,36 @@
+variable "cluster_name" {
+  type        = string
+  description = "Name of the AKS cluster to be connected to the CAST AI."
+}
+
+variable "cluster_region" {
+  type        = string
+  description = "Region of the cluster to be connected to CAST AI."
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Name of Azure Resource group that will be created for the cluster."
+}
+
+variable "castai_api_url" {
+  type        = string
+  description = "CAST AI url to API, default value is https://api.cast.ai"
+  default     = "https://api.cast.ai"
+}
+
+variable "castai_api_token" {
+  type        = string
+  description = "CAST AI API token created in console.cast.ai API Access keys section."
+}
+
+variable "subscription_id" {
+  type        = string
+  description = "Azure subscription ID"
+}
+
+variable "fqdn_without_proxy" {
+  type = list(string)
+  description = "FQDNs that will be allowed on the AKS egress firewall and will not require proxy setup."
+  default = []
+}

--- a/examples/aks/aks_cluster_with_proxy/versions.tf
+++ b/examples/aks/aks_cluster_with_proxy/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    azuread = {
+      source = "hashicorp/azuread"
+    }
+    castai = {
+      source = "castai/castai"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
Settings are passed at cluster level and used for log sender, init data gatherer, bootstrap token, etc. 

Also includes an example that deploys cluster with restricted network that _requires_ the proxy setup or Cast will not deploy or work properly. 