### PR TITLE
feat: deprecate autoscaler policies that were replaced by node templates

### DIFF
--- a/castai/resource_autoscaler.go
+++ b/castai/resource_autoscaler.go
@@ -141,7 +141,7 @@ func resourceAutoscaler() *schema.Resource {
 										Optional:    true,
 										MaxItems:    1,
 										Description: "additional headroom based on cluster's total available capacity for on-demand nodes.",
-										Deprecated:  "`headroom` is deprecated. Follow the FAQ here: https://docs.cast.ai/docs/autoscaler-1#can-you-please-share-some-guidance-on-cluster-headroom-i-would-like-to-add-some-buffer-room-so-that-pods-have-a-place-to-run-when-nodes-go-down",
+										Deprecated:  "`headroom` is deprecated. Please refer to the FAQ for guidance on cluster headroom: https://docs.cast.ai/docs/autoscaler-1#can-you-please-share-some-guidance-on-cluster-headroom-i-would-like-to-add-some-buffer-room-so-that-pods-have-a-place-to-run-when-nodes-go-down",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												FieldCPUPercentage: {
@@ -172,7 +172,7 @@ func resourceAutoscaler() *schema.Resource {
 										Optional:    true,
 										MaxItems:    1,
 										Description: "additional headroom based on cluster's total available capacity for spot nodes.",
-										Deprecated:  "`headroom_spot` is deprecated. Follow the FAQ here: https://docs.cast.ai/docs/autoscaler-1#can-you-please-share-some-guidance-on-cluster-headroom-i-would-like-to-add-some-buffer-room-so-that-pods-have-a-place-to-run-when-nodes-go-down",
+										Deprecated:  "`headroom_spot` is deprecated. Please refer to the FAQ for guidance on cluster headroom: https://docs.cast.ai/docs/autoscaler-1#can-you-please-share-some-guidance-on-cluster-headroom-i-would-like-to-add-some-buffer-room-so-that-pods-have-a-place-to-run-when-nodes-go-down",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												FieldCPUPercentage: {
@@ -203,7 +203,7 @@ func resourceAutoscaler() *schema.Resource {
 										Optional:    true,
 										MaxItems:    1,
 										Description: "defines the node constraints that will be applied when autoscaling with Unschedulable Pods policy.",
-										Deprecated:  "`node_constraints` is deprecated. Use `constraints` field from the `castai_node_template` resource to configure default template. Default node template have `is_default = true`.",
+										Deprecated:  "`node_constraints` under `unschedulable_pods` is deprecated. Use the `constraints` field in the default `castai_node_template` resource instead. The default node template has `is_default = true`.",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												FieldMinCPUCores: {
@@ -259,7 +259,7 @@ func resourceAutoscaler() *schema.Resource {
 										Type:        schema.TypeBool,
 										Optional:    true,
 										Default:     false,
-										Deprecated:  "`custom_instances_enabled` is deprecated. Use `custom_instances_enabled` field the `castai_node_template` resource.",
+										Deprecated:  "`custom_instances_enabled` under `unschedulable_pods.node_constraints` is deprecated. Use the `custom_instances_enabled` field in the default `castai_node_template` resource instead. The default node template has `is_default = true`.",
 										Description: "enable/disable custom instances policy.",
 									},
 								},
@@ -310,28 +310,28 @@ func resourceAutoscaler() *schema.Resource {
 							Optional:    true,
 							MaxItems:    1,
 							Description: "policy defining whether autoscaler can use spot instances for provisioning additional workloads.",
-							Deprecated:  "`spot_instances` is deprecated. Use `constraints` from the `castai_node_template` resource to configure default node template. Default node template have `is_default = true`.",
+							Deprecated:  "`spot_instances` is deprecated. Configure spot instance settings using the `constraints` field in the default `castai_node_template` resource. The default node template has `is_default = true`.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									FieldEnabled: {
 										Type:        schema.TypeBool,
 										Optional:    true,
 										Default:     false,
-										Deprecated:  "Enable spot instances in default node template, `castai_node_template` resource in `constraints.spot = true` instead. Default node template have `is_default = true`.",
+										Deprecated:  "`enabled` under `spot_instances` is deprecated. To enable spot instances, set `constraints.spot = true` in the default `castai_node_template` resource. The default node template has `is_default = true`.",
 										Description: "enable/disable spot instances policy.",
 									},
 									FieldMaxReclaimRate: {
 										Type:        schema.TypeInt,
 										Optional:    true,
 										Default:     0,
-										Deprecated:  "`max_reclaim_rate` is deprecated. The field have no equivalent to migrate and setting it have no effect.",
+										Deprecated:  "`max_reclaim_rate` under `spot_instances` is deprecated. This field has no direct equivalent in the `castai_node_template` resource, and setting it will have no effect.",
 										Description: "max allowed reclaim rate when choosing spot instance type. E.g. if the value is 10%, instance types having 10% or higher reclaim rate will not be considered. Set to zero to use all instance types regardless of reclaim rate.",
 									},
 									FieldSpotBackups: {
 										Type:        schema.TypeList,
 										Optional:    true,
 										MaxItems:    1,
-										Deprecated:  "`spot_backups` is deprecated. Use default `castai_node_template` resource and set `constraints.use_spot_fallbacks` and `constraints.fallback_restore_rate_seconds` instead. Default node template have `is_default = true`.",
+										Deprecated:  "`spot_backups` under `spot_instances` is deprecated. Configure spot backup behavior using `constraints.use_spot_fallbacks` and `constraints.fallback_restore_rate_seconds` in the default `castai_node_template` resource. The default node template has `is_default = true`.",
 										Description: "policy defining whether autoscaler can use spot backups instead of spot instances when spot instances are not available.",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
@@ -355,14 +355,14 @@ func resourceAutoscaler() *schema.Resource {
 										Type:        schema.TypeBool,
 										Optional:    true,
 										Default:     false,
-										Deprecated:  "`spot_diversity_enabled` is deprecated. Use `enable_spot_diversity` field from the `castai_node_template.constraints` resource to configure default node template. Default node template have `is_default = true`.",
+										Deprecated:  "`spot_diversity_enabled` is deprecated. Use the `enable_spot_diversity` field within `castai_node_template.constraints` in the default `castai_node_template` resource. The default node template has `is_default = true`.",
 										Description: "enable/disable spot diversity policy. When enabled, autoscaler will try to balance between diverse and cost optimal instance types.",
 									},
 									FieldSpotDiversityPriceIncreaseLimit: {
 										Type:             schema.TypeInt,
 										Optional:         true,
 										Default:          20,
-										Deprecated:       "`spot_diversity_price_increase_limit` is deprecated. Use `spot_diversity_price_increase_limit_percent` from the `castai_node_template.constraints` resource to configure default node template. Default node template have `is_default = true`.",
+										Deprecated:       "`spot_diversity_price_increase_limit` is deprecated. Use `spot_diversity_price_increase_limit_percent` within `castai_node_template.constraints` in the default `castai_node_template` resource. The default node template has `is_default = true`.",
 										Description:      "allowed node configuration price increase when diversifying instance types. E.g. if the value is 10%, then the overall price of diversified instance types can be 10% higher than the price of the optimal configuration.",
 										ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
 									},
@@ -371,7 +371,7 @@ func resourceAutoscaler() *schema.Resource {
 										Optional:    true,
 										MaxItems:    1,
 										Description: "configure the handling of SPOT interruption predictions.",
-										Deprecated:  "`spot_interruption_predictions` is deprecated. Use `spot_interruption_predictions_enabled` and `spot_interruption_predictions_type` field from the `castai_node_template` resource to configure default node template. Default node template have `is_default = true`.",
+										Deprecated:  "`spot_interruption_predictions` is deprecated. Use the `spot_interruption_predictions_enabled` and `spot_interruption_predictions_type` fields in the default `castai_node_template` resource. The default node template has `is_default = true`.",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												FieldEnabled: {

--- a/castai/resource_autoscaler.go
+++ b/castai/resource_autoscaler.go
@@ -141,7 +141,7 @@ func resourceAutoscaler() *schema.Resource {
 										Optional:    true,
 										MaxItems:    1,
 										Description: "additional headroom based on cluster's total available capacity for on-demand nodes.",
-										Deprecated:  "headroom is deprecated. Follow the FAQ here: https://docs.cast.ai/docs/autoscaler-1#can-you-please-share-some-guidance-on-cluster-headroom-i-would-like-to-add-some-buffer-room-so-that-pods-have-a-place-to-run-when-nodes-go-down",
+										Deprecated:  "`headroom` is deprecated. Follow the FAQ here: https://docs.cast.ai/docs/autoscaler-1#can-you-please-share-some-guidance-on-cluster-headroom-i-would-like-to-add-some-buffer-room-so-that-pods-have-a-place-to-run-when-nodes-go-down",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												FieldCPUPercentage: {
@@ -172,7 +172,7 @@ func resourceAutoscaler() *schema.Resource {
 										Optional:    true,
 										MaxItems:    1,
 										Description: "additional headroom based on cluster's total available capacity for spot nodes.",
-										Deprecated:  "headroom_spot is deprecated. Follow the FAQ here: https://docs.cast.ai/docs/autoscaler-1#can-you-please-share-some-guidance-on-cluster-headroom-i-would-like-to-add-some-buffer-room-so-that-pods-have-a-place-to-run-when-nodes-go-down",
+										Deprecated:  "`headroom_spot` is deprecated. Follow the FAQ here: https://docs.cast.ai/docs/autoscaler-1#can-you-please-share-some-guidance-on-cluster-headroom-i-would-like-to-add-some-buffer-room-so-that-pods-have-a-place-to-run-when-nodes-go-down",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												FieldCPUPercentage: {
@@ -203,7 +203,7 @@ func resourceAutoscaler() *schema.Resource {
 										Optional:    true,
 										MaxItems:    1,
 										Description: "defines the node constraints that will be applied when autoscaling with Unschedulable Pods policy.",
-										Deprecated:  "nodeConstraints is deprecated. Use `constraints` field from the `castai_node_template` resource to configure `default-by-castai` node template.",
+										Deprecated:  "`node_constraints` is deprecated. Use `constraints` field from the `castai_node_template` resource to configure default template. Default node template have `is_default = true`.",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												FieldMinCPUCores: {
@@ -259,7 +259,7 @@ func resourceAutoscaler() *schema.Resource {
 										Type:        schema.TypeBool,
 										Optional:    true,
 										Default:     false,
-										Deprecated:  "customInstancesEnabled is deprecated. Use custom_instances_enabled field the `castai_node_template` resource.",
+										Deprecated:  "`custom_instances_enabled` is deprecated. Use `custom_instances_enabled` field the `castai_node_template` resource.",
 										Description: "enable/disable custom instances policy.",
 									},
 								},
@@ -310,25 +310,28 @@ func resourceAutoscaler() *schema.Resource {
 							Optional:    true,
 							MaxItems:    1,
 							Description: "policy defining whether autoscaler can use spot instances for provisioning additional workloads.",
-							Deprecated:  "spotInstances is deprecated. Use `constraints` from the `castai_node_template` resource to configure `default-by-castai` node template.",
+							Deprecated:  "`spot_instances` is deprecated. Use `constraints` from the `castai_node_template` resource to configure default node template. Default node template have `is_default = true`.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									FieldEnabled: {
 										Type:        schema.TypeBool,
 										Optional:    true,
 										Default:     false,
+										Deprecated:  "Enable spot instances in default node template, `castai_node_template` resource in `constraints.spot = true` instead. Default node template have `is_default = true`.",
 										Description: "enable/disable spot instances policy.",
 									},
 									FieldMaxReclaimRate: {
 										Type:        schema.TypeInt,
 										Optional:    true,
 										Default:     0,
+										Deprecated:  "`max_reclaim_rate` is deprecated. The field have no equivalent to migrate and setting it have no effect.",
 										Description: "max allowed reclaim rate when choosing spot instance type. E.g. if the value is 10%, instance types having 10% or higher reclaim rate will not be considered. Set to zero to use all instance types regardless of reclaim rate.",
 									},
 									FieldSpotBackups: {
 										Type:        schema.TypeList,
 										Optional:    true,
 										MaxItems:    1,
+										Deprecated:  "`spot_backups` is deprecated. Use default `castai_node_template` resource and set `constraints.use_spot_fallbacks` and `constraints.fallback_restore_rate_seconds` instead. Default node template have `is_default = true`.",
 										Description: "policy defining whether autoscaler can use spot backups instead of spot instances when spot instances are not available.",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
@@ -352,14 +355,14 @@ func resourceAutoscaler() *schema.Resource {
 										Type:        schema.TypeBool,
 										Optional:    true,
 										Default:     false,
-										Deprecated:  "spotDiversityEnabled is deprecated. Use spot_diversity_enabled field from the `castai_node_template` resource to configure `default-by-castai` node template.",
+										Deprecated:  "`spot_diversity_enabled` is deprecated. Use `enable_spot_diversity` field from the `castai_node_template.constraints` resource to configure default node template. Default node template have `is_default = true`.",
 										Description: "enable/disable spot diversity policy. When enabled, autoscaler will try to balance between diverse and cost optimal instance types.",
 									},
 									FieldSpotDiversityPriceIncreaseLimit: {
 										Type:             schema.TypeInt,
 										Optional:         true,
 										Default:          20,
-										Deprecated:       "spotDiversityPriceIncreaseLimit is deprecated. Use spot_diversity_price_increase_limit from the `castai_node_template` resource to configure `default-by-castai` node template.",
+										Deprecated:       "`spot_diversity_price_increase_limit` is deprecated. Use `spot_diversity_price_increase_limit_percent` from the `castai_node_template.constraints` resource to configure default node template. Default node template have `is_default = true`.",
 										Description:      "allowed node configuration price increase when diversifying instance types. E.g. if the value is 10%, then the overall price of diversified instance types can be 10% higher than the price of the optimal configuration.",
 										ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
 									},
@@ -368,7 +371,7 @@ func resourceAutoscaler() *schema.Resource {
 										Optional:    true,
 										MaxItems:    1,
 										Description: "configure the handling of SPOT interruption predictions.",
-										Deprecated:  "spotInterruptionPredictions is deprecated. Use spot_interruption_predictions_enabled and spot_interruption_predictions_type field from the `castai_node_template` resource to configure `default-by-castai` node template.",
+										Deprecated:  "`spot_interruption_predictions` is deprecated. Use `spot_interruption_predictions_enabled` and `spot_interruption_predictions_type` field from the `castai_node_template` resource to configure default node template. Default node template have `is_default = true`.",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												FieldEnabled: {

--- a/castai/resource_autoscaler.go
+++ b/castai/resource_autoscaler.go
@@ -141,6 +141,7 @@ func resourceAutoscaler() *schema.Resource {
 										Optional:    true,
 										MaxItems:    1,
 										Description: "additional headroom based on cluster's total available capacity for on-demand nodes.",
+										Deprecated:  "headroom is deprecated. Follow the FAQ here: https://docs.cast.ai/docs/autoscaler-1#can-you-please-share-some-guidance-on-cluster-headroom-i-would-like-to-add-some-buffer-room-so-that-pods-have-a-place-to-run-when-nodes-go-down",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												FieldCPUPercentage: {
@@ -171,6 +172,7 @@ func resourceAutoscaler() *schema.Resource {
 										Optional:    true,
 										MaxItems:    1,
 										Description: "additional headroom based on cluster's total available capacity for spot nodes.",
+										Deprecated:  "headroom_spot is deprecated. Follow the FAQ here: https://docs.cast.ai/docs/autoscaler-1#can-you-please-share-some-guidance-on-cluster-headroom-i-would-like-to-add-some-buffer-room-so-that-pods-have-a-place-to-run-when-nodes-go-down",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												FieldCPUPercentage: {
@@ -201,6 +203,7 @@ func resourceAutoscaler() *schema.Resource {
 										Optional:    true,
 										MaxItems:    1,
 										Description: "defines the node constraints that will be applied when autoscaling with Unschedulable Pods policy.",
+										Deprecated:  "nodeConstraints is deprecated. Use `constraints` field from the `castai_node_template` resource to configure `default-by-castai` node template.",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												FieldMinCPUCores: {
@@ -256,7 +259,7 @@ func resourceAutoscaler() *schema.Resource {
 										Type:        schema.TypeBool,
 										Optional:    true,
 										Default:     false,
-										Deprecated:  "customInstancesEnabled is deprecated. Use custom_instances_enabled field the node template resource.",
+										Deprecated:  "customInstancesEnabled is deprecated. Use custom_instances_enabled field the `castai_node_template` resource.",
 										Description: "enable/disable custom instances policy.",
 									},
 								},
@@ -307,6 +310,7 @@ func resourceAutoscaler() *schema.Resource {
 							Optional:    true,
 							MaxItems:    1,
 							Description: "policy defining whether autoscaler can use spot instances for provisioning additional workloads.",
+							Deprecated:  "spotInstances is deprecated. Use `constraints` from the `castai_node_template` resource to configure `default-by-castai` node template.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									FieldEnabled: {
@@ -348,12 +352,14 @@ func resourceAutoscaler() *schema.Resource {
 										Type:        schema.TypeBool,
 										Optional:    true,
 										Default:     false,
+										Deprecated:  "spotDiversityEnabled is deprecated. Use spot_diversity_enabled field from the `castai_node_template` resource to configure `default-by-castai` node template.",
 										Description: "enable/disable spot diversity policy. When enabled, autoscaler will try to balance between diverse and cost optimal instance types.",
 									},
 									FieldSpotDiversityPriceIncreaseLimit: {
 										Type:             schema.TypeInt,
 										Optional:         true,
 										Default:          20,
+										Deprecated:       "spotDiversityPriceIncreaseLimit is deprecated. Use spot_diversity_price_increase_limit from the `castai_node_template` resource to configure `default-by-castai` node template.",
 										Description:      "allowed node configuration price increase when diversifying instance types. E.g. if the value is 10%, then the overall price of diversified instance types can be 10% higher than the price of the optimal configuration.",
 										ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
 									},
@@ -362,6 +368,7 @@ func resourceAutoscaler() *schema.Resource {
 										Optional:    true,
 										MaxItems:    1,
 										Description: "configure the handling of SPOT interruption predictions.",
+										Deprecated:  "spotInterruptionPredictions is deprecated. Use spot_interruption_predictions_enabled and spot_interruption_predictions_type field from the `castai_node_template` resource to configure `default-by-castai` node template.",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												FieldEnabled: {

--- a/docs/resources/autoscaler.md
+++ b/docs/resources/autoscaler.md
@@ -82,7 +82,7 @@ Optional:
 - `is_scoped_mode` (Boolean) run autoscaler in scoped mode. Only marked pods and nodes will be considered.
 - `node_downscaler` (Block List, Max: 1) node downscaler defines policies for removing nodes based on the configured conditions. (see [below for nested schema](#nestedblock--autoscaler_settings--node_downscaler))
 - `node_templates_partial_matching_enabled` (Boolean) marks whether partial matching should be used when deciding which custom node template to select.
-- `spot_instances` (Block List, Max: 1) policy defining whether autoscaler can use spot instances for provisioning additional workloads. (see [below for nested schema](#nestedblock--autoscaler_settings--spot_instances))
+- `spot_instances` (Block List, Max: 1, Deprecated) policy defining whether autoscaler can use spot instances for provisioning additional workloads. (see [below for nested schema](#nestedblock--autoscaler_settings--spot_instances))
 - `unschedulable_pods` (Block List, Max: 1) policy defining autoscaler's behavior when unschedulable pods were detected. (see [below for nested schema](#nestedblock--autoscaler_settings--unschedulable_pods))
 
 <a id="nestedblock--autoscaler_settings--cluster_limits"></a>
@@ -145,9 +145,9 @@ Optional:
 - `enabled` (Boolean) enable/disable spot instances policy.
 - `max_reclaim_rate` (Number) max allowed reclaim rate when choosing spot instance type. E.g. if the value is 10%, instance types having 10% or higher reclaim rate will not be considered. Set to zero to use all instance types regardless of reclaim rate.
 - `spot_backups` (Block List, Max: 1) policy defining whether autoscaler can use spot backups instead of spot instances when spot instances are not available. (see [below for nested schema](#nestedblock--autoscaler_settings--spot_instances--spot_backups))
-- `spot_diversity_enabled` (Boolean) enable/disable spot diversity policy. When enabled, autoscaler will try to balance between diverse and cost optimal instance types.
-- `spot_diversity_price_increase_limit` (Number) allowed node configuration price increase when diversifying instance types. E.g. if the value is 10%, then the overall price of diversified instance types can be 10% higher than the price of the optimal configuration.
-- `spot_interruption_predictions` (Block List, Max: 1) configure the handling of SPOT interruption predictions. (see [below for nested schema](#nestedblock--autoscaler_settings--spot_instances--spot_interruption_predictions))
+- `spot_diversity_enabled` (Boolean, Deprecated) enable/disable spot diversity policy. When enabled, autoscaler will try to balance between diverse and cost optimal instance types.
+- `spot_diversity_price_increase_limit` (Number, Deprecated) allowed node configuration price increase when diversifying instance types. E.g. if the value is 10%, then the overall price of diversified instance types can be 10% higher than the price of the optimal configuration.
+- `spot_interruption_predictions` (Block List, Max: 1, Deprecated) configure the handling of SPOT interruption predictions. (see [below for nested schema](#nestedblock--autoscaler_settings--spot_instances--spot_interruption_predictions))
 
 <a id="nestedblock--autoscaler_settings--spot_instances--spot_backups"></a>
 ### Nested Schema for `autoscaler_settings.spot_instances.spot_backups`
@@ -175,9 +175,9 @@ Optional:
 
 - `custom_instances_enabled` (Boolean, Deprecated) enable/disable custom instances policy.
 - `enabled` (Boolean) enable/disable unschedulable pods detection policy.
-- `headroom` (Block List, Max: 1) additional headroom based on cluster's total available capacity for on-demand nodes. (see [below for nested schema](#nestedblock--autoscaler_settings--unschedulable_pods--headroom))
-- `headroom_spot` (Block List, Max: 1) additional headroom based on cluster's total available capacity for spot nodes. (see [below for nested schema](#nestedblock--autoscaler_settings--unschedulable_pods--headroom_spot))
-- `node_constraints` (Block List, Max: 1) defines the node constraints that will be applied when autoscaling with Unschedulable Pods policy. (see [below for nested schema](#nestedblock--autoscaler_settings--unschedulable_pods--node_constraints))
+- `headroom` (Block List, Max: 1, Deprecated) additional headroom based on cluster's total available capacity for on-demand nodes. (see [below for nested schema](#nestedblock--autoscaler_settings--unschedulable_pods--headroom))
+- `headroom_spot` (Block List, Max: 1, Deprecated) additional headroom based on cluster's total available capacity for spot nodes. (see [below for nested schema](#nestedblock--autoscaler_settings--unschedulable_pods--headroom_spot))
+- `node_constraints` (Block List, Max: 1, Deprecated) defines the node constraints that will be applied when autoscaling with Unschedulable Pods policy. (see [below for nested schema](#nestedblock--autoscaler_settings--unschedulable_pods--node_constraints))
 - `pod_pinner` (Block List, Max: 1) defines the Cast AI Pod Pinner components settings. (see [below for nested schema](#nestedblock--autoscaler_settings--unschedulable_pods--pod_pinner))
 
 <a id="nestedblock--autoscaler_settings--unschedulable_pods--headroom"></a>

--- a/docs/resources/autoscaler.md
+++ b/docs/resources/autoscaler.md
@@ -142,9 +142,9 @@ Optional:
 
 Optional:
 
-- `enabled` (Boolean) enable/disable spot instances policy.
-- `max_reclaim_rate` (Number) max allowed reclaim rate when choosing spot instance type. E.g. if the value is 10%, instance types having 10% or higher reclaim rate will not be considered. Set to zero to use all instance types regardless of reclaim rate.
-- `spot_backups` (Block List, Max: 1) policy defining whether autoscaler can use spot backups instead of spot instances when spot instances are not available. (see [below for nested schema](#nestedblock--autoscaler_settings--spot_instances--spot_backups))
+- `enabled` (Boolean, Deprecated) enable/disable spot instances policy.
+- `max_reclaim_rate` (Number, Deprecated) max allowed reclaim rate when choosing spot instance type. E.g. if the value is 10%, instance types having 10% or higher reclaim rate will not be considered. Set to zero to use all instance types regardless of reclaim rate.
+- `spot_backups` (Block List, Max: 1, Deprecated) policy defining whether autoscaler can use spot backups instead of spot instances when spot instances are not available. (see [below for nested schema](#nestedblock--autoscaler_settings--spot_instances--spot_backups))
 - `spot_diversity_enabled` (Boolean, Deprecated) enable/disable spot diversity policy. When enabled, autoscaler will try to balance between diverse and cost optimal instance types.
 - `spot_diversity_price_increase_limit` (Number, Deprecated) allowed node configuration price increase when diversifying instance types. E.g. if the value is 10%, then the overall price of diversified instance types can be 10% higher than the price of the optimal configuration.
 - `spot_interruption_predictions` (Block List, Max: 1, Deprecated) configure the handling of SPOT interruption predictions. (see [below for nested schema](#nestedblock--autoscaler_settings--spot_instances--spot_interruption_predictions))

--- a/examples/aks/aks_cluster_arm_template/castai.tf
+++ b/examples/aks/aks_cluster_arm_template/castai.tf
@@ -114,18 +114,6 @@ module "castai-aks-cluster" {
 
     unschedulable_pods = {
       enabled = true
-
-      headroom = {
-        enabled           = true
-        cpu_percentage    = 10
-        memory_percentage = 10
-      }
-
-      headroom_spot = {
-        enabled           = true
-        cpu_percentage    = 10
-        memory_percentage = 10
-      }
     }
 
     node_downscaler = {

--- a/examples/aks/aks_cluster_autoscaler_policies/castai.tf
+++ b/examples/aks/aks_cluster_autoscaler_policies/castai.tf
@@ -130,18 +130,6 @@ module "castai-aks-cluster" {
 
     unschedulable_pods = {
       enabled = true
-
-      headroom = {
-        enabled           = true
-        cpu_percentage    = 10
-        memory_percentage = 10
-      }
-
-      headroom_spot = {
-        enabled           = true
-        cpu_percentage    = 10
-        memory_percentage = 10
-      }
     }
 
     node_downscaler = {

--- a/examples/eks/eks_cluster_autoscaler_policies/castai.tf
+++ b/examples/eks/eks_cluster_autoscaler_policies/castai.tf
@@ -182,18 +182,6 @@ module "castai-eks-cluster" {
 
     unschedulable_pods = {
       enabled = true
-
-      headroom = {
-        enabled           = true
-        cpu_percentage    = 10
-        memory_percentage = 10
-      }
-
-      headroom_spot = {
-        enabled           = true
-        cpu_percentage    = 10
-        memory_percentage = 10
-      }
     }
 
     node_downscaler = {

--- a/examples/gke/gke_cluster_gitops/castai.tf
+++ b/examples/gke/gke_cluster_gitops/castai.tf
@@ -46,11 +46,11 @@ resource "castai_node_template" "default_by_castai" {
 resource "castai_node_template" "example_spot_template" {
   cluster_id = castai_gke_cluster.this.id
 
-  name                     = "example_spot_template"
-  is_default               = false
-  is_enabled               = true
-  configuration_id         = castai_node_configuration.default.id
-  should_taint             = true
+  name             = "example_spot_template"
+  is_default       = false
+  is_enabled       = true
+  configuration_id = castai_node_configuration.default.id
+  should_taint     = true
 
   custom_labels = {
     type = "spot"

--- a/examples/gke/gke_cluster_gitops/castai.tf
+++ b/examples/gke/gke_cluster_gitops/castai.tf
@@ -39,6 +39,8 @@ resource "castai_node_template" "default_by_castai" {
   constraints {
     on_demand = true
   }
+
+  custom_instances_enabled = false
 }
 
 resource "castai_node_template" "example_spot_template" {
@@ -49,7 +51,6 @@ resource "castai_node_template" "example_spot_template" {
   is_enabled               = true
   configuration_id         = castai_node_configuration.default.id
   should_taint             = true
-  custom_instances_enabled = false # custom_instances_enabled should be set to same value(true or false) at Node templates & unschedulable_pods policy for backward compatability
 
   custom_labels = {
     type = "spot"


### PR DESCRIPTION
This PR deprecates fields from autoscaler_settings:
1. `headroom` and `headroom_spot` - reference this [FAQ section](https://docs.cast.ai/docs/autoscaler-1#can-you-please-share-some-guidance-on-cluster-headroom-i-would-like-to-add-some-buffer-room-so-that-pods-have-a-place-to-run-when-nodes-go-down) for a replacement functionality.
2. `node_constraints` - this field was moved from version 5.x.x and migration was advised.
3. `custom_instances_enabled` this field was moved from version 5.x.x and migration was advised.
4. `spot_instances` this object have now equivalent configuration in default node template, migration was advised from version 5.x.x.

Additionally removed/moved deprecated fields in examples.