### PR TITLE
KUBE-856: Add example that deploys cluster which requires proxy.

### DIFF
--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -3714,8 +3714,9 @@ type NodetemplatesV1TemplateConstraints struct {
 	MinMemory *int32 `json:"minMemory"`
 
 	// Should include on-demand instances in the considered pool.
-	OnDemand *bool     `json:"onDemand"`
-	Os       *[]string `json:"os,omitempty"`
+	OnDemand       *bool                                             `json:"onDemand"`
+	Os             *[]string                                         `json:"os,omitempty"`
+	ResourceLimits *NodetemplatesV1TemplateConstraintsResourceLimits `json:"resourceLimits,omitempty"`
 
 	// Should include spot instances in the considered pool.
 	// Note 1: if both spot and on-demand are false, then on-demand is assumed.
@@ -3780,6 +3781,15 @@ type NodetemplatesV1TemplateConstraintsGPUConstraints struct {
 type NodetemplatesV1TemplateConstraintsInstanceFamilyConstraints struct {
 	Exclude *[]string `json:"exclude,omitempty"`
 	Include *[]string `json:"include,omitempty"`
+}
+
+// NodetemplatesV1TemplateConstraintsResourceLimits defines model for nodetemplates.v1.TemplateConstraints.ResourceLimits.
+type NodetemplatesV1TemplateConstraintsResourceLimits struct {
+	// If set, enables CPU limits for the node template.
+	CpuLimitEnabled *bool `json:"cpuLimitEnabled,omitempty"`
+
+	// Specifies the maximum number of CPU cores that the nodes provisioned from this template can collectively have.
+	CpuLimitMaxCores *int32 `json:"cpuLimitMaxCores,omitempty"`
 }
 
 // NodetemplatesV1UpdateNodeTemplate defines model for nodetemplates.v1.UpdateNodeTemplate.
@@ -4502,6 +4512,11 @@ type WorkloadoptimizationV1KeyValuePair struct {
 	Value string `json:"value"`
 }
 
+// WorkloadoptimizationV1ListResourceQuotasResponse defines model for workloadoptimization.v1.ListResourceQuotasResponse.
+type WorkloadoptimizationV1ListResourceQuotasResponse struct {
+	Items []WorkloadoptimizationV1ResourceQuota `json:"items"`
+}
+
 // WorkloadoptimizationV1ListWorkloadEventsResponse defines model for workloadoptimization.v1.ListWorkloadEventsResponse.
 type WorkloadoptimizationV1ListWorkloadEventsResponse struct {
 	Items []WorkloadoptimizationV1WorkloadEvent `json:"items"`
@@ -4767,6 +4782,29 @@ type WorkloadoptimizationV1ResourcePoliciesFunction string
 type WorkloadoptimizationV1ResourceQuantity struct {
 	CpuCores  *float64 `json:"cpuCores"`
 	MemoryGib *float64 `json:"memoryGib"`
+}
+
+// WorkloadoptimizationV1ResourceQuota defines model for workloadoptimization.v1.ResourceQuota.
+type WorkloadoptimizationV1ResourceQuota struct {
+	ClusterId      string                                       `json:"clusterId"`
+	CpuLimits      *WorkloadoptimizationV1ResourceQuotaResource `json:"cpuLimits,omitempty"`
+	CpuRequests    *WorkloadoptimizationV1ResourceQuotaResource `json:"cpuRequests,omitempty"`
+	Id             string                                       `json:"id"`
+	MemoryLimits   *WorkloadoptimizationV1ResourceQuotaResource `json:"memoryLimits,omitempty"`
+	MemoryRequests *WorkloadoptimizationV1ResourceQuotaResource `json:"memoryRequests,omitempty"`
+	Name           string                                       `json:"name"`
+	Namespace      string                                       `json:"namespace"`
+	Object         map[string]interface{}                       `json:"object"`
+	OrganizationId string                                       `json:"organizationId"`
+}
+
+// WorkloadoptimizationV1ResourceQuotaResource defines model for workloadoptimization.v1.ResourceQuotaResource.
+type WorkloadoptimizationV1ResourceQuotaResource struct {
+	// The quota value for a resource. For memory - this is in MiB, for CPU - this is in cores.
+	Hard *float64 `json:"hard"`
+
+	// The used amount of a resource. For memory - this is in MiB, for CPU - this is in cores.
+	Used *float64 `json:"used"`
 }
 
 // WorkloadoptimizationV1Resources defines model for workloadoptimization.v1.Resources.

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -623,6 +623,9 @@ type ClientInterface interface {
 
 	WorkloadOptimizationAPIAssignScalingPolicyWorkloads(ctx context.Context, clusterId string, policyId string, body WorkloadOptimizationAPIAssignScalingPolicyWorkloadsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// WorkloadOptimizationAPIListResourceQuotas request
+	WorkloadOptimizationAPIListResourceQuotas(ctx context.Context, clusterId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// WorkloadOptimizationAPIListWorkloadEvents request
 	WorkloadOptimizationAPIListWorkloadEvents(ctx context.Context, clusterId string, params *WorkloadOptimizationAPIListWorkloadEventsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2983,6 +2986,18 @@ func (c *Client) WorkloadOptimizationAPIAssignScalingPolicyWorkloadsWithBody(ctx
 
 func (c *Client) WorkloadOptimizationAPIAssignScalingPolicyWorkloads(ctx context.Context, clusterId string, policyId string, body WorkloadOptimizationAPIAssignScalingPolicyWorkloadsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewWorkloadOptimizationAPIAssignScalingPolicyWorkloadsRequest(c.Server, clusterId, policyId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) WorkloadOptimizationAPIListResourceQuotas(ctx context.Context, clusterId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewWorkloadOptimizationAPIListResourceQuotasRequest(c.Server, clusterId)
 	if err != nil {
 		return nil, err
 	}
@@ -9802,6 +9817,40 @@ func NewWorkloadOptimizationAPIAssignScalingPolicyWorkloadsRequestWithBody(serve
 	return req, nil
 }
 
+// NewWorkloadOptimizationAPIListResourceQuotasRequest generates requests for WorkloadOptimizationAPIListResourceQuotas
+func NewWorkloadOptimizationAPIListResourceQuotasRequest(server string, clusterId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "clusterId", runtime.ParamLocationPath, clusterId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/workload-autoscaling/clusters/%s/resource-quotas", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewWorkloadOptimizationAPIListWorkloadEventsRequest generates requests for WorkloadOptimizationAPIListWorkloadEvents
 func NewWorkloadOptimizationAPIListWorkloadEventsRequest(server string, clusterId string, params *WorkloadOptimizationAPIListWorkloadEventsParams) (*http.Request, error) {
 	var err error
@@ -10933,6 +10982,9 @@ type ClientWithResponsesInterface interface {
 	WorkloadOptimizationAPIAssignScalingPolicyWorkloadsWithBodyWithResponse(ctx context.Context, clusterId string, policyId string, contentType string, body io.Reader) (*WorkloadOptimizationAPIAssignScalingPolicyWorkloadsResponse, error)
 
 	WorkloadOptimizationAPIAssignScalingPolicyWorkloadsWithResponse(ctx context.Context, clusterId string, policyId string, body WorkloadOptimizationAPIAssignScalingPolicyWorkloadsJSONRequestBody) (*WorkloadOptimizationAPIAssignScalingPolicyWorkloadsResponse, error)
+
+	// WorkloadOptimizationAPIListResourceQuotas request
+	WorkloadOptimizationAPIListResourceQuotasWithResponse(ctx context.Context, clusterId string) (*WorkloadOptimizationAPIListResourceQuotasResponse, error)
 
 	// WorkloadOptimizationAPIListWorkloadEvents request
 	WorkloadOptimizationAPIListWorkloadEventsWithResponse(ctx context.Context, clusterId string, params *WorkloadOptimizationAPIListWorkloadEventsParams) (*WorkloadOptimizationAPIListWorkloadEventsResponse, error)
@@ -15261,6 +15313,36 @@ func (r WorkloadOptimizationAPIAssignScalingPolicyWorkloadsResponse) GetBody() [
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
+type WorkloadOptimizationAPIListResourceQuotasResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *WorkloadoptimizationV1ListResourceQuotasResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r WorkloadOptimizationAPIListResourceQuotasResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r WorkloadOptimizationAPIListResourceQuotasResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r WorkloadOptimizationAPIListResourceQuotasResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
 type WorkloadOptimizationAPIListWorkloadEventsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -17231,6 +17313,15 @@ func (c *ClientWithResponses) WorkloadOptimizationAPIAssignScalingPolicyWorkload
 		return nil, err
 	}
 	return ParseWorkloadOptimizationAPIAssignScalingPolicyWorkloadsResponse(rsp)
+}
+
+// WorkloadOptimizationAPIListResourceQuotasWithResponse request returning *WorkloadOptimizationAPIListResourceQuotasResponse
+func (c *ClientWithResponses) WorkloadOptimizationAPIListResourceQuotasWithResponse(ctx context.Context, clusterId string) (*WorkloadOptimizationAPIListResourceQuotasResponse, error) {
+	rsp, err := c.WorkloadOptimizationAPIListResourceQuotas(ctx, clusterId)
+	if err != nil {
+		return nil, err
+	}
+	return ParseWorkloadOptimizationAPIListResourceQuotasResponse(rsp)
 }
 
 // WorkloadOptimizationAPIListWorkloadEventsWithResponse request returning *WorkloadOptimizationAPIListWorkloadEventsResponse
@@ -21001,6 +21092,32 @@ func ParseWorkloadOptimizationAPIAssignScalingPolicyWorkloadsResponse(rsp *http.
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest WorkloadoptimizationV1AssignScalingPolicyWorkloadsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseWorkloadOptimizationAPIListResourceQuotasResponse parses an HTTP response from a WorkloadOptimizationAPIListResourceQuotasWithResponse call
+func ParseWorkloadOptimizationAPIListResourceQuotasResponse(rsp *http.Response) (*WorkloadOptimizationAPIListResourceQuotasResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &WorkloadOptimizationAPIListResourceQuotasResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest WorkloadoptimizationV1ListResourceQuotasResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -4035,6 +4035,26 @@ func (mr *MockClientInterfaceMockRecorder) WorkloadOptimizationAPIGetWorkloadsSu
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetWorkloadsSummary", reflect.TypeOf((*MockClientInterface)(nil).WorkloadOptimizationAPIGetWorkloadsSummary), varargs...)
 }
 
+// WorkloadOptimizationAPIListResourceQuotas mocks base method.
+func (m *MockClientInterface) WorkloadOptimizationAPIListResourceQuotas(ctx context.Context, clusterId string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, clusterId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIListResourceQuotas", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadOptimizationAPIListResourceQuotas indicates an expected call of WorkloadOptimizationAPIListResourceQuotas.
+func (mr *MockClientInterfaceMockRecorder) WorkloadOptimizationAPIListResourceQuotas(ctx, clusterId interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, clusterId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIListResourceQuotas", reflect.TypeOf((*MockClientInterface)(nil).WorkloadOptimizationAPIListResourceQuotas), varargs...)
+}
+
 // WorkloadOptimizationAPIListWorkloadEvents mocks base method.
 func (m *MockClientInterface) WorkloadOptimizationAPIListWorkloadEvents(ctx context.Context, clusterId string, params *sdk.WorkloadOptimizationAPIListWorkloadEventsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -11126,6 +11146,41 @@ func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIGetWorkloadsSu
 func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIGetWorkloadsSummaryWithResponse(ctx, clusterId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetWorkloadsSummaryWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIGetWorkloadsSummaryWithResponse), ctx, clusterId)
+}
+
+// WorkloadOptimizationAPIListResourceQuotas mocks base method.
+func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIListResourceQuotas(ctx context.Context, clusterId string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, clusterId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIListResourceQuotas", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadOptimizationAPIListResourceQuotas indicates an expected call of WorkloadOptimizationAPIListResourceQuotas.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIListResourceQuotas(ctx, clusterId interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, clusterId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIListResourceQuotas", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIListResourceQuotas), varargs...)
+}
+
+// WorkloadOptimizationAPIListResourceQuotasWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIListResourceQuotasWithResponse(ctx context.Context, clusterId string) (*sdk.WorkloadOptimizationAPIListResourceQuotasResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIListResourceQuotasWithResponse", ctx, clusterId)
+	ret0, _ := ret[0].(*sdk.WorkloadOptimizationAPIListResourceQuotasResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadOptimizationAPIListResourceQuotasWithResponse indicates an expected call of WorkloadOptimizationAPIListResourceQuotasWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIListResourceQuotasWithResponse(ctx, clusterId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIListResourceQuotasWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIListResourceQuotasWithResponse), ctx, clusterId)
 }
 
 // WorkloadOptimizationAPIListWorkloadEvents mocks base method.

--- a/examples/aks/aks_cluster_with_proxy/README.MD
+++ b/examples/aks/aks_cluster_with_proxy/README.MD
@@ -11,9 +11,10 @@ The AKS cluster has the following setup:
 The goal of this example is to show how to configure CAST AI components so http proxy is enforced when communicating with the platform. 
 
 Example configuration should be analysed in the following order:
-1. Create Virtual network - `vnet.tf`
-2. Create AKS cluster - `aks.tf`
-3. Create CAST AI related resources to connect AKS cluster to CAST AI, configure Autoscaler and Node Configurations - `castai.tf`
+1. Setup network topology - `network.tf`
+2. Setup firewalls - `egress_firewall.tf` and `proxy_firewall.tf`
+3. Create AKS cluster and configure it to use one firewall for egress - `aks.tf`
+4. Create CAST AI related resources to connect AKS cluster to CAST AI and configure basic cluster components to use egress proxy - `castai.tf`.
 
 # Usage
 1. Rename `tf.vars.example` to `tf.vars`

--- a/examples/aks/aks_cluster_with_proxy/README.MD
+++ b/examples/aks/aks_cluster_with_proxy/README.MD
@@ -1,0 +1,34 @@
+# AKS and CAST AI example where nodes require egress proxy configuration
+Following example shows how to onboard AKS cluster to CAST AI, configure [Autoscaler policies](https://docs.cast.ai/reference/policiesapi_upsertclusterpolicies) and additional [Node Configurations](https://docs.cast.ai/docs/node-configuration/).
+
+The AKS cluster has the following setup:
+1. AKS cluster, a VNET and two firewalls are deployed in their own resource group.
+2. AKS cluster is set up to use one of the firewalls for egress communication. 
+3. Default communication for the cluster goes through a firewall that only allows traffic for AKS to work. No other egress traffic is allowed.
+4. A second firewall is deployed in a peered VNET to the cluster's VNET. The firewall is in explicit proxy mode. This firewall allows egress traffic to CAST AI and Google storage (required by CAST).
+5. The cluster is onboarded in CAST AI and configured so that the proxy firewall is used for egress communication. 
+
+The goal of this example is to show how to configure CAST AI components so http proxy is enforced when communicating with the platform. 
+
+Example configuration should be analysed in the following order:
+1. Create Virtual network - `vnet.tf`
+2. Create AKS cluster - `aks.tf`
+3. Create CAST AI related resources to connect AKS cluster to CAST AI, configure Autoscaler and Node Configurations - `castai.tf`
+
+# Usage
+1. Rename `tf.vars.example` to `tf.vars`
+2. Update `tf.vars` file with your cluster name, cluster region and CAST AI API token.
+3. Initialize Terraform. Under example root folder run:
+```
+terraform init
+```
+4. Run Terraform apply:
+```
+terraform apply -var-file=tf.vars
+```
+5. To destroy resources created by this example:
+```
+terraform destroy -var-file=tf.vars
+```
+
+Please refer to this guide if you run into any issues https://docs.cast.ai/docs/terraform-troubleshooting

--- a/examples/aks/aks_cluster_with_proxy/aks.tf
+++ b/examples/aks/aks_cluster_with_proxy/aks.tf
@@ -66,4 +66,10 @@ resource "azurerm_kubernetes_cluster" "aks" {
     azurerm_route_table.route_table,
     azurerm_subnet_route_table_association.route_table_association
   ]
+
+  lifecycle {
+    ignore_changes = [
+      tags["CreatedAt"]
+    ]
+  }
 }

--- a/examples/aks/aks_cluster_with_proxy/aks.tf
+++ b/examples/aks/aks_cluster_with_proxy/aks.tf
@@ -1,0 +1,69 @@
+
+resource "azurerm_resource_group" "rg" {
+  name     = var.resource_group_name
+  location = var.cluster_region
+}
+
+resource "azurerm_route_table" "route_table" {
+  name                = "aks-route-table"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  depends_on          = [azurerm_subnet.egress_firewall_subnet]
+}
+
+resource "azurerm_subnet_route_table_association" "route_table_association" {
+  subnet_id      = azurerm_subnet.aks_subnet.id
+  route_table_id = azurerm_route_table.route_table.id
+}
+
+resource "azurerm_route" "egress_route" {
+  name                   = "default-egress"
+  route_table_name       = azurerm_route_table.route_table.name
+  resource_group_name    = azurerm_resource_group.rg.name
+  address_prefix         = "0.0.0.0/0"
+  next_hop_type          = "VirtualAppliance"
+  next_hop_in_ip_address = azurerm_firewall.egress_firewall.ip_configuration[0].private_ip_address
+}
+
+resource "azurerm_route" "internet_route" {
+  name                = "internet-egress"
+  route_table_name    = azurerm_route_table.route_table.name
+  resource_group_name = azurerm_resource_group.rg.name
+  address_prefix      = "${azurerm_public_ip.firewall_public_ip.ip_address}/32"
+  next_hop_type       = "Internet"
+}
+
+resource "azurerm_kubernetes_cluster" "aks" {
+  name                = var.cluster_name
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  dns_prefix          = "aksproxy"
+
+  default_node_pool {
+    name           = "agentpool"
+    vm_size        = "Standard_DS2_v2"
+    node_count     = 2
+    vnet_subnet_id = azurerm_subnet.aks_subnet.id
+
+    upgrade_settings {
+      drain_timeout_in_minutes      = 0
+      max_surge                     = "10%"
+      node_soak_duration_in_minutes = 0
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin = "azure"
+    network_policy = "azure"
+    outbound_type  = "userDefinedRouting"
+  }
+
+  depends_on = [
+    azurerm_route_table.route_table,
+    azurerm_subnet_route_table_association.route_table_association
+  ]
+}

--- a/examples/aks/aks_cluster_with_proxy/castai.tf
+++ b/examples/aks/aks_cluster_with_proxy/castai.tf
@@ -36,6 +36,7 @@ module "castai-aks-cluster" {
     }
   }
 
+  # Configure proxy and disable VPA. The VPA image source is dynamic and hard to make a static "firewall" rule for - this should make running the example easier.
   agent_values = [
     <<-EOF
     podAnnotations:
@@ -44,6 +45,8 @@ module "castai-aks-cluster" {
       HTTP_PROXY: "${local.http_proxy_address}"
       HTTPS_PROXY: "${local.https_proxy_address}"
       NO_PROXY: "${join(",", local.no_proxy_agent)}"
+    clusterVPA:
+      enabled: false
     EOF
   ]
 
@@ -61,6 +64,7 @@ module "castai-aks-cluster" {
   # Networking setup should be completed before trying to onboard cluster; otherwise components get stuck with no connectivity.
   depends_on = [
     azurerm_firewall.egress_firewall,
-    azurerm_firewall.explicit_firewall
+    azurerm_firewall.explicit_firewall,
+    azurerm_firewall_network_rule_collection.egress_rule
   ]
 }

--- a/examples/aks/aks_cluster_with_proxy/castai.tf
+++ b/examples/aks/aks_cluster_with_proxy/castai.tf
@@ -6,8 +6,7 @@ locals {
 }
 
 module "castai-aks-cluster" {
-  # source = "castai/aks/castai"
-  source = "/Users/lachezar/Src/terraform-castai-aks"
+  source = "castai/aks/castai"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/aks/aks_cluster_with_proxy/castai.tf
+++ b/examples/aks/aks_cluster_with_proxy/castai.tf
@@ -58,4 +58,10 @@ module "castai-aks-cluster" {
       NO_PROXY: "${join(",", local.no_proxy_default)}"
     EOF
   ]
+
+  # Networking setup should be completed before trying to onboard cluster; otherwise components get stuck with no connectivity.
+  depends_on = [
+    azurerm_firewall.egress_firewall,
+    azurerm_firewall.explicit_firewall
+  ]
 }

--- a/examples/aks/aks_cluster_with_proxy/castai.tf
+++ b/examples/aks/aks_cluster_with_proxy/castai.tf
@@ -1,0 +1,61 @@
+locals {
+  http_proxy_address = "${azurerm_firewall.explicit_firewall.ip_configuration[0].private_ip_address}:${azurerm_firewall_policy.explicit_proxy_policy.explicit_proxy[0].http_port}"
+  https_proxy_address = "${azurerm_firewall.explicit_firewall.ip_configuration[0].private_ip_address}:${azurerm_firewall_policy.explicit_proxy_policy.explicit_proxy[0].https_port}"
+  no_proxy_default = concat([azurerm_kubernetes_cluster.aks.fqdn], var.fqdn_without_proxy)
+  no_proxy_agent = concat(local.no_proxy_default, ["169.254.169.254"])  # Agent requires access to local metadata endpoint as well
+}
+
+module "castai-aks-cluster" {
+  # source = "castai/aks/castai"
+  source = "/Users/lachezar/Src/terraform-castai-aks"
+
+  api_url                = var.castai_api_url
+  castai_api_token       = var.castai_api_token
+  grpc_url               = var.castai_grpc_url
+  wait_for_cluster_ready = true
+
+  aks_cluster_name    = var.cluster_name
+  aks_cluster_region  = azurerm_kubernetes_cluster.aks.location
+  node_resource_group = azurerm_kubernetes_cluster.aks.node_resource_group
+  resource_group      = azurerm_kubernetes_cluster.aks.resource_group_name
+
+  http_proxy = local.http_proxy_address
+  https_proxy = local.https_proxy_address
+  no_proxy = var.fqdn_without_proxy
+
+  delete_nodes_on_disconnect = true
+
+  subscription_id = data.azurerm_subscription.current.subscription_id
+  tenant_id       = data.azurerm_subscription.current.tenant_id
+
+  default_node_configuration = module.castai-aks-cluster.castai_node_configurations["default"]
+
+  node_configurations = {
+    default = {
+      disk_cpu_ratio = 25
+      subnets        = [azurerm_subnet.aks_subnet.id]
+    }
+  }
+
+  agent_values = [
+    <<-EOF
+    podAnnotations:
+      kubernetes.azure.com/set-kube-service-host-fqdn: "true"
+    additionalEnv:
+      HTTP_PROXY: "${local.http_proxy_address}"
+      HTTPS_PROXY: "${local.https_proxy_address}"
+      NO_PROXY: "${join(",", local.no_proxy_agent)}"
+    EOF
+  ]
+
+  cluster_controller_values = [
+    <<-EOF
+    podAnnotations:
+      kubernetes.azure.com/set-kube-service-host-fqdn: "true"
+    additionalEnv:
+      HTTP_PROXY: "${local.http_proxy_address}"
+      HTTPS_PROXY: "${local.https_proxy_address}"
+      NO_PROXY: "${join(",", local.no_proxy_default)}"
+    EOF
+  ]
+}

--- a/examples/aks/aks_cluster_with_proxy/castai.tf
+++ b/examples/aks/aks_cluster_with_proxy/castai.tf
@@ -1,8 +1,8 @@
 locals {
-  http_proxy_address = "${azurerm_firewall.explicit_firewall.ip_configuration[0].private_ip_address}:${azurerm_firewall_policy.explicit_proxy_policy.explicit_proxy[0].http_port}"
+  http_proxy_address  = "${azurerm_firewall.explicit_firewall.ip_configuration[0].private_ip_address}:${azurerm_firewall_policy.explicit_proxy_policy.explicit_proxy[0].http_port}"
   https_proxy_address = "${azurerm_firewall.explicit_firewall.ip_configuration[0].private_ip_address}:${azurerm_firewall_policy.explicit_proxy_policy.explicit_proxy[0].https_port}"
-  no_proxy_default = concat([azurerm_kubernetes_cluster.aks.fqdn], var.fqdn_without_proxy)
-  no_proxy_agent = concat(local.no_proxy_default, ["169.254.169.254"])  # Agent requires access to local metadata endpoint as well
+  no_proxy_default    = concat([azurerm_kubernetes_cluster.aks.fqdn], var.fqdn_without_proxy)
+  no_proxy_agent      = concat(local.no_proxy_default, ["169.254.169.254"]) # Agent requires access to local metadata endpoint as well
 }
 
 module "castai-aks-cluster" {
@@ -18,9 +18,9 @@ module "castai-aks-cluster" {
   node_resource_group = azurerm_kubernetes_cluster.aks.node_resource_group
   resource_group      = azurerm_kubernetes_cluster.aks.resource_group_name
 
-  http_proxy = local.http_proxy_address
+  http_proxy  = local.http_proxy_address
   https_proxy = local.https_proxy_address
-  no_proxy = var.fqdn_without_proxy
+  no_proxy    = var.fqdn_without_proxy
 
   delete_nodes_on_disconnect = true
 

--- a/examples/aks/aks_cluster_with_proxy/data.tf
+++ b/examples/aks/aks_cluster_with_proxy/data.tf
@@ -1,0 +1,3 @@
+data "azuread_client_config" "current" {}
+
+data "azurerm_subscription" "current" {}

--- a/examples/aks/aks_cluster_with_proxy/egress_firewall.tf
+++ b/examples/aks/aks_cluster_with_proxy/egress_firewall.tf
@@ -93,9 +93,9 @@ resource "azurerm_firewall_network_rule_collection" "egress_rule" {
   dynamic "rule" {
     for_each = length(var.fqdn_without_proxy) > 0 ? [1] : []
     content {
-      name = "allowed_fqdns"
-      protocols = ["Any"]
-      source_addresses = ["10.42.1.0/24"]
+      name              = "allowed_fqdns"
+      protocols         = ["Any"]
+      source_addresses  = ["10.42.1.0/24"]
       destination_fqdns = var.fqdn_without_proxy
       destination_ports = ["80", "443"]
     }

--- a/examples/aks/aks_cluster_with_proxy/egress_firewall.tf
+++ b/examples/aks/aks_cluster_with_proxy/egress_firewall.tf
@@ -1,0 +1,165 @@
+
+resource "azurerm_firewall" "egress_firewall" {
+  name                = "aks-firewall"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
+  dns_proxy_enabled   = true
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.egress_firewall_subnet.id
+    public_ip_address_id = azurerm_public_ip.firewall_public_ip.id
+  }
+}
+
+resource "azurerm_public_ip" "firewall_public_ip" {
+  name                = "firewall-public-ip"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+
+resource "azurerm_firewall_network_rule_collection" "egress_rule" {
+  name                = "egress-rule"
+  azure_firewall_name = azurerm_firewall.egress_firewall.name
+  resource_group_name = azurerm_resource_group.rg.name
+  priority            = 100
+  action              = "Allow"
+
+  rule {
+    name                  = "apiudp"
+    protocols             = ["UDP"]
+    source_addresses      = ["10.42.1.0/24"]
+    destination_addresses = ["AzureCloud.${azurerm_resource_group.rg.location}"]
+    destination_ports     = ["1194"]
+  }
+  rule {
+    name                  = "apitcp"
+    protocols             = ["TCP"]
+    source_addresses      = ["10.42.1.0/24"]
+    destination_addresses = ["AzureCloud.${azurerm_resource_group.rg.location}"]
+    destination_ports     = ["9000"]
+  }
+  rule {
+    name                  = "time"
+    protocols             = ["UDP"]
+    source_addresses      = ["10.42.1.0/24"]
+    destination_addresses = ["*"]
+    destination_ports     = ["123"]
+  }
+  rule {
+    name              = "ghcr"
+    protocols         = ["TCP"]
+    source_addresses  = ["10.42.1.0/24"]
+    destination_fqdns = ["ghcr.io", "pkg-containers.githubusercontent.com"]
+    destination_ports = ["443"]
+  }
+  rule {
+    name             = "docker"
+    protocols        = ["TCP"]
+    source_addresses = ["10.42.1.0/24"]
+    destination_fqdns = [
+      # Some registries used by system images or CAST AI images.
+      "docker.io",
+      "registry-1.docker.io",
+      "production.cloudflare.docker.com",
+      "registry.k8s.io",
+      "us-docker.pkg.dev",
+      "europe-west2-docker.pkg.dev",
+      "prod-registry-k8s-io-eu-west-1.s3.dualstack.eu-west-1.amazonaws.com"
+    ]
+    destination_ports = ["443"]
+  }
+  rule {
+    name                  = "dns"
+    source_addresses      = ["10.42.1.0/24"]
+    destination_ports     = ["53"]
+    destination_addresses = ["*"]
+    protocols = [
+      "Any"
+    ]
+  }
+
+  dynamic "rule" {
+    for_each = length(var.fqdn_without_proxy) > 0 ? [1] : []
+    content {
+      name = "allowed_fqdns"
+      protocols = ["Any"]
+      source_addresses = ["10.42.1.0/24"]
+      destination_fqdns = var.fqdn_without_proxy
+      destination_ports = ["80", "443"]
+    }
+  }
+}
+
+
+resource "azurerm_firewall_network_rule_collection" "servicetags" {
+  name                = "servicetags"
+  azure_firewall_name = azurerm_firewall.egress_firewall.name
+  resource_group_name = azurerm_resource_group.rg.name
+  priority            = 200
+  action              = "Allow"
+
+  rule {
+    name              = "allow service tags"
+    source_addresses  = ["10.42.1.0/24"]
+    destination_ports = ["*"]
+    destination_addresses = [
+      "AzureContainerRegistry.${azurerm_resource_group.rg.location}",
+      "MicrosoftContainerRegistry.${azurerm_resource_group.rg.location}",
+      "AzureActiveDirectory",
+      "AzureMonitor",
+      "AzureWebPubSub",
+      "Storage",
+      "StorageSyncService"
+    ]
+    protocols = [
+      "Any"
+    ]
+  }
+}
+
+resource "azurerm_firewall_application_rule_collection" "fw-aks-google" {
+  name                = "forbid-gcs-explicit"
+  azure_firewall_name = azurerm_firewall.egress_firewall.name
+  resource_group_name = azurerm_resource_group.rg.name
+  priority            = 300
+  action              = "Deny"
+
+  # We add this rule because allowing traffic to the AKS FQDN tag actually includes `storage.googleapis.com` as well (at least at time of writing).
+  # In order to simulate environment where this is not allowed by default (as CAST AI depends on it), we explicitly forbid it.
+  # The list of URLs behind the tag is not public and dynamic; this was found via trial and error.
+  rule {
+    name             = "forbid google storage for testing fqdn for AKS"
+    source_addresses = ["*"]
+    target_fqdns     = ["storage.googleapis.com"]
+
+    protocol {
+      port = "443"
+      type = "Https"
+    }
+
+    protocol {
+      port = "80"
+      type = "Http"
+    }
+  }
+}
+
+resource "azurerm_firewall_application_rule_collection" "fw-aks" {
+  name                = "application-rules"
+  azure_firewall_name = azurerm_firewall.egress_firewall.name
+  resource_group_name = azurerm_resource_group.rg.name
+  priority            = 400
+  action              = "Allow"
+
+  rule {
+    name             = "allow fqdn for AKS"
+    source_addresses = ["10.42.1.0/24"]
+    fqdn_tags        = ["AzureKubernetesService"]
+  }
+}

--- a/examples/aks/aks_cluster_with_proxy/egress_firewall.tf
+++ b/examples/aks/aks_cluster_with_proxy/egress_firewall.tf
@@ -12,6 +12,12 @@ resource "azurerm_firewall" "egress_firewall" {
     subnet_id            = azurerm_subnet.egress_firewall_subnet.id
     public_ip_address_id = azurerm_public_ip.firewall_public_ip.id
   }
+
+  lifecycle {
+    ignore_changes = [
+      tags["CreatedAt"]
+    ]
+  }
 }
 
 resource "azurerm_public_ip" "firewall_public_ip" {

--- a/examples/aks/aks_cluster_with_proxy/network.tf
+++ b/examples/aks/aks_cluster_with_proxy/network.tf
@@ -1,0 +1,60 @@
+resource "azurerm_virtual_network" "vnet" {
+  name                = "aks-vnet"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  address_space       = ["10.42.0.0/16"]
+}
+
+resource "azurerm_subnet" "aks_subnet" {
+  name                 = "aks-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.42.1.0/24"]
+}
+
+resource "azurerm_subnet" "egress_firewall_subnet" {
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.42.2.0/24"]
+}
+
+
+resource "azurerm_virtual_network" "proxy_vnet" {
+  name                = "proxy-vnet"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  address_space       = ["10.43.0.0/16"]
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_subnet" "explicit_firewall_subnet" {
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.proxy_vnet.name
+  address_prefixes     = ["10.43.1.0/24"]
+}
+
+resource "azurerm_virtual_network_peering" "peer_vnets" {
+  name                         = "peer-firewall-vnets"
+  resource_group_name          = azurerm_resource_group.rg.name
+  virtual_network_name         = azurerm_virtual_network.proxy_vnet.name
+  remote_virtual_network_id    = azurerm_virtual_network.vnet.id
+  allow_virtual_network_access = true
+
+  depends_on = [azurerm_virtual_network.proxy_vnet]
+}
+
+
+resource "azurerm_virtual_network_peering" "peer_vnets_reverse" {
+  name                         = "peer-firewall-vnets-reverse"
+  resource_group_name          = azurerm_resource_group.rg.name
+  virtual_network_name         = azurerm_virtual_network.vnet.name
+  remote_virtual_network_id    = azurerm_virtual_network.proxy_vnet.id
+  allow_virtual_network_access = true
+
+  depends_on = [azurerm_virtual_network.proxy_vnet]
+}
+

--- a/examples/aks/aks_cluster_with_proxy/providers.tf
+++ b/examples/aks/aks_cluster_with_proxy/providers.tf
@@ -6,3 +6,17 @@ provider "azurerm" {
 provider "azuread" {
   tenant_id = data.azurerm_subscription.current.tenant_id
 }
+
+provider "castai" {
+  api_url   = var.castai_api_url
+  api_token = var.castai_api_token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = azurerm_kubernetes_cluster.aks.kube_config.0.host
+    client_certificate     = base64decode(azurerm_kubernetes_cluster.aks.kube_config.0.client_certificate)
+    client_key             = base64decode(azurerm_kubernetes_cluster.aks.kube_config.0.client_key)
+    cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.aks.kube_config.0.cluster_ca_certificate)
+  }
+}

--- a/examples/aks/aks_cluster_with_proxy/providers.tf
+++ b/examples/aks/aks_cluster_with_proxy/providers.tf
@@ -1,0 +1,8 @@
+provider "azurerm" {
+  subscription_id = var.subscription_id
+  features {}
+}
+
+provider "azuread" {
+  tenant_id = data.azurerm_subscription.current.tenant_id
+}

--- a/examples/aks/aks_cluster_with_proxy/proxy_firewall.tf
+++ b/examples/aks/aks_cluster_with_proxy/proxy_firewall.tf
@@ -1,0 +1,99 @@
+resource "azurerm_public_ip" "explicit_firewall_ip" {
+  name                = "explicit-firewall-public-ip"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+
+resource "azurerm_firewall" "explicit_firewall" {
+  name                = "explicit-proxy-firewall"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.explicit_firewall_subnet.id
+    public_ip_address_id = azurerm_public_ip.explicit_firewall_ip.id
+  }
+
+  firewall_policy_id = azurerm_firewall_policy.explicit_proxy_policy.id
+}
+
+
+resource "azurerm_firewall_policy" "explicit_proxy_policy" {
+  name                = "explicit-proxy-policy"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+
+  explicit_proxy {
+    enabled = true
+
+    http_port  = 3128
+    https_port = 3129
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+
+resource "azurerm_firewall_policy_rule_collection_group" "explicit_proxy_rules" {
+  name               = "allow-any-traffic"
+  firewall_policy_id = azurerm_firewall_policy.explicit_proxy_policy.id
+  priority           = 100
+
+  network_rule_collection {
+    name     = "allow-all"
+    action   = "Allow"
+    priority = 100
+
+    rule {
+      name                  = "allow-all"
+      protocols             = ["Any"]
+      source_addresses      = ["*"]
+      destination_addresses = ["*"]
+      destination_ports     = ["80", "443"]
+    }
+  }
+
+  application_rule_collection {
+    name = "allow-traffic"
+    action = "Allow"
+    priority =  200
+
+    rule {
+      name = "allow-cast"
+      protocols {
+        port = "80"
+        type = "Http"
+      }
+      protocols {
+        port = "443"
+        type = "Https"
+      }
+      source_addresses = ["*"]
+      destination_fqdns = [ "api.cast.ai", "cast.ai", "storage.googleapis.com" ]
+    }
+
+    # Uncomment to allow all traffic
+    # rule {
+    #   name = "allow-all"
+    #   protocols {
+    #     port = "80"
+    #     type = "Http"
+    #   }
+    #   protocols {
+    #     port = "443"
+    #     type = "Https"
+    #   }
+    #   source_addresses = ["*"]
+    #   destination_fqdns = [ "*" ]
+    # }
+  }
+}
+

--- a/examples/aks/aks_cluster_with_proxy/proxy_firewall.tf
+++ b/examples/aks/aks_cluster_with_proxy/proxy_firewall.tf
@@ -1,7 +1,7 @@
 locals {
   # Regexes from https://developer.hashicorp.com/terraform/language/functions/regex#examples
   castai_api_url_parts = regex("(?:(?P<scheme>[^:/?#]+):)?(?://(?P<authority>[^/?#]*))?(?P<path>[^?#]*)(?:\\?(?P<query>[^#]*))?(?:#(?P<fragment>.*))?", var.castai_api_url)
-  castai_api_fqdn = local.castai_api_url_parts["authority"]
+  castai_api_fqdn      = local.castai_api_url_parts["authority"]
 }
 
 resource "azurerm_public_ip" "explicit_firewall_ip" {
@@ -74,9 +74,9 @@ resource "azurerm_firewall_policy_rule_collection_group" "explicit_proxy_rules" 
   }
 
   application_rule_collection {
-    name = "allow-traffic"
-    action = "Allow"
-    priority =  200
+    name     = "allow-traffic"
+    action   = "Allow"
+    priority = 200
 
     rule {
       name = "allow-cast"

--- a/examples/aks/aks_cluster_with_proxy/tf.vars.example
+++ b/examples/aks/aks_cluster_with_proxy/tf.vars.example
@@ -1,0 +1,4 @@
+cluster_name     = "EXAMPLE"
+cluster_region   = "EXAMPLE"
+castai_api_token = "EXAMPLE"
+subscription_id  = "<place-holder>"

--- a/examples/aks/aks_cluster_with_proxy/tf.vars.example
+++ b/examples/aks/aks_cluster_with_proxy/tf.vars.example
@@ -2,3 +2,4 @@ cluster_name     = "EXAMPLE"
 cluster_region   = "EXAMPLE"
 castai_api_token = "EXAMPLE"
 subscription_id  = "<place-holder>"
+fqdn_without_proxy = [fqdn1", "fqdn2"]

--- a/examples/aks/aks_cluster_with_proxy/variables.tf
+++ b/examples/aks/aks_cluster_with_proxy/variables.tf
@@ -24,6 +24,12 @@ variable "castai_api_token" {
   description = "CAST AI API token created in console.cast.ai API Access keys section."
 }
 
+variable "castai_grpc_url" {
+  type        = string
+  description = "CAST AI gRPC URL"
+  default     = "grpc.cast.ai:443"
+}
+
 variable "subscription_id" {
   type        = string
   description = "Azure subscription ID"

--- a/examples/aks/aks_cluster_with_proxy/variables.tf
+++ b/examples/aks/aks_cluster_with_proxy/variables.tf
@@ -36,7 +36,7 @@ variable "subscription_id" {
 }
 
 variable "fqdn_without_proxy" {
-  type = list(string)
+  type        = list(string)
   description = "FQDNs that will be allowed on the AKS egress firewall and will not require proxy setup."
-  default = []
+  default     = []
 }

--- a/examples/aks/aks_cluster_with_proxy/variables.tf
+++ b/examples/aks/aks_cluster_with_proxy/variables.tf
@@ -1,0 +1,36 @@
+variable "cluster_name" {
+  type        = string
+  description = "Name of the AKS cluster to be connected to the CAST AI."
+}
+
+variable "cluster_region" {
+  type        = string
+  description = "Region of the cluster to be connected to CAST AI."
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Name of Azure Resource group that will be created for the cluster."
+}
+
+variable "castai_api_url" {
+  type        = string
+  description = "CAST AI url to API, default value is https://api.cast.ai"
+  default     = "https://api.cast.ai"
+}
+
+variable "castai_api_token" {
+  type        = string
+  description = "CAST AI API token created in console.cast.ai API Access keys section."
+}
+
+variable "subscription_id" {
+  type        = string
+  description = "Azure subscription ID"
+}
+
+variable "fqdn_without_proxy" {
+  type = list(string)
+  description = "FQDNs that will be allowed on the AKS egress firewall and will not require proxy setup."
+  default = []
+}

--- a/examples/aks/aks_cluster_with_proxy/versions.tf
+++ b/examples/aks/aks_cluster_with_proxy/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    azuread = {
+      source = "hashicorp/azuread"
+    }
+    castai = {
+      source = "castai/castai"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
This is mostly to show how to use (and test) the HTTP proxy functionality as it is not always obvious how to configure an AKS cluster with proxy setup. 