### PR TITLE
KUBE-766: bugfix: cast_service_account on read

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ init-examples:
 	GOOS=`go env GOOS`; \
 	GOARCH=`go env GOARCH`; \
 	git fetch --tags > /dev/null; \
-	NEXT_MINOR=`git tag --list 'v*'|sort|tail -n 1| awk -F. -v OFS=. '{$$NF += 1 ; print}'`; \
+	NEXT_MINOR=`git tag --list 'v*'|sort -V|tail -n 1| awk -F. -v OFS=. '{$$NF += 1 ; print}'`; \
 	echo "using next possible minor version without 'v' prefix: $${NEXT_MINOR:1}"; \
 	for examples in examples/eks examples/gke examples/aks ; do \
 		for tfproject in $$examples/* ; do \

--- a/castai/resource_gke_cluster_id.go
+++ b/castai/resource_gke_cluster_id.go
@@ -172,9 +172,6 @@ func resourceCastaiGKEClusterIdRead(ctx context.Context, data *schema.ResourceDa
 		if err := data.Set(FieldGKEClientSA, toString(GKE.ClientServiceAccount)); err != nil {
 			return diag.FromErr(fmt.Errorf("setting cluster client sa email: %w", err))
 		}
-		if err := data.Set(FieldGKECastSA, toString(GKE.CastServiceAccount)); err != nil {
-			return diag.FromErr(fmt.Errorf("setting cluster cast sa email: %w", err))
-		}
 	}
 	return nil
 }

--- a/castai/resource_gke_cluster_id_test.go
+++ b/castai/resource_gke_cluster_id_test.go
@@ -69,7 +69,6 @@ func TestGKEClusterIdResourceReadContext(t *testing.T) {
 	r.Nil(result)
 	r.False(result.HasError())
 	r.Equal(`ID = b6bfc074-a267-400f-b8f1-db0850c36gke
-cast_service_account = cast-service-account
 client_service_account = client-service-account
 location = eu-central-1
 name = gke-cluster


### PR DESCRIPTION
Read from get cluster rewrite created cast_service_account, which causes _terraform apply_ to fail on the second run.