### PR TITLE
feat: add adaptive threshold

### DIFF
--- a/castai/resource_workload_scaling_policy.go
+++ b/castai/resource_workload_scaling_policy.go
@@ -354,7 +354,7 @@ func validateConvertableToNonNegativeFloat() schema.SchemaValidateDiagFunc {
 	})
 }
 
-func resourceWorkloadScalingPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWorkloadScalingPolicyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*ProviderConfig).api
 
 	clusterID := d.Get(FieldClusterID).(string)
@@ -367,7 +367,7 @@ func resourceWorkloadScalingPolicyCreate(ctx context.Context, d *schema.Resource
 	}
 
 	if v, ok := d.GetOk("cpu"); ok {
-		cpu, err := toWorkloadScalingPolicies("cpu", v.([]interface{})[0].(map[string]interface{}))
+		cpu, err := toWorkloadScalingPolicies("cpu", v.([]any)[0].(map[string]any))
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -375,7 +375,7 @@ func resourceWorkloadScalingPolicyCreate(ctx context.Context, d *schema.Resource
 	}
 
 	if v, ok := d.GetOk("memory"); ok {
-		memory, err := toWorkloadScalingPolicies("memory", v.([]interface{})[0].(map[string]interface{}))
+		memory, err := toWorkloadScalingPolicies("memory", v.([]any)[0].(map[string]any))
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -414,7 +414,7 @@ func resourceWorkloadScalingPolicyCreate(ctx context.Context, d *schema.Resource
 	}
 }
 
-func resourceWorkloadScalingPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWorkloadScalingPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*ProviderConfig).api
 
 	clusterID := d.Get(FieldClusterID).(string)
@@ -424,7 +424,7 @@ func resourceWorkloadScalingPolicyRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if !d.IsNewResource() && resp.StatusCode() == http.StatusNotFound {
-		tflog.Warn(ctx, "Scaling policy not found, removing from state", map[string]interface{}{"id": d.Id()})
+		tflog.Warn(ctx, "Scaling policy not found, removing from state", map[string]any{"id": d.Id()})
 		d.SetId("")
 		return nil
 	}
@@ -472,7 +472,7 @@ func getResourceFrom(d *schema.ResourceData, resource string) map[string]any {
 	return map[string]any{}
 }
 
-func resourceWorkloadScalingPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWorkloadScalingPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	if !d.HasChanges(
 		"name",
 		"apply_type",
@@ -490,11 +490,11 @@ func resourceWorkloadScalingPolicyUpdate(ctx context.Context, d *schema.Resource
 
 	client := meta.(*ProviderConfig).api
 	clusterID := d.Get(FieldClusterID).(string)
-	cpu, err := toWorkloadScalingPolicies("cpu", d.Get("cpu").([]interface{})[0].(map[string]interface{}))
+	cpu, err := toWorkloadScalingPolicies("cpu", d.Get("cpu").([]any)[0].(map[string]any))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	memory, err := toWorkloadScalingPolicies("memory", d.Get("memory").([]interface{})[0].(map[string]interface{}))
+	memory, err := toWorkloadScalingPolicies("memory", d.Get("memory").([]any)[0].(map[string]any))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -519,7 +519,7 @@ func resourceWorkloadScalingPolicyUpdate(ctx context.Context, d *schema.Resource
 	return resourceWorkloadScalingPolicyRead(ctx, d, meta)
 }
 
-func resourceWorkloadScalingPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWorkloadScalingPolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*ProviderConfig).api
 	clusterID := d.Get(FieldClusterID).(string)
 
@@ -528,7 +528,7 @@ func resourceWorkloadScalingPolicyDelete(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 	if resp.StatusCode() == http.StatusNotFound {
-		tflog.Debug(ctx, "Scaling policy not found, skipping delete", map[string]interface{}{"id": d.Id()})
+		tflog.Debug(ctx, "Scaling policy not found, skipping delete", map[string]any{"id": d.Id()})
 		return nil
 	}
 	if err := sdk.StatusOk(resp); err != nil {
@@ -536,7 +536,7 @@ func resourceWorkloadScalingPolicyDelete(ctx context.Context, d *schema.Resource
 	}
 
 	if resp.JSON200.IsReadonly || resp.JSON200.IsDefault {
-		tflog.Warn(ctx, "Default/readonly scaling policy can't be deleted, removing from state", map[string]interface{}{
+		tflog.Warn(ctx, "Default/readonly scaling policy can't be deleted, removing from state", map[string]any{
 			"id": d.Id(),
 		})
 		return nil
@@ -553,20 +553,20 @@ func resourceWorkloadScalingPolicyDelete(ctx context.Context, d *schema.Resource
 	return nil
 }
 
-func resourceWorkloadScalingPolicyDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+func resourceWorkloadScalingPolicyDiff(_ context.Context, d *schema.ResourceDiff, _ any) error {
 	// Since tf doesn't support cross field validation, doing it here.
-	_, err := toWorkloadScalingPolicies("cpu", d.Get("cpu").([]interface{})[0].(map[string]interface{}))
+	_, err := toWorkloadScalingPolicies("cpu", d.Get("cpu").([]any)[0].(map[string]any))
 	if err != nil {
 		return err
 	}
-	_, err = toWorkloadScalingPolicies("memory", d.Get("memory").([]interface{})[0].(map[string]interface{}))
+	_, err = toWorkloadScalingPolicies("memory", d.Get("memory").([]any)[0].(map[string]any))
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func workloadScalingPolicyImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func workloadScalingPolicyImporter(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	clusterID, nameOrID, found := strings.Cut(d.Id(), "/")
 	if !found {
 		return nil, fmt.Errorf("expected import id with format: <cluster_id>/<scaling_policy name or id>, got: %q", d.Id())
@@ -593,14 +593,14 @@ func workloadScalingPolicyImporter(ctx context.Context, d *schema.ResourceData, 
 	return []*schema.ResourceData{d}, nil
 }
 
-func toWorkloadScalingPolicies(resource string, obj map[string]interface{}) (sdk.WorkloadoptimizationV1ResourcePolicies, error) {
+func toWorkloadScalingPolicies(resource string, obj map[string]any) (sdk.WorkloadoptimizationV1ResourcePolicies, error) {
 	var err error
 	out := sdk.WorkloadoptimizationV1ResourcePolicies{}
 
 	if v, ok := obj["function"].(string); ok {
 		out.Function = sdk.WorkloadoptimizationV1ResourcePoliciesFunction(v)
 	}
-	if v, ok := obj["args"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := obj["args"].([]any); ok && len(v) > 0 {
 		out.Args = toStringList(v)
 	}
 
@@ -641,7 +641,7 @@ func toWorkloadScalingPolicies(resource string, obj map[string]interface{}) (sdk
 	return out, err
 }
 
-func resolveApplyThresholdStrategy(obj map[string]interface{}) (*sdk.WorkloadoptimizationV1ApplyThresholdStrategy, error) {
+func resolveApplyThresholdStrategy(obj map[string]any) (*sdk.WorkloadoptimizationV1ApplyThresholdStrategy, error) {
 	if v, ok := obj[DeprecatedFieldApplyThreshold].(float64); ok && v > 0 {
 		return toWorkloadResourcePercentageThresholdStrategy(v), nil
 	}
@@ -793,8 +793,8 @@ func toWorkloadResourceCustomAdaptiveThresholdStrategy(numerator, denominator, e
 	}
 }
 
-func toWorkloadScalingPoliciesMap(previousCfg map[string]interface{}, p sdk.WorkloadoptimizationV1ResourcePolicies) []map[string]interface{} {
-	m := map[string]interface{}{
+func toWorkloadScalingPoliciesMap(previousCfg map[string]any, p sdk.WorkloadoptimizationV1ResourcePolicies) []map[string]any {
+	m := map[string]any{
 		"function": p.Function,
 		"args":     p.Args,
 		"overhead": p.Overhead,
@@ -822,7 +822,7 @@ func toWorkloadScalingPoliciesMap(previousCfg map[string]interface{}, p sdk.Work
 		m["management_option"] = string(*p.ManagementOption)
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
 func applyThresholdStrategyToMap(s *sdk.WorkloadoptimizationV1ApplyThresholdStrategy) []map[string]any {
@@ -852,7 +852,7 @@ func applyThresholdStrategyToMap(s *sdk.WorkloadoptimizationV1ApplyThresholdStra
 	return []map[string]any{m}
 }
 
-func toStartup(startup map[string]interface{}) *sdk.WorkloadoptimizationV1StartupSettings {
+func toStartup(startup map[string]any) *sdk.WorkloadoptimizationV1StartupSettings {
 	if len(startup) == 0 {
 		return nil
 	}
@@ -865,12 +865,12 @@ func toStartup(startup map[string]interface{}) *sdk.WorkloadoptimizationV1Startu
 	return result
 }
 
-func toStartupMap(s *sdk.WorkloadoptimizationV1StartupSettings) []map[string]interface{} {
+func toStartupMap(s *sdk.WorkloadoptimizationV1StartupSettings) []map[string]any {
 	if s == nil {
 		return nil
 	}
 
-	m := map[string]interface{}{}
+	m := map[string]any{}
 
 	if s.PeriodSeconds != nil {
 		m["period_seconds"] = int(*s.PeriodSeconds)
@@ -880,7 +880,7 @@ func toStartupMap(s *sdk.WorkloadoptimizationV1StartupSettings) []map[string]int
 		return nil
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
 func toDownscaling(downscaling map[string]any) *sdk.WorkloadoptimizationV1DownscalingSettings {

--- a/castai/resource_workload_scaling_policy_test.go
+++ b/castai/resource_workload_scaling_policy_test.go
@@ -46,8 +46,10 @@ func TestAccResourceWorkloadScalingPolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cpu.0.limit.0.multiplier", "1.2"),
 					resource.TestCheckResourceAttr(resourceName, "memory.0.function", "MAX"),
 					resource.TestCheckResourceAttr(resourceName, "memory.0.overhead", "0.25"),
-					resource.TestCheckResourceAttr(resourceName, "memory.0.apply_threshold_strategy.0.type", "PERCENTAGE"),
-					resource.TestCheckResourceAttr(resourceName, "memory.0.apply_threshold_strategy.0.percentage", "0.1"),
+					resource.TestCheckResourceAttr(resourceName, "memory.0.apply_threshold_strategy.0.type", "CUSTOM_ADAPTIVE"),
+					resource.TestCheckResourceAttr(resourceName, "memory.0.apply_threshold_strategy.0.numerator", "0.4"),
+					resource.TestCheckResourceAttr(resourceName, "memory.0.apply_threshold_strategy.0.denominator", "0.5"),
+					resource.TestCheckResourceAttr(resourceName, "memory.0.apply_threshold_strategy.0.exponent", "0.6"),
 					resource.TestCheckResourceAttr(resourceName, "memory.0.args.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "memory.0.min", "100"),
 					resource.TestCheckResourceAttr(resourceName, "memory.0.limit.0.type", "MULTIPLIER"),
@@ -133,8 +135,10 @@ func scalingPolicyConfig(clusterName, projectID, name string) string {
 			function 		= "MAX"
 			overhead 		= 0.25
 			apply_threshold_strategy {
-				type = "PERCENTAGE"
-				percentage = 0.1
+				type = "CUSTOM_ADAPTIVE"
+				numerator = 0.4
+				denominator = 0.5
+                exponent = 0.6
 			}
             min             = 100
 			limit {

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -123,6 +123,12 @@ const (
 	Ssd     CastaiInventoryV1beta1StorageInfoDeviceType = "ssd"
 )
 
+// Defines values for CastaiRbacV1beta1Effects.
+const (
+	ALLOW CastaiRbacV1beta1Effects = "ALLOW"
+	DENY  CastaiRbacV1beta1Effects = "DENY"
+)
+
 // Defines values for CastaiRbacV1beta1Kind.
 const (
 	SERVICEACCOUNT CastaiRbacV1beta1Kind = "SERVICE_ACCOUNT"
@@ -1508,6 +1514,9 @@ type CastaiRbacV1beta1DeleteGroupResponse = map[string]interface{}
 // CastaiRbacV1beta1DeleteRoleBindingResponse defines model for castai.rbac.v1beta1.DeleteRoleBindingResponse.
 type CastaiRbacV1beta1DeleteRoleBindingResponse = map[string]interface{}
 
+// Effects represent the effect of a permission.
+type CastaiRbacV1beta1Effects string
+
 // CastaiRbacV1beta1Group defines model for castai.rbac.v1beta1.Group.
 type CastaiRbacV1beta1Group struct {
 	// CreatedAt is the timestamp when the group was created.
@@ -1553,6 +1562,22 @@ type CastaiRbacV1beta1GroupSubject struct {
 // Kind represents the type of the member.
 type CastaiRbacV1beta1Kind string
 
+// CastaiRbacV1beta1ListRoleBindingsResponse defines model for castai.rbac.v1beta1.ListRoleBindingsResponse.
+type CastaiRbacV1beta1ListRoleBindingsResponse struct {
+	// Page defines how many and which fields should be returned.
+	NextPage     CastaiPaginationV1beta1Page     `json:"nextPage"`
+	RoleBindings *[]CastaiRbacV1beta1RoleBinding `json:"roleBindings,omitempty"`
+	TotalCount   *string                         `json:"totalCount,omitempty"`
+}
+
+// CastaiRbacV1beta1ListRolesResponse defines model for castai.rbac.v1beta1.ListRolesResponse.
+type CastaiRbacV1beta1ListRolesResponse struct {
+	// Page defines how many and which fields should be returned.
+	NextPage   *CastaiPaginationV1beta1Page `json:"nextPage,omitempty"`
+	Roles      *[]CastaiRbacV1beta1Role     `json:"roles,omitempty"`
+	TotalCount *string                      `json:"totalCount,omitempty"`
+}
+
 // CastaiRbacV1beta1Member defines model for castai.rbac.v1beta1.Member.
 type CastaiRbacV1beta1Member struct {
 	// AddedAt is the timestamp when the user has been added to the group.
@@ -1577,6 +1602,14 @@ type CastaiRbacV1beta1OrganizationScope struct {
 	Id string `json:"id"`
 }
 
+// CastaiRbacV1beta1Permissions defines model for castai.rbac.v1beta1.Permissions.
+type CastaiRbacV1beta1Permissions struct {
+	// Effects represent the effect of a permission.
+	Effect    CastaiRbacV1beta1Effects `json:"effect"`
+	Endpoints *[]string                `json:"endpoints,omitempty"`
+	Groups    *[]string                `json:"groups,omitempty"`
+}
+
 // PoliciesState represents the state of the policies generation.
 //
 //   - ACCEPTED: ACCEPTED is the state when the policies async generation is ongoing.
@@ -1594,6 +1627,35 @@ type CastaiRbacV1beta1PolicyID struct {
 type CastaiRbacV1beta1ResourceScope struct {
 	// ID is the unique identifier of the resource.
 	Id string `json:"id"`
+}
+
+// CastaiRbacV1beta1Role defines model for castai.rbac.v1beta1.Role.
+type CastaiRbacV1beta1Role struct {
+	// CreatedAt is the timestamp when the role was created.
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
+
+	// Default is a flag that indicates if the role is a default role.
+	Default    *bool                           `json:"default,omitempty"`
+	Definition CastaiRbacV1beta1RoleDefinition `json:"definition"`
+
+	// Deprecated is a flag that indicates if the role is deprecated.
+	Deprecated *bool `json:"deprecated,omitempty"`
+
+	// Description is the description of the role.
+	Description *string `json:"description,omitempty"`
+	Id          *string `json:"id,omitempty"`
+
+	// Priority level of the role (higher is more important).
+	Level *int32 `json:"level,omitempty"`
+
+	// Name is the name of the role.
+	Name *string `json:"name,omitempty"`
+
+	// OrganizationID is the unique identifier of the organization.
+	OrganizationId *string `json:"organizationId,omitempty"`
+
+	// UpdatedAt is the timestamp when the role was last updated.
+	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
 }
 
 // CastaiRbacV1beta1RoleBinding defines model for castai.rbac.v1beta1.RoleBinding.
@@ -1653,6 +1715,12 @@ type CastaiRbacV1beta1RoleBindingStatus struct {
 
 	// UpdatedAt is the timestamp when the status was last updated.
 	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+}
+
+// CastaiRbacV1beta1RoleDefinition defines model for castai.rbac.v1beta1.RoleDefinition.
+type CastaiRbacV1beta1RoleDefinition struct {
+	// Permissions is a list of permissions.
+	Permissions *[]CastaiRbacV1beta1Permissions `json:"permissions,omitempty"`
 }
 
 // Scope represents the scope of the role binding.
@@ -2255,6 +2323,13 @@ type CastaiUsersV1beta1UserOrganization struct {
 
 	// name of the organization.
 	Name string `json:"name"`
+
+	// Deprecated: for RBACv2 user can be bound to multiple roles.
+	// Use https://docs.cast.ai/reference/rbacserviceapi instead.
+	// user role in the organization.
+	//
+	// TODO: cleanup once all orgs are migrated to RBACv2
+	//  https://castai.atlassian.net/browse/WIRE-954
 	Role string `json:"role"`
 }
 
@@ -4166,9 +4241,26 @@ type WorkloadoptimizationV1AntiAffinitySettings struct {
 
 // WorkloadoptimizationV1ApplyThresholdStrategy defines model for workloadoptimization.v1.ApplyThresholdStrategy.
 type WorkloadoptimizationV1ApplyThresholdStrategy struct {
+	CustomAdaptiveThreshold  *WorkloadoptimizationV1ApplyThresholdStrategyCustomAdaptiveThreshold  `json:"customAdaptiveThreshold,omitempty"`
+	DefaultAdaptiveThreshold *WorkloadoptimizationV1ApplyThresholdStrategyDefaultAdaptiveThreshold `json:"defaultAdaptiveThreshold,omitempty"`
+
 	// PercentageThreshold is the percentage for the apply threshold strategy.
 	PercentageThreshold *WorkloadoptimizationV1ApplyThresholdStrategyPercentageThreshold `json:"percentageThreshold,omitempty"`
 }
+
+// WorkloadoptimizationV1ApplyThresholdStrategyCustomAdaptiveThreshold defines model for workloadoptimization.v1.ApplyThresholdStrategy.CustomAdaptiveThreshold.
+type WorkloadoptimizationV1ApplyThresholdStrategyCustomAdaptiveThreshold struct {
+	// If value is close or equal to 0, the threshold will be much bigger for small values.
+	// For example when numerator, exponent is 1 and denominator is 0 the threshold for 0.5 req. CPU will be 200%.
+	Denominator float64 `json:"denominator"`
+	Exponent    float64 `json:"exponent"`
+
+	// It affects vertical stretch of function - smaller number will create smaller threshold.
+	Numerator float64 `json:"numerator"`
+}
+
+// WorkloadoptimizationV1ApplyThresholdStrategyDefaultAdaptiveThreshold defines model for workloadoptimization.v1.ApplyThresholdStrategy.DefaultAdaptiveThreshold.
+type WorkloadoptimizationV1ApplyThresholdStrategyDefaultAdaptiveThreshold = map[string]interface{}
 
 // PercentageThreshold is the percentage for the apply threshold strategy.
 type WorkloadoptimizationV1ApplyThresholdStrategyPercentageThreshold struct {
@@ -5203,11 +5295,30 @@ type InventoryAPIAddReservationJSONBody = CastaiInventoryV1beta1GenericReservati
 // InventoryAPIOverwriteReservationsJSONBody defines parameters for InventoryAPIOverwriteReservations.
 type InventoryAPIOverwriteReservationsJSONBody = CastaiInventoryV1beta1GenericReservationsList
 
+// RbacServiceAPIListRoleBindingsParams defines parameters for RbacServiceAPIListRoleBindings.
+type RbacServiceAPIListRoleBindingsParams struct {
+	PageLimit *string `form:"page.limit,omitempty" json:"page.limit,omitempty"`
+
+	// Cursor that defines token indicating where to start the next page.
+	// Empty value indicates to start from beginning of the dataset.
+	PageCursor *string `form:"page.cursor,omitempty" json:"page.cursor,omitempty"`
+	RoleId     *string `form:"roleId,omitempty" json:"roleId,omitempty"`
+}
+
 // RbacServiceAPICreateRoleBindingsJSONBody defines parameters for RbacServiceAPICreateRoleBindings.
 type RbacServiceAPICreateRoleBindingsJSONBody = []CastaiRbacV1beta1CreateRoleBindingsRequestRoleBinding
 
 // RbacServiceAPIUpdateRoleBindingJSONBody defines parameters for RbacServiceAPIUpdateRoleBinding.
 type RbacServiceAPIUpdateRoleBindingJSONBody = RoleBindingIsTheRoleBindingToBeUpdated
+
+// RbacServiceAPIListRolesParams defines parameters for RbacServiceAPIListRoles.
+type RbacServiceAPIListRolesParams struct {
+	PageLimit *string `form:"page.limit,omitempty" json:"page.limit,omitempty"`
+
+	// Cursor that defines token indicating where to start the next page.
+	// Empty value indicates to start from beginning of the dataset.
+	PageCursor *string `form:"page.cursor,omitempty" json:"page.cursor,omitempty"`
+}
 
 // ServiceAccountsAPIDeleteServiceAccountsParams defines parameters for ServiceAccountsAPIDeleteServiceAccounts.
 type ServiceAccountsAPIDeleteServiceAccountsParams struct {

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -417,6 +417,9 @@ type ClientInterface interface {
 	// InventoryAPIDeleteReservation request
 	InventoryAPIDeleteReservation(ctx context.Context, organizationId string, reservationId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// RbacServiceAPIListRoleBindings request
+	RbacServiceAPIListRoleBindings(ctx context.Context, organizationId string, params *RbacServiceAPIListRoleBindingsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// RbacServiceAPICreateRoleBindings request with any body
 	RbacServiceAPICreateRoleBindingsWithBody(ctx context.Context, organizationId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -432,6 +435,9 @@ type ClientInterface interface {
 	RbacServiceAPIUpdateRoleBindingWithBody(ctx context.Context, organizationId string, roleBindingId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	RbacServiceAPIUpdateRoleBinding(ctx context.Context, organizationId string, roleBindingId string, body RbacServiceAPIUpdateRoleBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RbacServiceAPIListRoles request
+	RbacServiceAPIListRoles(ctx context.Context, organizationId string, params *RbacServiceAPIListRolesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ServiceAccountsAPIDeleteServiceAccounts request
 	ServiceAccountsAPIDeleteServiceAccounts(ctx context.Context, organizationId string, params *ServiceAccountsAPIDeleteServiceAccountsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2087,6 +2093,18 @@ func (c *Client) InventoryAPIDeleteReservation(ctx context.Context, organization
 	return c.Client.Do(req)
 }
 
+func (c *Client) RbacServiceAPIListRoleBindings(ctx context.Context, organizationId string, params *RbacServiceAPIListRoleBindingsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRbacServiceAPIListRoleBindingsRequest(c.Server, organizationId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) RbacServiceAPICreateRoleBindingsWithBody(ctx context.Context, organizationId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRbacServiceAPICreateRoleBindingsRequestWithBody(c.Server, organizationId, contentType, body)
 	if err != nil {
@@ -2149,6 +2167,18 @@ func (c *Client) RbacServiceAPIUpdateRoleBindingWithBody(ctx context.Context, or
 
 func (c *Client) RbacServiceAPIUpdateRoleBinding(ctx context.Context, organizationId string, roleBindingId string, body RbacServiceAPIUpdateRoleBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRbacServiceAPIUpdateRoleBindingRequest(c.Server, organizationId, roleBindingId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RbacServiceAPIListRoles(ctx context.Context, organizationId string, params *RbacServiceAPIListRolesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRbacServiceAPIListRolesRequest(c.Server, organizationId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -7167,6 +7197,92 @@ func NewInventoryAPIDeleteReservationRequest(server string, organizationId strin
 	return req, nil
 }
 
+// NewRbacServiceAPIListRoleBindingsRequest generates requests for RbacServiceAPIListRoleBindings
+func NewRbacServiceAPIListRoleBindingsRequest(server string, organizationId string, params *RbacServiceAPIListRoleBindingsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "organizationId", runtime.ParamLocationPath, organizationId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/organizations/%s/role-bindings", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.PageLimit != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.limit", runtime.ParamLocationQuery, *params.PageLimit); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.PageCursor != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.cursor", runtime.ParamLocationQuery, *params.PageCursor); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.RoleId != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "roleId", runtime.ParamLocationQuery, *params.RoleId); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewRbacServiceAPICreateRoleBindingsRequest calls the generic RbacServiceAPICreateRoleBindings builder with application/json body
 func NewRbacServiceAPICreateRoleBindingsRequest(server string, organizationId string, body RbacServiceAPICreateRoleBindingsJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -7346,6 +7462,76 @@ func NewRbacServiceAPIUpdateRoleBindingRequestWithBody(server string, organizati
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewRbacServiceAPIListRolesRequest generates requests for RbacServiceAPIListRoles
+func NewRbacServiceAPIListRolesRequest(server string, organizationId string, params *RbacServiceAPIListRolesParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "organizationId", runtime.ParamLocationPath, organizationId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/organizations/%s/roles", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.PageLimit != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.limit", runtime.ParamLocationQuery, *params.PageLimit); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.PageCursor != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.cursor", runtime.ParamLocationQuery, *params.PageCursor); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -10542,6 +10728,9 @@ type ClientWithResponsesInterface interface {
 	// InventoryAPIDeleteReservation request
 	InventoryAPIDeleteReservationWithResponse(ctx context.Context, organizationId string, reservationId string) (*InventoryAPIDeleteReservationResponse, error)
 
+	// RbacServiceAPIListRoleBindings request
+	RbacServiceAPIListRoleBindingsWithResponse(ctx context.Context, organizationId string, params *RbacServiceAPIListRoleBindingsParams) (*RbacServiceAPIListRoleBindingsResponse, error)
+
 	// RbacServiceAPICreateRoleBindings request  with any body
 	RbacServiceAPICreateRoleBindingsWithBodyWithResponse(ctx context.Context, organizationId string, contentType string, body io.Reader) (*RbacServiceAPICreateRoleBindingsResponse, error)
 
@@ -10557,6 +10746,9 @@ type ClientWithResponsesInterface interface {
 	RbacServiceAPIUpdateRoleBindingWithBodyWithResponse(ctx context.Context, organizationId string, roleBindingId string, contentType string, body io.Reader) (*RbacServiceAPIUpdateRoleBindingResponse, error)
 
 	RbacServiceAPIUpdateRoleBindingWithResponse(ctx context.Context, organizationId string, roleBindingId string, body RbacServiceAPIUpdateRoleBindingJSONRequestBody) (*RbacServiceAPIUpdateRoleBindingResponse, error)
+
+	// RbacServiceAPIListRoles request
+	RbacServiceAPIListRolesWithResponse(ctx context.Context, organizationId string, params *RbacServiceAPIListRolesParams) (*RbacServiceAPIListRolesResponse, error)
 
 	// ServiceAccountsAPIDeleteServiceAccounts request
 	ServiceAccountsAPIDeleteServiceAccountsWithResponse(ctx context.Context, organizationId string, params *ServiceAccountsAPIDeleteServiceAccountsParams) (*ServiceAccountsAPIDeleteServiceAccountsResponse, error)
@@ -13389,6 +13581,36 @@ func (r InventoryAPIDeleteReservationResponse) GetBody() []byte {
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
+type RbacServiceAPIListRoleBindingsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CastaiRbacV1beta1ListRoleBindingsResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r RbacServiceAPIListRoleBindingsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RbacServiceAPIListRoleBindingsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r RbacServiceAPIListRoleBindingsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
 type RbacServiceAPICreateRoleBindingsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -13504,6 +13726,36 @@ func (r RbacServiceAPIUpdateRoleBindingResponse) StatusCode() int {
 // TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 // Body returns body of byte array
 func (r RbacServiceAPIUpdateRoleBindingResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
+type RbacServiceAPIListRolesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CastaiRbacV1beta1ListRolesResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r RbacServiceAPIListRolesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RbacServiceAPIListRolesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r RbacServiceAPIListRolesResponse) GetBody() []byte {
 	return r.Body
 }
 
@@ -16325,6 +16577,15 @@ func (c *ClientWithResponses) InventoryAPIDeleteReservationWithResponse(ctx cont
 	return ParseInventoryAPIDeleteReservationResponse(rsp)
 }
 
+// RbacServiceAPIListRoleBindingsWithResponse request returning *RbacServiceAPIListRoleBindingsResponse
+func (c *ClientWithResponses) RbacServiceAPIListRoleBindingsWithResponse(ctx context.Context, organizationId string, params *RbacServiceAPIListRoleBindingsParams) (*RbacServiceAPIListRoleBindingsResponse, error) {
+	rsp, err := c.RbacServiceAPIListRoleBindings(ctx, organizationId, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRbacServiceAPIListRoleBindingsResponse(rsp)
+}
+
 // RbacServiceAPICreateRoleBindingsWithBodyWithResponse request with arbitrary body returning *RbacServiceAPICreateRoleBindingsResponse
 func (c *ClientWithResponses) RbacServiceAPICreateRoleBindingsWithBodyWithResponse(ctx context.Context, organizationId string, contentType string, body io.Reader) (*RbacServiceAPICreateRoleBindingsResponse, error) {
 	rsp, err := c.RbacServiceAPICreateRoleBindingsWithBody(ctx, organizationId, contentType, body)
@@ -16375,6 +16636,15 @@ func (c *ClientWithResponses) RbacServiceAPIUpdateRoleBindingWithResponse(ctx co
 		return nil, err
 	}
 	return ParseRbacServiceAPIUpdateRoleBindingResponse(rsp)
+}
+
+// RbacServiceAPIListRolesWithResponse request returning *RbacServiceAPIListRolesResponse
+func (c *ClientWithResponses) RbacServiceAPIListRolesWithResponse(ctx context.Context, organizationId string, params *RbacServiceAPIListRolesParams) (*RbacServiceAPIListRolesResponse, error) {
+	rsp, err := c.RbacServiceAPIListRoles(ctx, organizationId, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRbacServiceAPIListRolesResponse(rsp)
 }
 
 // ServiceAccountsAPIDeleteServiceAccountsWithResponse request returning *ServiceAccountsAPIDeleteServiceAccountsResponse
@@ -19294,6 +19564,32 @@ func ParseInventoryAPIDeleteReservationResponse(rsp *http.Response) (*InventoryA
 	return response, nil
 }
 
+// ParseRbacServiceAPIListRoleBindingsResponse parses an HTTP response from a RbacServiceAPIListRoleBindingsWithResponse call
+func ParseRbacServiceAPIListRoleBindingsResponse(rsp *http.Response) (*RbacServiceAPIListRoleBindingsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RbacServiceAPIListRoleBindingsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CastaiRbacV1beta1ListRoleBindingsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseRbacServiceAPICreateRoleBindingsResponse parses an HTTP response from a RbacServiceAPICreateRoleBindingsWithResponse call
 func ParseRbacServiceAPICreateRoleBindingsResponse(rsp *http.Response) (*RbacServiceAPICreateRoleBindingsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -19388,6 +19684,32 @@ func ParseRbacServiceAPIUpdateRoleBindingResponse(rsp *http.Response) (*RbacServ
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest CastaiRbacV1beta1RoleBinding
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRbacServiceAPIListRolesResponse parses an HTTP response from a RbacServiceAPIListRolesWithResponse call
+func ParseRbacServiceAPIListRolesResponse(rsp *http.Response) (*RbacServiceAPIListRolesResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RbacServiceAPIListRolesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CastaiRbacV1beta1ListRolesResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -2435,6 +2435,46 @@ func (mr *MockClientInterfaceMockRecorder) RbacServiceAPIGetRoleBinding(ctx, org
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIGetRoleBinding", reflect.TypeOf((*MockClientInterface)(nil).RbacServiceAPIGetRoleBinding), varargs...)
 }
 
+// RbacServiceAPIListRoleBindings mocks base method.
+func (m *MockClientInterface) RbacServiceAPIListRoleBindings(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRoleBindingsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRoleBindings", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRoleBindings indicates an expected call of RbacServiceAPIListRoleBindings.
+func (mr *MockClientInterfaceMockRecorder) RbacServiceAPIListRoleBindings(ctx, organizationId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRoleBindings", reflect.TypeOf((*MockClientInterface)(nil).RbacServiceAPIListRoleBindings), varargs...)
+}
+
+// RbacServiceAPIListRoles mocks base method.
+func (m *MockClientInterface) RbacServiceAPIListRoles(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRolesParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRoles", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRoles indicates an expected call of RbacServiceAPIListRoles.
+func (mr *MockClientInterfaceMockRecorder) RbacServiceAPIListRoles(ctx, organizationId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRoles", reflect.TypeOf((*MockClientInterface)(nil).RbacServiceAPIListRoles), varargs...)
+}
+
 // RbacServiceAPIUpdateGroup mocks base method.
 func (m *MockClientInterface) RbacServiceAPIUpdateGroup(ctx context.Context, organizationId, groupId string, body sdk.RbacServiceAPIUpdateGroupJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -8286,6 +8326,76 @@ func (m *MockClientWithResponsesInterface) RbacServiceAPIGetRoleBindingWithRespo
 func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIGetRoleBindingWithResponse(ctx, organizationId, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIGetRoleBindingWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIGetRoleBindingWithResponse), ctx, organizationId, id)
+}
+
+// RbacServiceAPIListRoleBindings mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIListRoleBindings(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRoleBindingsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRoleBindings", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRoleBindings indicates an expected call of RbacServiceAPIListRoleBindings.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIListRoleBindings(ctx, organizationId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRoleBindings", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIListRoleBindings), varargs...)
+}
+
+// RbacServiceAPIListRoleBindingsWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIListRoleBindingsWithResponse(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRoleBindingsParams) (*sdk.RbacServiceAPIListRoleBindingsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRoleBindingsWithResponse", ctx, organizationId, params)
+	ret0, _ := ret[0].(*sdk.RbacServiceAPIListRoleBindingsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRoleBindingsWithResponse indicates an expected call of RbacServiceAPIListRoleBindingsWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIListRoleBindingsWithResponse(ctx, organizationId, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRoleBindingsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIListRoleBindingsWithResponse), ctx, organizationId, params)
+}
+
+// RbacServiceAPIListRoles mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIListRoles(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRolesParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRoles", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRoles indicates an expected call of RbacServiceAPIListRoles.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIListRoles(ctx, organizationId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRoles", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIListRoles), varargs...)
+}
+
+// RbacServiceAPIListRolesWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIListRolesWithResponse(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListRolesParams) (*sdk.RbacServiceAPIListRolesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RbacServiceAPIListRolesWithResponse", ctx, organizationId, params)
+	ret0, _ := ret[0].(*sdk.RbacServiceAPIListRolesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListRolesWithResponse indicates an expected call of RbacServiceAPIListRolesWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIListRolesWithResponse(ctx, organizationId, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListRolesWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIListRolesWithResponse), ctx, organizationId, params)
 }
 
 // RbacServiceAPIUpdateGroup mocks base method.

--- a/docs/resources/workload_scaling_policy.md
+++ b/docs/resources/workload_scaling_policy.md
@@ -111,7 +111,7 @@ Required:
 - `type` (String) Defines apply theshold strategy type.
 	- PERCENTAGE - recommendation will be applied when diff of current requests and new recommendation is greater than set value
     - DEFAULT_ADAPTIVE - will pick larger threshold percentage for small workloads and smaller percentage for large workloads.
-    - CUSTOM_ADAPTIVE - works in same way as DEFAULT_ADAPTIVE, but it allows to tweak parameters of adaptive threshold formula: percentage = numerator/(currentRequest + denominator)^exponent
+    - CUSTOM_ADAPTIVE - works in same way as DEFAULT_ADAPTIVE, but it allows to tweak parameters of adaptive threshold formula: percentage = numerator/(currentRequest + denominator)^exponent. This strategy is for advance use cases, we recommend to use DEFAULT_ADAPTIVE strategy.
 
 Optional:
 
@@ -163,7 +163,7 @@ Required:
 - `type` (String) Defines apply theshold strategy type.
 	- PERCENTAGE - recommendation will be applied when diff of current requests and new recommendation is greater than set value
     - DEFAULT_ADAPTIVE - will pick larger threshold percentage for small workloads and smaller percentage for large workloads.
-    - CUSTOM_ADAPTIVE - works in same way as DEFAULT_ADAPTIVE, but it allows to tweak parameters of adaptive threshold formula: percentage = numerator/(currentRequest + denominator)^exponent
+    - CUSTOM_ADAPTIVE - works in same way as DEFAULT_ADAPTIVE, but it allows to tweak parameters of adaptive threshold formula: percentage = numerator/(currentRequest + denominator)^exponent. This strategy is for advance use cases, we recommend to use DEFAULT_ADAPTIVE strategy.
 
 Optional:
 

--- a/docs/resources/workload_scaling_policy.md
+++ b/docs/resources/workload_scaling_policy.md
@@ -36,8 +36,7 @@ resource "castai_workload_scaling_policy" "services" {
     function = "MAX"
     overhead = 0.35
     apply_threshold_strategy {
-      type       = "PERCENTAGE"
-      percentage = 0.2
+      type = "DEFAULT_ADAPTIVE"
     }
     limit {
       type       = "MULTIPLIER"
@@ -111,9 +110,17 @@ Required:
 
 - `type` (String) Defines apply theshold strategy type.
 	- PERCENTAGE - recommendation will be applied when diff of current requests and new recommendation is greater than set value
+    - DEFAULT_ADAPTIVE - will pick larger threshold percentage for small workloads and smaller percentage for large workloads.
+    - CUSTOM_ADAPTIVE - works in same way as DEFAULT_ADAPTIVE, but it allows to tweak parameters of adaptive threshold formula: percentage = numerator/(currentRequest + denominator)^exponent
 
 Optional:
 
+- `denominator` (Number) If denominator is close or equal to 0, the threshold will be much bigger for small values.For example when numerator, exponent is 1 and denominator is 0 the threshold for 0.5 req. CPU will be 200%.It must be defined for the CUSTOM_ADAPTIVE strategy.
+- `exponent` (Number) The exponent changes how fast the curve is going down. The smaller value will cause that we won’t pick extremely small number for big resources, for example:
+	- if numerator is 0, denominator is 1, and exponent is 1, for 50 CPU we will pick 2% threshold
+	- if numerator is 0, denominator is 1, and exponent is 0.8, for 50 CPU we will pick 4.3% threshold
+	It must be defined for the CUSTOM_ADAPTIVE strategy.
+- `numerator` (Number) The numerator affects vertical stretch of function used in adaptive threshold - smaller number will create smaller threshold.It must be defined for the CUSTOM_ADAPTIVE strategy.
 - `percentage` (Number) Percentage of a how much difference should there be between the current pod requests and the new recommendation. It must be defined for the PERCENTAGE strategy.
 
 
@@ -155,9 +162,17 @@ Required:
 
 - `type` (String) Defines apply theshold strategy type.
 	- PERCENTAGE - recommendation will be applied when diff of current requests and new recommendation is greater than set value
+    - DEFAULT_ADAPTIVE - will pick larger threshold percentage for small workloads and smaller percentage for large workloads.
+    - CUSTOM_ADAPTIVE - works in same way as DEFAULT_ADAPTIVE, but it allows to tweak parameters of adaptive threshold formula: percentage = numerator/(currentRequest + denominator)^exponent
 
 Optional:
 
+- `denominator` (Number) If denominator is close or equal to 0, the threshold will be much bigger for small values.For example when numerator, exponent is 1 and denominator is 0 the threshold for 0.5 req. CPU will be 200%.It must be defined for the CUSTOM_ADAPTIVE strategy.
+- `exponent` (Number) The exponent changes how fast the curve is going down. The smaller value will cause that we won’t pick extremely small number for big resources, for example:
+	- if numerator is 0, denominator is 1, and exponent is 1, for 50 CPU we will pick 2% threshold
+	- if numerator is 0, denominator is 1, and exponent is 0.8, for 50 CPU we will pick 4.3% threshold
+	It must be defined for the CUSTOM_ADAPTIVE strategy.
+- `numerator` (Number) The numerator affects vertical stretch of function used in adaptive threshold - smaller number will create smaller threshold.It must be defined for the CUSTOM_ADAPTIVE strategy.
 - `percentage` (Number) Percentage of a how much difference should there be between the current pod requests and the new recommendation. It must be defined for the PERCENTAGE strategy.
 
 

--- a/docs/resources/workload_scaling_policy.md
+++ b/docs/resources/workload_scaling_policy.md
@@ -115,7 +115,7 @@ Required:
 
 Optional:
 
-- `denominator` (Number) If denominator is close or equal to 0, the threshold will be much bigger for small values.For example when numerator, exponent is 1 and denominator is 0 the threshold for 0.5 req. CPU will be 200%.It must be defined for the CUSTOM_ADAPTIVE strategy.
+- `denominator` (String) If denominator is close or equal to 0, the threshold will be much bigger for small values.For example when numerator, exponent is 1 and denominator is 0 the threshold for 0.5 req. CPU will be 200%.It must be defined for the CUSTOM_ADAPTIVE strategy.
 - `exponent` (Number) The exponent changes how fast the curve is going down. The smaller value will cause that we won’t pick extremely small number for big resources, for example:
 	- if numerator is 0, denominator is 1, and exponent is 1, for 50 CPU we will pick 2% threshold
 	- if numerator is 0, denominator is 1, and exponent is 0.8, for 50 CPU we will pick 4.3% threshold
@@ -167,7 +167,7 @@ Required:
 
 Optional:
 
-- `denominator` (Number) If denominator is close or equal to 0, the threshold will be much bigger for small values.For example when numerator, exponent is 1 and denominator is 0 the threshold for 0.5 req. CPU will be 200%.It must be defined for the CUSTOM_ADAPTIVE strategy.
+- `denominator` (String) If denominator is close or equal to 0, the threshold will be much bigger for small values.For example when numerator, exponent is 1 and denominator is 0 the threshold for 0.5 req. CPU will be 200%.It must be defined for the CUSTOM_ADAPTIVE strategy.
 - `exponent` (Number) The exponent changes how fast the curve is going down. The smaller value will cause that we won’t pick extremely small number for big resources, for example:
 	- if numerator is 0, denominator is 1, and exponent is 1, for 50 CPU we will pick 2% threshold
 	- if numerator is 0, denominator is 1, and exponent is 0.8, for 50 CPU we will pick 4.3% threshold

--- a/examples/resources/castai_workload_scaling_policy/resource.tf
+++ b/examples/resources/castai_workload_scaling_policy/resource.tf
@@ -19,8 +19,7 @@ resource "castai_workload_scaling_policy" "services" {
     function = "MAX"
     overhead = 0.35
     apply_threshold_strategy {
-      type       = "PERCENTAGE"
-      percentage = 0.2
+      type = "DEFAULT_ADAPTIVE"
     }
     limit {
       type       = "MULTIPLIER"


### PR DESCRIPTION
There was one issue with TF sdk being unable to recognize unset and zero values. Kube team recommended setting value to string. 

- I had to rework how validation works - the denominator in req is float and not pointer, so I would have to map it to 
  -1 or something like that, or validate it during mapping
- I choose to validate it during mapping, too me it seems as much cleaner way how to do it, instead of validating req struct
- Because of that I also had to change tests a little bit

```terraform
resource "castai_workload_scaling_policy" "xyz" {
  name              = "xyz"
  cluster_id        = "68f9f4ce-6910-4e66-a545-b32f93a4638f"
  apply_type        = "IMMEDIATE"
  management_option = "MANAGED"
  cpu {
    apply_threshold_strategy {
      type        = "CUSTOM_ADAPTIVE"
      numerator   = 0.4
      denominator = 0.3
      exponent    = 0.5
    }

    function                 = "QUANTILE"
    overhead                 = 0.15
    args                     = ["0.9"]
    look_back_period_seconds = 172800
    min                      = 0.1
    max                      = 1
  }
  memory {
    function = "MAX"
    overhead = 0.35
    apply_threshold_strategy {
      type        = "DEFAULT_ADAPTIVE"
    }

    limit {
      type       = "MULTIPLIER"
      multiplier = 1.5
    }
    management_option = "READ_ONLY"
  }
  startup {
    period_seconds = 240
  }
  downscaling {
    apply_type = "DEFERRED"
  }
  memory_event {
    apply_type = "IMMEDIATE"
  }
  anti_affinity {
    consider_anti_affinity = false
  }
}

``` 