### PR TITLE
Update castai.tf

### DIFF
--- a/examples/eks/eks_cluster_gitops/castai.tf
+++ b/examples/eks/eks_cluster_gitops/castai.tf
@@ -123,7 +123,7 @@ resource "castai_node_template" "example_spot_template" {
     min_memory                                  = 4096
     max_memory                                  = 24576
     architectures                               = ["amd64"]
-    azs                                         = ["", ""] 
+    azs                                         = [] 
     customer_specific                           = "disabled"
 
     instance_families {

--- a/examples/eks/eks_cluster_gitops/castai.tf
+++ b/examples/eks/eks_cluster_gitops/castai.tf
@@ -123,7 +123,7 @@ resource "castai_node_template" "example_spot_template" {
     min_memory                                  = 4096
     max_memory                                  = 24576
     architectures                               = ["amd64"]
-    azs                                         = []
+    azs                                         = var.azs
     customer_specific                           = "disabled"
 
     instance_families {

--- a/examples/eks/eks_cluster_gitops/castai.tf
+++ b/examples/eks/eks_cluster_gitops/castai.tf
@@ -123,7 +123,7 @@ resource "castai_node_template" "example_spot_template" {
     min_memory                                  = 4096
     max_memory                                  = 24576
     architectures                               = ["amd64"]
-    azs                                         = ["eu-central-1a", "eu-central-1b"]
+    azs                                         = ["", ""] 
     customer_specific                           = "disabled"
 
     instance_families {

--- a/examples/eks/eks_cluster_gitops/castai.tf
+++ b/examples/eks/eks_cluster_gitops/castai.tf
@@ -123,7 +123,7 @@ resource "castai_node_template" "example_spot_template" {
     min_memory                                  = 4096
     max_memory                                  = 24576
     architectures                               = ["amd64"]
-    azs                                         = [] 
+    azs                                         = []
     customer_specific                           = "disabled"
 
     instance_families {

--- a/examples/eks/eks_cluster_gitops/variables.tf
+++ b/examples/eks/eks_cluster_gitops/variables.tf
@@ -65,3 +65,9 @@ variable "delete_nodes_on_disconnect" {
   description = "Optionally delete Cast AI created nodes when the cluster is destroyed"
   default     = false
 }
+
+variable "azs" {
+  description = "List of availability zones"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
azs                                         = ["", ""] # this was hardcoded like this (["eu-central-1a", "eu-central-1b"],which throws an error when its a different region. can we just remove it and leave it empty for customer to fill it with their specific regions?