### PR TITLE
feat: support granular aggressive mode config

### DIFF
--- a/castai/data_source_resource_rebalancing_schedule_test.go
+++ b/castai/data_source_resource_rebalancing_schedule_test.go
@@ -50,7 +50,10 @@ func TestRebalancingScheduleDataSourceRead(t *testing.T) {
                     "evictGracefully": false,
                     "aggressiveMode": false,
                     "aggressiveModeConfig": {
-                        "ignoreLocalPersistentVolumes": true	
+                        "ignoreLocalPersistentVolumes": true,
+						"ignoreProblemJobPods": true,
+						"ignoreProblemRemovalDisabledPods": true,
+						"ignoreProblemPodsWithoutController": true
                     }
                 },
                 "numTargetedNodes": 20,
@@ -131,6 +134,9 @@ launch_configuration.# = 1
 launch_configuration.0.aggressive_mode = false
 launch_configuration.0.aggressive_mode_config.# = 1
 launch_configuration.0.aggressive_mode_config.0.ignore_local_persistent_volumes = true
+launch_configuration.0.aggressive_mode_config.0.ignore_problem_job_pods = true
+launch_configuration.0.aggressive_mode_config.0.ignore_problem_pods_without_controller = true
+launch_configuration.0.aggressive_mode_config.0.ignore_problem_removal_disabled_pods = true
 launch_configuration.0.execution_conditions.# = 1
 launch_configuration.0.execution_conditions.0.achieved_savings_percentage = 15
 launch_configuration.0.execution_conditions.0.enabled = true

--- a/castai/resource_rebalancing_schedule_test.go
+++ b/castai/resource_rebalancing_schedule_test.go
@@ -44,6 +44,9 @@ func TestAccResourceRebalancingSchedule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("castai_rebalancing_schedule.test", "schedule.0.cron", "1 4 * * *"),
 					resource.TestCheckResourceAttr("castai_rebalancing_schedule.test", "launch_configuration.0.aggressive_mode", "true"),
 					resource.TestCheckResourceAttr("castai_rebalancing_schedule.test", "launch_configuration.0.aggressive_mode_config.0.ignore_local_persistent_volumes", "true"),
+					resource.TestCheckResourceAttr("castai_rebalancing_schedule.test", "launch_configuration.0.aggressive_mode_config.0.ignore_problem_job_pods", "true"),
+					resource.TestCheckResourceAttr("castai_rebalancing_schedule.test", "launch_configuration.0.aggressive_mode_config.0.ignore_problem_removal_disabled_pods", "true"),
+					resource.TestCheckResourceAttr("castai_rebalancing_schedule.test", "launch_configuration.0.aggressive_mode_config.0.ignore_problem_pods_without_controller", "true"),
 				),
 			},
 			{
@@ -96,6 +99,9 @@ resource "castai_rebalancing_schedule" "test" {
 		aggressive_mode = true
 		aggressive_mode_config {
       		ignore_local_persistent_volumes = true
+      		ignore_problem_job_pods = true
+      		ignore_problem_removal_disabled_pods = true
+      		ignore_problem_pods_without_controller = true
     	}
 		selector = jsonencode({
 			nodeSelectorTerms = [{

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -4093,8 +4093,22 @@ type PoliciesV1UnschedulablePodsPolicy struct {
 
 // ScheduledrebalancingV1AggressiveModeConfig defines model for scheduledrebalancing.v1.AggressiveModeConfig.
 type ScheduledrebalancingV1AggressiveModeConfig struct {
-	// Rebalance workloads using local-path Persistent Volumes. THIS WILL RESULT IN DATA LOSS.
+	// Rebalance workloads that use local-path Persistent Volumes.
+	// WARNING: THIS WILL RESULT IN DATA LOSS.
 	IgnoreLocalPersistentVolumes *bool `json:"ignoreLocalPersistentVolumes,omitempty"`
+
+	// Pods spawned by Jobs or CronJobs will not prevent the Rebalancer from deleting a node on which they run.
+	// WARNING: When true, pods spawned by Jobs or CronJobs will be terminated if the Rebalancer picks a node that runs them.
+	// As such, they are likely to lose their progress.
+	IgnoreProblemJobPods *bool `json:"ignoreProblemJobPods,omitempty"`
+
+	// Pods that don't have a controller (bare pods) will not prevent the Rebalancer from deleting a node on which they run.
+	// WARNING: When true, such pods might not restart, since they have no controller to do it.
+	IgnoreProblemPodsWithoutController *bool `json:"ignoreProblemPodsWithoutController,omitempty"`
+
+	// Pods that are marked with "removal disabled" will not prevent the Rebalancer from deleting a node on which they run.
+	// WARNING: When true, such pods will be evicted and disrupted.
+	IgnoreProblemRemovalDisabledPods *bool `json:"ignoreProblemRemovalDisabledPods,omitempty"`
 }
 
 // ScheduledrebalancingV1DeleteRebalancingJobResponse defines model for scheduledrebalancing.v1.DeleteRebalancingJobResponse.

--- a/docs/data-sources/rebalancing_schedule.md
+++ b/docs/data-sources/rebalancing_schedule.md
@@ -47,6 +47,9 @@ Read-Only:
 Read-Only:
 
 - `ignore_local_persistent_volumes` (Boolean)
+- `ignore_problem_job_pods` (Boolean)
+- `ignore_problem_pods_without_controller` (Boolean)
+- `ignore_problem_removal_disabled_pods` (Boolean)
 
 
 <a id="nestedobjatt--launch_configuration--execution_conditions"></a>

--- a/docs/resources/rebalancing_schedule.md
+++ b/docs/resources/rebalancing_schedule.md
@@ -83,7 +83,10 @@ Optional:
 
 Required:
 
-- `ignore_local_persistent_volumes` (Boolean) Rebalance workloads using local-path Persistent Volumes. THIS WILL RESULT IN DATA LOSS.
+- `ignore_local_persistent_volumes` (Boolean) Rebalance workloads that use local-path Persistent Volumes. THIS WILL RESULT IN DATA LOSS.
+- `ignore_problem_job_pods` (Boolean) Pods spawned by Jobs or CronJobs will not prevent the Rebalancer from deleting a node on which they run. WARNING: When true, pods spawned by Jobs or CronJobs will be terminated if the Rebalancer picks a node that runs them. As such, they are likely to lose their progress.
+- `ignore_problem_pods_without_controller` (Boolean) Pods that don't have a controller (bare pods) will not prevent the Rebalancer from deleting a node on which they run. WARNING: When true, such pods might not restart, since they have no controller to do it.
+- `ignore_problem_removal_disabled_pods` (Boolean) Pods that are marked with "removal disabled" will not prevent the Rebalancer from deleting a node on which they run. WARNING: When true, such pods will be evicted and disrupted.
 
 
 <a id="nestedblock--launch_configuration--execution_conditions"></a>


### PR DESCRIPTION
This PR adds support for an updated granular aggressive mode config in scheduled rebalancing. We intend to replace the legacy bool-based `aggressiveMode` flag by this config.