### PR TITLE
Update tf.vars.example

### DIFF
--- a/examples/aks/aks_cluster_existing/tf.vars.example
+++ b/examples/aks/aks_cluster_existing/tf.vars.example
@@ -1,5 +1,5 @@
 cluster_name                = "<place-holder>"
-cluster_rg                  = "<place-holder>"
+resource_group              = "<place-holder>"
 cluster_region              = "<place-holder>"
 castai_api_token            = "<place-holder>"
 subscription_id             = "<place-holder>"


### PR DESCRIPTION
The defined variable name is resource_group 

variable "resource_group" {
  type        = string
  description = "Resource Group of the AKS cluster, resources will be created for."
}


not cluster_rg and it throws an error when running it