### PR TITLE
KUBE-856: Add http proxy settings to AKS 

### DIFF
--- a/castai/resource_aks_cluster.go
+++ b/castai/resource_aks_cluster.go
@@ -109,7 +109,7 @@ func resourceAKSCluster() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				MaxItems:    1,
-				Description: "HTTP proxy configuration for Cast nodes and node components.",
+				Description: "HTTP proxy configuration for CAST AI nodes and node components.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						FieldAKSHttpProxyDestination: {

--- a/castai/resource_aks_cluster.go
+++ b/castai/resource_aks_cluster.go
@@ -176,16 +176,20 @@ func resourceCastaiAKSClusterRead(ctx context.Context, data *schema.ResourceData
 		if err := data.Set(FieldAKSClusterRegion, toString(aks.Region)); err != nil {
 			return diag.FromErr(fmt.Errorf("setting region: %w", err))
 		}
+
+		var proxyConfig []any
 		if aks.HttpProxyConfig != nil {
-			if err := data.Set(FieldAKSHttpProxyConfig, []any{
+			proxyConfig = []any{
 				map[string]any{
-					FieldAKSHttpProxyConfig:       lo.FromPtr(aks.HttpProxyConfig.HttpProxy),
+					FieldAKSHttpProxyDestination:  lo.FromPtr(aks.HttpProxyConfig.HttpProxy),
 					FieldAKSHttpsProxyDestination: lo.FromPtr(aks.HttpProxyConfig.HttpsProxy),
 					FieldAKSNoProxyDestinations:   lo.FromPtr(aks.HttpProxyConfig.NoProxy),
 				},
-			}); err != nil {
-				return diag.FromErr(fmt.Errorf("setting http proxy config: %w", err))
 			}
+		}
+
+		if err := data.Set(FieldAKSHttpProxyConfig, proxyConfig); err != nil {
+			return diag.FromErr(fmt.Errorf("setting http proxy config: %w", err))
 		}
 	}
 

--- a/castai/resource_aks_cluster_test.go
+++ b/castai/resource_aks_cluster_test.go
@@ -3,6 +3,7 @@ package castai
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/castai/terraform-provider-castai/castai/sdk"
@@ -50,7 +52,14 @@ func TestAKSClusterResourceReadContext(t *testing.T) {
 					"networkPlugin": "calico",
 					"nodeResourceGroup": "ng",
 					"region": "westeurope",
-					"subscriptionId": "subID"
+					"subscriptionId": "subID",
+					"httpProxyConfig": {
+						  "httpProxy": "http-proxy",
+						  "httpsProxy": "https-proxy",
+						  "noProxy": [
+							"domain1", "domain2"
+						  ]
+						}
 				  },
 				  "clusterNameId": "aks-cluster-b6bfc074",
 				  "private": true
@@ -74,6 +83,70 @@ func TestAKSClusterResourceReadContext(t *testing.T) {
 		r.False(result.HasError())
 		r.Equal(`ID = b6bfc074-a267-400f-b8f1-db0850c369b1
 credentials_id = 9b8d0456-177b-4a3d-b162-e68030d656aa
+http_proxy_config.# = 1
+http_proxy_config.0.http_proxy = http-proxy
+http_proxy_config.0.https_proxy = https-proxy
+http_proxy_config.0.no_proxy.# = 2
+http_proxy_config.0.no_proxy.0 = domain1
+http_proxy_config.0.no_proxy.1 = domain2
+region = westeurope
+Tainted = false
+`, data.State().String())
+	})
+
+	t.Run("when proxy config is reset remotely, shows drift", func(t *testing.T) {
+		r := require.New(t)
+		mockctrl := gomock.NewController(t)
+		mockClient := mock_sdk.NewMockClientInterface(mockctrl)
+		provider := &ProviderConfig{
+			api: &sdk.ClientWithResponses{
+				ClientInterface: mockClient,
+			},
+		}
+
+		body := io.NopCloser(bytes.NewReader([]byte(`{
+				  "id": "b6bfc074-a267-400f-b8f1-db0850c369b1",
+				  "name": "aks-cluster",
+				  "organizationId": "2836f775-aaaa-eeee-bbbb-3d3c29512692",
+				  "credentialsId": "9b8d0456-177b-4a3d-b162-e68030d656aa",
+				  "createdAt": "2022-01-27T19:03:31.570829Z",
+				  "status": "ready",
+				  "agentSnapshotReceivedAt": "2022-03-21T10:33:56.192020Z",
+				  "agentStatus": "online",
+				  "providerType": "aks",
+				  "aks": {
+					"maxPodsPerNode": 100,
+					"networkPlugin": "calico",
+					"nodeResourceGroup": "ng",
+					"region": "westeurope",
+					"subscriptionId": "subID"
+				  },
+				  "clusterNameId": "aks-cluster-b6bfc074",
+				  "private": true
+				}`)))
+		mockClient.EXPECT().
+			ExternalClusterAPIGetCluster(gomock.Any(), clusterID).
+			Return(&http.Response{StatusCode: 200, Body: body, Header: map[string][]string{"Content-Type": {"json"}}}, nil)
+
+		aksResource := resourceAKSCluster()
+
+		val := cty.ObjectVal(map[string]cty.Value{
+			FieldAKSHttpProxyConfig: cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					FieldAKSHttpProxyDestination: cty.StringVal("http-proxy"),
+				}),
+			}),
+		})
+		state := terraform.NewInstanceStateShimmedFromValue(val, 0)
+
+		data := aksResource.Data(state)
+		result := aksResource.ReadContext(ctx, data, provider)
+		r.Nil(result)
+		r.False(result.HasError())
+		// Note: even if the array for proxy is nil, terraform saves the length so we still have _some_ state about it below.
+		r.Equal(`ID = b6bfc074-a267-400f-b8f1-db0850c369b1
+credentials_id = 9b8d0456-177b-4a3d-b162-e68030d656aa
+http_proxy_config.# = 0
 region = westeurope
 Tainted = false
 `, data.State().String())
@@ -269,6 +342,69 @@ func TestAKSClusterResourceUpdateContext(t *testing.T) {
 			r.NotEqual(credentialsID, valueAfter)
 			r.Contains(valueAfter, "drift")
 		})
+	})
+
+	t.Run("Saves proxy settings correctly", func(t *testing.T) {
+		r := require.New(t)
+		mockctrl := gomock.NewController(t)
+		mockClient := mock_sdk.NewMockClientInterface(mockctrl)
+		provider := &ProviderConfig{
+			api: &sdk.ClientWithResponses{
+				ClientInterface: mockClient,
+			},
+		}
+
+		expectedHttpProxySettings := &sdk.ExternalClusterAPIUpdateClusterJSONRequestBody{
+			Aks: &sdk.ExternalclusterV1UpdateAKSClusterParams{
+				HttpProxyConfig: &sdk.ExternalclusterV1HttpProxyConfig{
+					HttpProxy:  lo.ToPtr("http-proxy"),
+					HttpsProxy: lo.ToPtr("https-proxy"),
+					NoProxy:    lo.ToPtr([]string{"domain1", "domain2"}),
+				},
+			},
+		}
+		jsonHttpProxy, err := json.Marshal(expectedHttpProxySettings)
+		r.NoError(err)
+
+		readResponse := io.NopCloser(bytes.NewReader([]byte(`{"credentialsId": ""}`)))
+		updateResponse := io.NopCloser(bytes.NewReader(jsonHttpProxy))
+		mockClient.EXPECT().
+			ExternalClusterAPIGetCluster(gomock.Any(), clusterID).
+			Return(&http.Response{StatusCode: 200, Body: readResponse, Header: map[string][]string{"Content-Type": {"json"}}}, nil)
+		mockClient.EXPECT().
+			ExternalClusterAPIUpdateCluster(gomock.Any(), clusterID, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, body sdk.ExternalClusterAPIUpdateClusterJSONRequestBody) (*http.Response, error) {
+				r.Equal(expectedHttpProxySettings.Aks.HttpProxyConfig.HttpsProxy, body.Aks.HttpProxyConfig.HttpsProxy)
+				r.Equal(expectedHttpProxySettings.Aks.HttpProxyConfig.HttpProxy, body.Aks.HttpProxyConfig.HttpProxy)
+				r.ElementsMatch(*expectedHttpProxySettings.Aks.HttpProxyConfig.NoProxy, *body.Aks.HttpProxyConfig.NoProxy)
+				return &http.Response{StatusCode: 200, Body: updateResponse, Header: map[string][]string{"Content-Type": {"json"}}}, nil
+			})
+
+		aksResource := resourceAKSCluster()
+
+		diff := map[string]any{
+			FieldAKSHttpProxyConfig: []any{
+				map[string]any{
+					FieldAKSHttpProxyDestination:  "http-proxy",
+					FieldAKSHttpsProxyDestination: "https-proxy",
+					FieldAKSNoProxyDestinations:   []any{"domain1", "domain2"},
+				},
+			},
+		}
+		data := schema.TestResourceDataRaw(t, aksResource.Schema, diff)
+		data.SetId(clusterID)
+		diagnostics := aksResource.UpdateContext(ctx, data, provider)
+
+		r.Empty(diagnostics)
+
+		// Validate that the settings are populated in state as expected.
+		stateProxyConfig := data.Get(FieldAKSHttpProxyConfig).([]any)
+		r.NotNil(stateProxyConfig)
+		r.Len(stateProxyConfig, 1)
+		proxyConfigElem := stateProxyConfig[0].(map[string]any)
+		r.Equal(proxyConfigElem[FieldAKSHttpProxyDestination], *expectedHttpProxySettings.Aks.HttpProxyConfig.HttpProxy)
+		r.Equal(proxyConfigElem[FieldAKSHttpsProxyDestination], *expectedHttpProxySettings.Aks.HttpProxyConfig.HttpsProxy)
+		r.ElementsMatch(proxyConfigElem[FieldAKSNoProxyDestinations], *expectedHttpProxySettings.Aks.HttpProxyConfig.NoProxy)
 	})
 }
 

--- a/castai/resource_aks_cluster_test.go
+++ b/castai/resource_aks_cluster_test.go
@@ -138,6 +138,10 @@ Tainted = false
 			}),
 		})
 		state := terraform.NewInstanceStateShimmedFromValue(val, 0)
+		state.ID = clusterID
+		// If local credentials don't match remote, drift detection would trigger.
+		// If local state has no credentials but remote has them, then the drift does exist so - there is separate test for that.
+		state.Attributes[FieldClusterCredentialsId] = "9b8d0456-177b-4a3d-b162-e68030d656aa"
 
 		data := aksResource.Data(state)
 		result := aksResource.ReadContext(ctx, data, provider)

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -123,6 +123,12 @@ const (
 	Ssd     CastaiInventoryV1beta1StorageInfoDeviceType = "ssd"
 )
 
+// Defines values for CastaiRbacV1beta1Effects.
+const (
+	ALLOW CastaiRbacV1beta1Effects = "ALLOW"
+	DENY  CastaiRbacV1beta1Effects = "DENY"
+)
+
 // Defines values for CastaiRbacV1beta1Kind.
 const (
 	SERVICEACCOUNT CastaiRbacV1beta1Kind = "SERVICE_ACCOUNT"
@@ -1508,6 +1514,9 @@ type CastaiRbacV1beta1DeleteGroupResponse = map[string]interface{}
 // CastaiRbacV1beta1DeleteRoleBindingResponse defines model for castai.rbac.v1beta1.DeleteRoleBindingResponse.
 type CastaiRbacV1beta1DeleteRoleBindingResponse = map[string]interface{}
 
+// Effects represent the effect of a permission.
+type CastaiRbacV1beta1Effects string
+
 // CastaiRbacV1beta1Group defines model for castai.rbac.v1beta1.Group.
 type CastaiRbacV1beta1Group struct {
 	// CreatedAt is the timestamp when the group was created.
@@ -1553,6 +1562,22 @@ type CastaiRbacV1beta1GroupSubject struct {
 // Kind represents the type of the member.
 type CastaiRbacV1beta1Kind string
 
+// CastaiRbacV1beta1ListRoleBindingsResponse defines model for castai.rbac.v1beta1.ListRoleBindingsResponse.
+type CastaiRbacV1beta1ListRoleBindingsResponse struct {
+	// Page defines how many and which fields should be returned.
+	NextPage     CastaiPaginationV1beta1Page     `json:"nextPage"`
+	RoleBindings *[]CastaiRbacV1beta1RoleBinding `json:"roleBindings,omitempty"`
+	TotalCount   *string                         `json:"totalCount,omitempty"`
+}
+
+// CastaiRbacV1beta1ListRolesResponse defines model for castai.rbac.v1beta1.ListRolesResponse.
+type CastaiRbacV1beta1ListRolesResponse struct {
+	// Page defines how many and which fields should be returned.
+	NextPage   *CastaiPaginationV1beta1Page `json:"nextPage,omitempty"`
+	Roles      *[]CastaiRbacV1beta1Role     `json:"roles,omitempty"`
+	TotalCount *string                      `json:"totalCount,omitempty"`
+}
+
 // CastaiRbacV1beta1Member defines model for castai.rbac.v1beta1.Member.
 type CastaiRbacV1beta1Member struct {
 	// AddedAt is the timestamp when the user has been added to the group.
@@ -1577,6 +1602,14 @@ type CastaiRbacV1beta1OrganizationScope struct {
 	Id string `json:"id"`
 }
 
+// CastaiRbacV1beta1Permissions defines model for castai.rbac.v1beta1.Permissions.
+type CastaiRbacV1beta1Permissions struct {
+	// Effects represent the effect of a permission.
+	Effect    CastaiRbacV1beta1Effects `json:"effect"`
+	Endpoints *[]string                `json:"endpoints,omitempty"`
+	Groups    *[]string                `json:"groups,omitempty"`
+}
+
 // PoliciesState represents the state of the policies generation.
 //
 //   - ACCEPTED: ACCEPTED is the state when the policies async generation is ongoing.
@@ -1594,6 +1627,35 @@ type CastaiRbacV1beta1PolicyID struct {
 type CastaiRbacV1beta1ResourceScope struct {
 	// ID is the unique identifier of the resource.
 	Id string `json:"id"`
+}
+
+// CastaiRbacV1beta1Role defines model for castai.rbac.v1beta1.Role.
+type CastaiRbacV1beta1Role struct {
+	// CreatedAt is the timestamp when the role was created.
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
+
+	// Default is a flag that indicates if the role is a default role.
+	Default    *bool                           `json:"default,omitempty"`
+	Definition CastaiRbacV1beta1RoleDefinition `json:"definition"`
+
+	// Deprecated is a flag that indicates if the role is deprecated.
+	Deprecated *bool `json:"deprecated,omitempty"`
+
+	// Description is the description of the role.
+	Description *string `json:"description,omitempty"`
+	Id          *string `json:"id,omitempty"`
+
+	// Priority level of the role (higher is more important).
+	Level *int32 `json:"level,omitempty"`
+
+	// Name is the name of the role.
+	Name *string `json:"name,omitempty"`
+
+	// OrganizationID is the unique identifier of the organization.
+	OrganizationId *string `json:"organizationId,omitempty"`
+
+	// UpdatedAt is the timestamp when the role was last updated.
+	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
 }
 
 // CastaiRbacV1beta1RoleBinding defines model for castai.rbac.v1beta1.RoleBinding.
@@ -1653,6 +1715,12 @@ type CastaiRbacV1beta1RoleBindingStatus struct {
 
 	// UpdatedAt is the timestamp when the status was last updated.
 	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+}
+
+// CastaiRbacV1beta1RoleDefinition defines model for castai.rbac.v1beta1.RoleDefinition.
+type CastaiRbacV1beta1RoleDefinition struct {
+	// Permissions is a list of permissions.
+	Permissions *[]CastaiRbacV1beta1Permissions `json:"permissions,omitempty"`
 }
 
 // Scope represents the scope of the role binding.
@@ -2255,6 +2323,13 @@ type CastaiUsersV1beta1UserOrganization struct {
 
 	// name of the organization.
 	Name string `json:"name"`
+
+	// Deprecated: for RBACv2 user can be bound to multiple roles.
+	// Use https://docs.cast.ai/reference/rbacserviceapi instead.
+	// user role in the organization.
+	//
+	// TODO: cleanup once all orgs are migrated to RBACv2
+	//  https://castai.atlassian.net/browse/WIRE-954
 	Role string `json:"role"`
 }
 
@@ -4166,9 +4241,26 @@ type WorkloadoptimizationV1AntiAffinitySettings struct {
 
 // WorkloadoptimizationV1ApplyThresholdStrategy defines model for workloadoptimization.v1.ApplyThresholdStrategy.
 type WorkloadoptimizationV1ApplyThresholdStrategy struct {
+	CustomAdaptiveThreshold  *WorkloadoptimizationV1ApplyThresholdStrategyCustomAdaptiveThreshold  `json:"customAdaptiveThreshold,omitempty"`
+	DefaultAdaptiveThreshold *WorkloadoptimizationV1ApplyThresholdStrategyDefaultAdaptiveThreshold `json:"defaultAdaptiveThreshold,omitempty"`
+
 	// PercentageThreshold is the percentage for the apply threshold strategy.
 	PercentageThreshold *WorkloadoptimizationV1ApplyThresholdStrategyPercentageThreshold `json:"percentageThreshold,omitempty"`
 }
+
+// WorkloadoptimizationV1ApplyThresholdStrategyCustomAdaptiveThreshold defines model for workloadoptimization.v1.ApplyThresholdStrategy.CustomAdaptiveThreshold.
+type WorkloadoptimizationV1ApplyThresholdStrategyCustomAdaptiveThreshold struct {
+	// If value is close or equal to 0, the threshold will be much bigger for small values.
+	// For example when numerator, exponent is 1 and denominator is 0 the threshold for 0.5 req. CPU will be 200%.
+	Denominator float64 `json:"denominator"`
+	Exponent    float64 `json:"exponent"`
+
+	// It affects vertical stretch of function - smaller number will create smaller threshold.
+	Numerator float64 `json:"numerator"`
+}
+
+// WorkloadoptimizationV1ApplyThresholdStrategyDefaultAdaptiveThreshold defines model for workloadoptimization.v1.ApplyThresholdStrategy.DefaultAdaptiveThreshold.
+type WorkloadoptimizationV1ApplyThresholdStrategyDefaultAdaptiveThreshold = map[string]interface{}
 
 // PercentageThreshold is the percentage for the apply threshold strategy.
 type WorkloadoptimizationV1ApplyThresholdStrategyPercentageThreshold struct {
@@ -5203,11 +5295,30 @@ type InventoryAPIAddReservationJSONBody = CastaiInventoryV1beta1GenericReservati
 // InventoryAPIOverwriteReservationsJSONBody defines parameters for InventoryAPIOverwriteReservations.
 type InventoryAPIOverwriteReservationsJSONBody = CastaiInventoryV1beta1GenericReservationsList
 
+// RbacServiceAPIListRoleBindingsParams defines parameters for RbacServiceAPIListRoleBindings.
+type RbacServiceAPIListRoleBindingsParams struct {
+	PageLimit *string `form:"page.limit,omitempty" json:"page.limit,omitempty"`
+
+	// Cursor that defines token indicating where to start the next page.
+	// Empty value indicates to start from beginning of the dataset.
+	PageCursor *string `form:"page.cursor,omitempty" json:"page.cursor,omitempty"`
+	RoleId     *string `form:"roleId,omitempty" json:"roleId,omitempty"`
+}
+
 // RbacServiceAPICreateRoleBindingsJSONBody defines parameters for RbacServiceAPICreateRoleBindings.
 type RbacServiceAPICreateRoleBindingsJSONBody = []CastaiRbacV1beta1CreateRoleBindingsRequestRoleBinding
 
 // RbacServiceAPIUpdateRoleBindingJSONBody defines parameters for RbacServiceAPIUpdateRoleBinding.
 type RbacServiceAPIUpdateRoleBindingJSONBody = RoleBindingIsTheRoleBindingToBeUpdated
+
+// RbacServiceAPIListRolesParams defines parameters for RbacServiceAPIListRoles.
+type RbacServiceAPIListRolesParams struct {
+	PageLimit *string `form:"page.limit,omitempty" json:"page.limit,omitempty"`
+
+	// Cursor that defines token indicating where to start the next page.
+	// Empty value indicates to start from beginning of the dataset.
+	PageCursor *string `form:"page.cursor,omitempty" json:"page.cursor,omitempty"`
+}
 
 // ServiceAccountsAPIDeleteServiceAccountsParams defines parameters for ServiceAccountsAPIDeleteServiceAccounts.
 type ServiceAccountsAPIDeleteServiceAccountsParams struct {

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -417,6 +417,9 @@ type ClientInterface interface {
 	// InventoryAPIDeleteReservation request
 	InventoryAPIDeleteReservation(ctx context.Context, organizationId string, reservationId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// RbacServiceAPIListRoleBindings request
+	RbacServiceAPIListRoleBindings(ctx context.Context, organizationId string, params *RbacServiceAPIListRoleBindingsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// RbacServiceAPICreateRoleBindings request with any body
 	RbacServiceAPICreateRoleBindingsWithBody(ctx context.Context, organizationId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -432,6 +435,9 @@ type ClientInterface interface {
 	RbacServiceAPIUpdateRoleBindingWithBody(ctx context.Context, organizationId string, roleBindingId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	RbacServiceAPIUpdateRoleBinding(ctx context.Context, organizationId string, roleBindingId string, body RbacServiceAPIUpdateRoleBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RbacServiceAPIListRoles request
+	RbacServiceAPIListRoles(ctx context.Context, organizationId string, params *RbacServiceAPIListRolesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ServiceAccountsAPIDeleteServiceAccounts request
 	ServiceAccountsAPIDeleteServiceAccounts(ctx context.Context, organizationId string, params *ServiceAccountsAPIDeleteServiceAccountsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2087,6 +2093,18 @@ func (c *Client) InventoryAPIDeleteReservation(ctx context.Context, organization
 	return c.Client.Do(req)
 }
 
+func (c *Client) RbacServiceAPIListRoleBindings(ctx context.Context, organizationId string, params *RbacServiceAPIListRoleBindingsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRbacServiceAPIListRoleBindingsRequest(c.Server, organizationId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) RbacServiceAPICreateRoleBindingsWithBody(ctx context.Context, organizationId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRbacServiceAPICreateRoleBindingsRequestWithBody(c.Server, organizationId, contentType, body)
 	if err != nil {
@@ -2149,6 +2167,18 @@ func (c *Client) RbacServiceAPIUpdateRoleBindingWithBody(ctx context.Context, or
 
 func (c *Client) RbacServiceAPIUpdateRoleBinding(ctx context.Context, organizationId string, roleBindingId string, body RbacServiceAPIUpdateRoleBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRbacServiceAPIUpdateRoleBindingRequest(c.Server, organizationId, roleBindingId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RbacServiceAPIListRoles(ctx context.Context, organizationId string, params *RbacServiceAPIListRolesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRbacServiceAPIListRolesRequest(c.Server, organizationId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -7167,6 +7197,92 @@ func NewInventoryAPIDeleteReservationRequest(server string, organizationId strin
 	return req, nil
 }
 
+// NewRbacServiceAPIListRoleBindingsRequest generates requests for RbacServiceAPIListRoleBindings
+func NewRbacServiceAPIListRoleBindingsRequest(server string, organizationId string, params *RbacServiceAPIListRoleBindingsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "organizationId", runtime.ParamLocationPath, organizationId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/organizations/%s/role-bindings", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.PageLimit != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.limit", runtime.ParamLocationQuery, *params.PageLimit); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.PageCursor != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.cursor", runtime.ParamLocationQuery, *params.PageCursor); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.RoleId != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "roleId", runtime.ParamLocationQuery, *params.RoleId); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewRbacServiceAPICreateRoleBindingsRequest calls the generic RbacServiceAPICreateRoleBindings builder with application/json body
 func NewRbacServiceAPICreateRoleBindingsRequest(server string, organizationId string, body RbacServiceAPICreateRoleBindingsJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -7346,6 +7462,76 @@ func NewRbacServiceAPIUpdateRoleBindingRequestWithBody(server string, organizati
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewRbacServiceAPIListRolesRequest generates requests for RbacServiceAPIListRoles
+func NewRbacServiceAPIListRolesRequest(server string, organizationId string, params *RbacServiceAPIListRolesParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "organizationId", runtime.ParamLocationPath, organizationId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/organizations/%s/roles", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.PageLimit != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.limit", runtime.ParamLocationQuery, *params.PageLimit); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.PageCursor != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.cursor", runtime.ParamLocationQuery, *params.PageCursor); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -10542,6 +10728,9 @@ type ClientWithResponsesInterface interface {
 	// InventoryAPIDeleteReservation request
 	InventoryAPIDeleteReservationWithResponse(ctx context.Context, organizationId string, reservationId string) (*InventoryAPIDeleteReservationResponse, error)
 
+	// RbacServiceAPIListRoleBindings request
+	RbacServiceAPIListRoleBindingsWithResponse(ctx context.Context, organizationId string, params *RbacServiceAPIListRoleBindingsParams) (*RbacServiceAPIListRoleBindingsResponse, error)
+
 	// RbacServiceAPICreateRoleBindings request  with any body
 	RbacServiceAPICreateRoleBindingsWithBodyWithResponse(ctx context.Context, organizationId string, contentType string, body io.Reader) (*RbacServiceAPICreateRoleBindingsResponse, error)
 
@@ -10557,6 +10746,9 @@ type ClientWithResponsesInterface interface {
 	RbacServiceAPIUpdateRoleBindingWithBodyWithResponse(ctx context.Context, organizationId string, roleBindingId string, contentType string, body io.Reader) (*RbacServiceAPIUpdateRoleBindingResponse, error)
 
 	RbacServiceAPIUpdateRoleBindingWithResponse(ctx context.Context, organizationId string, roleBindingId string, body RbacServiceAPIUpdateRoleBindingJSONRequestBody) (*RbacServiceAPIUpdateRoleBindingResponse, error)
+
+	// RbacServiceAPIListRoles request
+	RbacServiceAPIListRolesWithResponse(ctx context.Context, organizationId string, params *RbacServiceAPIListRolesParams) (*RbacServiceAPIListRolesResponse, error)
 
 	// ServiceAccountsAPIDeleteServiceAccounts request
 	ServiceAccountsAPIDeleteServiceAccountsWithResponse(ctx context.Context, organizationId string, params *ServiceAccountsAPIDeleteServiceAccountsParams) (*ServiceAccountsAPIDeleteServiceAccountsResponse, error)
@@ -13389,6 +13581,36 @@ func (r InventoryAPIDeleteReservationResponse) GetBody() []byte {
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
+type RbacServiceAPIListRoleBindingsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CastaiRbacV1beta1ListRoleBindingsResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r RbacServiceAPIListRoleBindingsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RbacServiceAPIListRoleBindingsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r RbacServiceAPIListRoleBindingsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
 type RbacServiceAPICreateRoleBindingsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -13504,6 +13726,36 @@ func (r RbacServiceAPIUpdateRoleBindingResponse) StatusCode() int {
 // TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 // Body returns body of byte array
 func (r RbacServiceAPIUpdateRoleBindingResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
+type RbacServiceAPIListRolesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CastaiRbacV1beta1ListRolesResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r RbacServiceAPIListRolesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RbacServiceAPIListRolesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r RbacServiceAPIListRolesResponse) GetBody() []byte {
 	return r.Body
 }
 
@@ -16325,6 +16577,15 @@ func (c *ClientWithResponses) InventoryAPIDeleteReservationWithResponse(ctx cont
 	return ParseInventoryAPIDeleteReservationResponse(rsp)
 }
 
+// RbacServiceAPIListRoleBindingsWithResponse request returning *RbacServiceAPIListRoleBindingsResponse
+func (c *ClientWithResponses) RbacServiceAPIListRoleBindingsWithResponse(ctx context.Context, organizationId string, params *RbacServiceAPIListRoleBindingsParams) (*RbacServiceAPIListRoleBindingsResponse, error) {
+	rsp, err := c.RbacServiceAPIListRoleBindings(ctx, organizationId, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRbacServiceAPIListRoleBindingsResponse(rsp)
+}
+
 // RbacServiceAPICreateRoleBindingsWithBodyWithResponse request with arbitrary body returning *RbacServiceAPICreateRoleBindingsResponse
 func (c *ClientWithResponses) RbacServiceAPICreateRoleBindingsWithBodyWithResponse(ctx context.Context, organizationId string, contentType string, body io.Reader) (*RbacServiceAPICreateRoleBindingsResponse, error) {
 	rsp, err := c.RbacServiceAPICreateRoleBindingsWithBody(ctx, organizationId, contentType, body)
@@ -16375,6 +16636,15 @@ func (c *ClientWithResponses) RbacServiceAPIUpdateRoleBindingWithResponse(ctx co
 		return nil, err
 	}
 	return ParseRbacServiceAPIUpdateRoleBindingResponse(rsp)
+}
+
+// RbacServiceAPIListRolesWithResponse request returning *RbacServiceAPIListRolesResponse
+func (c *ClientWithResponses) RbacServiceAPIListRolesWithResponse(ctx context.Context, organizationId string, params *RbacServiceAPIListRolesParams) (*RbacServiceAPIListRolesResponse, error) {
+	rsp, err := c.RbacServiceAPIListRoles(ctx, organizationId, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRbacServiceAPIListRolesResponse(rsp)
 }
 
 // ServiceAccountsAPIDeleteServiceAccountsWithResponse request returning *ServiceAccountsAPIDeleteServiceAccountsResponse
@@ -19294,6 +19564,32 @@ func ParseInventoryAPIDeleteReservationResponse(rsp *http.Response) (*InventoryA
 	return response, nil
 }
 
+// ParseRbacServiceAPIListRoleBindingsResponse parses an HTTP response from a RbacServiceAPIListRoleBindingsWithResponse call
+func ParseRbacServiceAPIListRoleBindingsResponse(rsp *http.Response) (*RbacServiceAPIListRoleBindingsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RbacServiceAPIListRoleBindingsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CastaiRbacV1beta1ListRoleBindingsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseRbacServiceAPICreateRoleBindingsResponse parses an HTTP response from a RbacServiceAPICreateRoleBindingsWithResponse call
 func ParseRbacServiceAPICreateRoleBindingsResponse(rsp *http.Response) (*RbacServiceAPICreateRoleBindingsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -19388,6 +19684,32 @@ func ParseRbacServiceAPIUpdateRoleBindingResponse(rsp *http.Response) (*RbacServ
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest CastaiRbacV1beta1RoleBinding
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRbacServiceAPIListRolesResponse parses an HTTP response from a RbacServiceAPIListRolesWithResponse call
+func ParseRbacServiceAPIListRolesResponse(rsp *http.Response) (*RbacServiceAPIListRolesResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RbacServiceAPIListRolesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CastaiRbacV1beta1ListRolesResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -2435,6 +2435,46 @@ func (mr *MockClientInterfaceMockRecorder) RbacServiceAPIGetRoleBinding(ctx, org
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIGetRoleBinding", reflect.TypeOf((*MockClientInterface)(nil).RbacServiceAPIGetRoleBinding), varargs...)
 }
 
+// RbacServiceAPIListRoleBindings mocks base method.
+func (m *MockClientInterface) RbacServiceAPIListRoleBindings(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRoleBindingsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRoleBindings", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRoleBindings indicates an expected call of RbacServiceAPIListRoleBindings.
+func (mr *MockClientInterfaceMockRecorder) RbacServiceAPIListRoleBindings(ctx, organizationId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRoleBindings", reflect.TypeOf((*MockClientInterface)(nil).RbacServiceAPIListRoleBindings), varargs...)
+}
+
+// RbacServiceAPIListRoles mocks base method.
+func (m *MockClientInterface) RbacServiceAPIListRoles(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRolesParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRoles", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRoles indicates an expected call of RbacServiceAPIListRoles.
+func (mr *MockClientInterfaceMockRecorder) RbacServiceAPIListRoles(ctx, organizationId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRoles", reflect.TypeOf((*MockClientInterface)(nil).RbacServiceAPIListRoles), varargs...)
+}
+
 // RbacServiceAPIUpdateGroup mocks base method.
 func (m *MockClientInterface) RbacServiceAPIUpdateGroup(ctx context.Context, organizationId, groupId string, body sdk.RbacServiceAPIUpdateGroupJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -8286,6 +8326,76 @@ func (m *MockClientWithResponsesInterface) RbacServiceAPIGetRoleBindingWithRespo
 func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIGetRoleBindingWithResponse(ctx, organizationId, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIGetRoleBindingWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIGetRoleBindingWithResponse), ctx, organizationId, id)
+}
+
+// RbacServiceAPIListRoleBindings mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIListRoleBindings(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRoleBindingsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRoleBindings", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRoleBindings indicates an expected call of RbacServiceAPIListRoleBindings.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIListRoleBindings(ctx, organizationId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRoleBindings", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIListRoleBindings), varargs...)
+}
+
+// RbacServiceAPIListRoleBindingsWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIListRoleBindingsWithResponse(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRoleBindingsParams) (*sdk.RbacServiceAPIListRoleBindingsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRoleBindingsWithResponse", ctx, organizationId, params)
+	ret0, _ := ret[0].(*sdk.RbacServiceAPIListRoleBindingsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRoleBindingsWithResponse indicates an expected call of RbacServiceAPIListRoleBindingsWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIListRoleBindingsWithResponse(ctx, organizationId, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRoleBindingsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIListRoleBindingsWithResponse), ctx, organizationId, params)
+}
+
+// RbacServiceAPIListRoles mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIListRoles(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRolesParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRoles", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRoles indicates an expected call of RbacServiceAPIListRoles.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIListRoles(ctx, organizationId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRoles", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIListRoles), varargs...)
+}
+
+// RbacServiceAPIListRolesWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIListRolesWithResponse(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRolesParams) (*sdk.RbacServiceAPIListRolesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRolesWithResponse", ctx, organizationId, params)
+	ret0, _ := ret[0].(*sdk.RbacServiceAPIListRolesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRolesWithResponse indicates an expected call of RbacServiceAPIListRolesWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIListRolesWithResponse(ctx, organizationId, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRolesWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIListRolesWithResponse), ctx, organizationId, params)
 }
 
 // RbacServiceAPIUpdateGroup mocks base method.

--- a/docs/resources/aks_cluster.md
+++ b/docs/resources/aks_cluster.md
@@ -44,6 +44,7 @@ resource "castai_aks_cluster" "this" {
 ### Optional
 
 - `delete_nodes_on_disconnect` (Boolean) Should CAST AI remove nodes managed by CAST.AI on disconnect.
+- `http_proxy_config` (Block List, Max: 1) HTTP proxy configuration for Cast nodes and node components. (see [below for nested schema](#nestedblock--http_proxy_config))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -51,6 +52,16 @@ resource "castai_aks_cluster" "this" {
 - `cluster_token` (String, Sensitive) CAST AI cluster token.
 - `credentials_id` (String) CAST AI internal credentials ID
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--http_proxy_config"></a>
+### Nested Schema for `http_proxy_config`
+
+Optional:
+
+- `http_proxy` (String) Address to use for proxying HTTP requests.
+- `https_proxy` (String) Address to use for proxying HTTPS/TLS requests.
+- `no_proxy` (List of String) List of destinations that should not go through proxy.
+
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/resources/aks_cluster.md
+++ b/docs/resources/aks_cluster.md
@@ -44,7 +44,7 @@ resource "castai_aks_cluster" "this" {
 ### Optional
 
 - `delete_nodes_on_disconnect` (Boolean) Should CAST AI remove nodes managed by CAST.AI on disconnect.
-- `http_proxy_config` (Block List, Max: 1) HTTP proxy configuration for Cast nodes and node components. (see [below for nested schema](#nestedblock--http_proxy_config))
+- `http_proxy_config` (Block List, Max: 1) HTTP proxy configuration for CAST AI nodes and node components. (see [below for nested schema](#nestedblock--http_proxy_config))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only


### PR DESCRIPTION
Used in scenarios where cluster egress communication must go through proxy. Configures our log sender, bootstrap checker, init data to use that proxy. Does not configure cluster components (this is doable via helm values). 