### PR TITLE
NOJIRA: Don't cancel existing build jobs (long running) but queue instead.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 # Only one instance of this job can be running
 concurrency:
   group: build-and-test
-  cancel-in-progress: true
+  cancel-in-progress: false # Don't cancel other people's jobs; currently 1 job can be queued so it's still possible to "override" other people.
 
 on:
   pull_request:


### PR DESCRIPTION
At least this way 2 people doing MRs won't be stepping on each other's toes.