### PR TITLE
feat: add GPU sharing settings to Node Template

### DIFF
--- a/castai/resource_node_template.go
+++ b/castai/resource_node_template.go
@@ -651,21 +651,23 @@ func resourceNodeTemplate() *schema.Resource {
 					"Custom instances are only supported in GCP.",
 			},
 			FieldNodeTemplateGpu: {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "GPU configuration.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						FieldNodeTemplateEnableTimeSharing: {
 							Type:        schema.TypeBool,
 							Optional:    true,
+							Default:     false,
 							Description: "Enable/disable GPU time-sharing.",
 						},
 						FieldNodeTemplateDefaultSharedClientsPerGpu: {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Default:     1,
-							Description: "Defines default shared client per GPU.",
+							Description: "Defines default number of shared clients per GPU.",
 						},
 						FieldNodeTemplateSharingConfiguration: {
 							Type:        schema.TypeList,
@@ -681,7 +683,7 @@ func resourceNodeTemplate() *schema.Resource {
 									FieldNodeTemplateSharedClientsPerGpu: {
 										Type:        schema.TypeInt,
 										Required:    true,
-										Description: "Defines default shared clients per GPU.",
+										Description: "Defines number of shared clients for specific GPU device.",
 									},
 								},
 							},

--- a/castai/resource_node_template_test.go
+++ b/castai/resource_node_template_test.go
@@ -682,6 +682,8 @@ func TestAccResourceNodeTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.resource_limits.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.resource_limits.0.cpu_limit_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.resource_limits.0.cpu_limit_max_cores", "0"),
+					resource.TestCheckResourceAttr(resourceName, "gpu.0.default_shared_clients_per_gpu", "1"),
+					resource.TestCheckResourceAttr(resourceName, "gpu.0.enable_time_sharing", "false"),
 				),
 			},
 			{
@@ -758,7 +760,8 @@ func TestAccResourceNodeTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.resource_limits.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.resource_limits.0.cpu_limit_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.resource_limits.0.cpu_limit_max_cores", "50"),
-					resource.TestCheckResourceAttr(resourceName, "constraints.0.bare_metal", "false"),
+					resource.TestCheckResourceAttr(resourceName, "gpu.0.default_shared_clients_per_gpu", "1"),
+					resource.TestCheckResourceAttr(resourceName, "gpu.0.enable_time_sharing", "false"),
 				),
 			},
 		},
@@ -803,6 +806,16 @@ func testAccNodeTemplateConfig(rName, clusterName string) string {
 
 			custom_taints {
 				key = "%[1]s-taint-key-4"
+			}
+
+			gpu {
+			  default_shared_clients_per_gpu = 1
+			  enable_time_sharing            = false
+		
+			  sharing_configuration {
+				gpu_name = "L4"
+				shared_clients_per_gpu = 8
+			  }
 			}
 
 			constraints {
@@ -868,6 +881,11 @@ func testNodeTemplateUpdated(rName, clusterName string) string {
 			custom_taints {
 				key = "%[1]s-taint-key-2"
 				effect = "NoSchedule"
+			}
+
+			gpu {
+			  default_shared_clients_per_gpu = 1
+			  enable_time_sharing            = false
 			}
 
 			constraints {

--- a/castai/resource_node_template_test.go
+++ b/castai/resource_node_template_test.go
@@ -46,6 +46,15 @@ func TestNodeTemplateResourceReadContext(t *testing.T) {
 				"configurationId": "7dc4f922-29c9-4377-889c-0c8c5fb8d497",
 				"configurationName": "default",
 				"isEnabled": true,
+			   "gpu": {
+				 "enableTimeSharing": true,
+				 "defaultSharedClientsPerGpu": 10,
+				 "sharingConfiguration": {
+					"A100": {
+					  "sharedClientsPerGpu": 5
+					}
+				 }
+				},
 				"name": "gpu",
 				"constraints": {
 				  "spot": false,
@@ -153,6 +162,7 @@ func TestNodeTemplateResourceReadContext(t *testing.T) {
 	state.ID = "gpu"
 
 	data := resource.Data(state)
+	//spew.Dump(data)
 	result := resource.ReadContext(ctx, data, provider)
 	r.Nil(result)
 	r.False(result.HasError())
@@ -251,6 +261,12 @@ name = gpu
 rebalancing_config_min_nodes = 0
 should_taint = true
 Tainted = false
+gpu.# = 1
+gpu.0.default_shared_clients_per_gpu = 10
+gpu.0.enable_time_sharing = true
+gpu.0.sharing_configuration.# = 1
+gpu.0.sharing_configuration.0.gpu_name = A100
+gpu.0.sharing_configuration.0.shared_clients_per_gpu = 5
 `, "\n"),
 		strings.Split(data.State().String(), "\n"),
 	)

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -5448,6 +5448,12 @@ type WorkloadoptimizationV1GetWorkloadsSummaryResponse struct {
 	// OptimizedCount Number of all optimized workloads.
 	OptimizedCount int32 `json:"optimizedCount"`
 
+	// OriginalRequestedCpuCores Original requested CPU cores.
+	OriginalRequestedCpuCores float64 `json:"originalRequestedCpuCores"`
+
+	// OriginalRequestedMemoryGibs Original requested memory in Gi.
+	OriginalRequestedMemoryGibs float64 `json:"originalRequestedMemoryGibs"`
+
 	// RecommendedCpuCores Number of recommended CPU cores.
 	RecommendedCpuCores float64 `json:"recommendedCpuCores"`
 
@@ -5462,6 +5468,12 @@ type WorkloadoptimizationV1GetWorkloadsSummaryResponse struct {
 
 	// TotalCount Total number of workloads.
 	TotalCount int32 `json:"totalCount"`
+
+	// UsageCpuCores CPU usage in cores.
+	UsageCpuCores float64 `json:"usageCpuCores"`
+
+	// UsageMemoryGibs Memory usage in Gi.
+	UsageMemoryGibs float64 `json:"usageMemoryGibs"`
 
 	// VpaOptimizedCount Number of workloads with vertical optimization enabled.
 	VpaOptimizedCount int32 `json:"vpaOptimizedCount"`

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -83,7 +83,7 @@ resource "castai_node_template" "default_by_castai" {
 - `custom_instances_with_extended_memory_enabled` (Boolean) Marks whether custom instances with extended memory should be used when deciding which parts of inventory are available. Custom instances are only supported in GCP.
 - `custom_labels` (Map of String) Custom labels to be added to nodes created from this template.
 - `custom_taints` (Block List) Custom taints to be added to the nodes created from this template. `shouldTaint` has to be `true` in order to create/update the node template with custom taints. If `shouldTaint` is `true`, but no custom taints are provided, the nodes will be tainted with the default node template taint. (see [below for nested schema](#nestedblock--custom_taints))
-- `gpu` (Block List, Max: 1) (see [below for nested schema](#nestedblock--gpu))
+- `gpu` (Block List, Max: 1) GPU configuration. (see [below for nested schema](#nestedblock--gpu))
 - `is_default` (Boolean) Flag whether the node template is default.
 - `is_enabled` (Boolean) Flag whether the node template is enabled and considered for autoscaling.
 - `rebalancing_config_min_nodes` (Number) Minimum nodes that will be kept when rebalancing nodes using this node template.
@@ -220,7 +220,7 @@ Optional:
 
 Optional:
 
-- `default_shared_clients_per_gpu` (Number) Defines default shared client per GPU.
+- `default_shared_clients_per_gpu` (Number) Defines default number of shared clients per GPU.
 - `enable_time_sharing` (Boolean) Enable/disable GPU time-sharing.
 - `sharing_configuration` (Block List) Defines GPU sharing configurations for GPU devices. (see [below for nested schema](#nestedblock--gpu--sharing_configuration))
 
@@ -230,7 +230,7 @@ Optional:
 Required:
 
 - `gpu_name` (String) GPU name.
-- `shared_clients_per_gpu` (Number) Defines default shared clients per GPU.
+- `shared_clients_per_gpu` (Number) Defines number of shared clients for specific GPU device.
 
 
 

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -83,6 +83,7 @@ resource "castai_node_template" "default_by_castai" {
 - `custom_instances_with_extended_memory_enabled` (Boolean) Marks whether custom instances with extended memory should be used when deciding which parts of inventory are available. Custom instances are only supported in GCP.
 - `custom_labels` (Map of String) Custom labels to be added to nodes created from this template.
 - `custom_taints` (Block List) Custom taints to be added to the nodes created from this template. `shouldTaint` has to be `true` in order to create/update the node template with custom taints. If `shouldTaint` is `true`, but no custom taints are provided, the nodes will be tainted with the default node template taint. (see [below for nested schema](#nestedblock--custom_taints))
+- `gpu` (Block List, Max: 1) (see [below for nested schema](#nestedblock--gpu))
 - `is_default` (Boolean) Flag whether the node template is default.
 - `is_enabled` (Boolean) Flag whether the node template is enabled and considered for autoscaling.
 - `rebalancing_config_min_nodes` (Number) Minimum nodes that will be kept when rebalancing nodes using this node template.
@@ -212,6 +213,25 @@ Optional:
 
 - `effect` (String) Effect of a taint to be added to nodes created from this template, the default is NoSchedule. Allowed values: NoSchedule, NoExecute.
 - `value` (String) Value of a taint to be added to nodes created from this template.
+
+
+<a id="nestedblock--gpu"></a>
+### Nested Schema for `gpu`
+
+Optional:
+
+- `default_shared_clients_per_gpu` (Number) Defines default shared client per GPU.
+- `enable_time_sharing` (Boolean) Enable/disable GPU time-sharing.
+- `sharing_configuration` (Block List) Defines GPU sharing configurations for GPU devices. (see [below for nested schema](#nestedblock--gpu--sharing_configuration))
+
+<a id="nestedblock--gpu--sharing_configuration"></a>
+### Nested Schema for `gpu.sharing_configuration`
+
+Required:
+
+- `gpu_name` (String) GPU name.
+- `shared_clients_per_gpu` (Number) Defines default shared clients per GPU.
+
 
 
 <a id="nestedblock--timeouts"></a>


### PR DESCRIPTION
example configuration:
```
resource "castai_node_template" "gpu_sharing" {
    cluster_id = castai_eks_clusterid.cluster_id.id

    name             = "gpu_sharing"
    is_default       = false
    is_enabled       = true
    configuration_id = "32354e7c-adac-4b7a-b82f-cdafaf86a4ab"
    should_taint     = false

    constraints {
      on_demand = true
    }

    gpu {
      default_shared_clients_per_gpu = 5
      enable_time_sharing            = true

      sharing_configuration {
        gpu_name = "L4"
        shared_clients_per_gpu = 8
      }
      sharing_configuration {
        gpu_name = "L5"
        shared_clients_per_gpu = 2
      }
      sharing_configuration {
        gpu_name = "Tesla T4"
        shared_clients_per_gpu = 4
      }
    }
  }
```

Related changes in terraform module for EKS: https://github.com/castai/terraform-castai-eks-cluster/pull/128