### PR TITLE
feat: Add option to specify the assignment rules for scaling policy

### DIFF
--- a/castai/resource_workload_scaling_policy_test.go
+++ b/castai/resource_workload_scaling_policy_test.go
@@ -53,6 +53,17 @@ func TestAccResourceWorkloadScalingPolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "memory.0.limit.0.multiplier", "1.8"),
 					resource.TestCheckResourceAttr(resourceName, "memory.0.management_option", "READ_ONLY"),
 					resource.TestCheckResourceAttr(resourceName, "confidence.0.threshold", "0.4"),
+					resource.TestCheckResourceAttr(resourceName, "confidence.0.overhead", "0.5"),
+					resource.TestCheckResourceAttr(resourceName, "assignment_rules.0.rules.0.namespace.0.names.0", "default"),
+					resource.TestCheckResourceAttr(resourceName, "assignment_rules.0.rules.0.namespace.0.names.1", "kube-system"),
+					resource.TestCheckResourceAttr(resourceName, "assignment_rules.0.rules.1.workload.0.gvk.0", "Deployment"),
+					resource.TestCheckResourceAttr(resourceName, "assignment_rules.0.rules.1.workload.0.gvk.1", "StatefulSet"),
+					resource.TestCheckResourceAttr(resourceName, "assignment_rules.0.rules.1.workload.0.labels_expressions.0.key", "region"),
+					resource.TestCheckResourceAttr(resourceName, "assignment_rules.0.rules.1.workload.0.labels_expressions.0.operator", "NotIn"),
+					resource.TestCheckResourceAttr(resourceName, "assignment_rules.0.rules.1.workload.0.labels_expressions.0.values.0", "eu-west-1"),
+					resource.TestCheckResourceAttr(resourceName, "assignment_rules.0.rules.1.workload.0.labels_expressions.0.values.1", "eu-west-2"),
+					resource.TestCheckResourceAttr(resourceName, "assignment_rules.0.rules.1.workload.0.labels_expressions.1.key", "helm.sh/chart"),
+					resource.TestCheckResourceAttr(resourceName, "assignment_rules.0.rules.1.workload.0.labels_expressions.1.operator", "Exists"),
 				),
 			},
 			{
@@ -90,7 +101,10 @@ func TestAccResourceWorkloadScalingPolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "downscaling.0.apply_type", "DEFERRED"),
 					resource.TestCheckResourceAttr(resourceName, "memory_event.0.apply_type", "DEFERRED"),
 					resource.TestCheckResourceAttr(resourceName, "confidence.0.threshold", "0.6"),
-					resource.TestCheckResourceAttr(resourceName, "anti_affinity.0.consider_anti_affinity", "true"),
+					resource.TestCheckResourceAttr(resourceName, "assignment_rules.0.rules.0.namespace.0.names.0", "team-a"),
+					resource.TestCheckResourceAttr(resourceName, "assignment_rules.0.rules.1.workload.0.gvk.0", "DaemonSet"),
+					resource.TestCheckResourceAttr(resourceName, "assignment_rules.0.rules.1.workload.0.labels_expressions.0.key", "helm.sh/chart"),
+					resource.TestCheckResourceAttr(resourceName, "assignment_rules.0.rules.1.workload.0.labels_expressions.0.operator", "NotExists"),
 				),
 			},
 		},
@@ -117,6 +131,27 @@ func scalingPolicyConfig(clusterName, projectID, name string) string {
 		confidence {
 			threshold = 0.4
 		}
+    assignment_rules {
+      rules {
+        namespace {
+          names = ["default", "kube-system"]
+        }
+      }
+      rules {
+        workload {
+          gvk = ["Deployment", "StatefulSet"]
+          labels_expressions {
+            key      = "region"
+            operator = "NotIn"
+            values = ["eu-west-1", "eu-west-2"]
+          }
+          labels_expressions {
+            key      = "helm.sh/chart"
+            operator = "Exists"
+          }
+        }
+      }
+    }
 		cpu {
 			function 		= "QUANTILE"
 			overhead 		= 0.05
@@ -162,6 +197,22 @@ func scalingPolicyConfigUpdated(clusterName, projectID, name string) string {
 		cluster_id			= castai_gke_cluster.test.id
 		apply_type			= "IMMEDIATE"
 		management_option	= "MANAGED"
+    assignment_rules {
+      rules {
+        namespace {
+          names = ["team-a"]
+        }
+      }
+      rules {
+        workload {
+          gvk = ["DaemonSet"]
+          labels_expressions {
+            key      = "helm.sh/chart"
+            operator = "NotExists"
+          }
+        }
+      }
+    }
 		cpu {
 			function 		= "QUANTILE"
 			overhead 		= 0.15

--- a/docs/resources/workload_scaling_policy.md
+++ b/docs/resources/workload_scaling_policy.md
@@ -20,6 +20,27 @@ resource "castai_workload_scaling_policy" "services" {
   cluster_id        = castai_gke_cluster.dev.id
   apply_type        = "IMMEDIATE"
   management_option = "MANAGED"
+  assignment_rules {
+    rules {
+      namespace {
+        names = ["default", "kube-system"]
+      }
+    }
+    rules {
+      workload {
+        gvk = ["Deployment", "StatefulSet"]
+        labels_expressions {
+          key      = "region"
+          operator = "NotIn"
+          values = ["eu-west-1", "eu-west-2"]
+        }
+        labels_expressions {
+          key      = "helm.sh/chart"
+          operator = "Exists"
+        }
+      }
+    }
+  }
   cpu {
     function = "QUANTILE"
     overhead = 0.15
@@ -81,6 +102,7 @@ resource "castai_workload_scaling_policy" "services" {
 ### Optional
 
 - `anti_affinity` (Block List, Max: 1) (see [below for nested schema](#nestedblock--anti_affinity))
+- `assignment_rules` (Block List) Allows defining conditions for automatically assigning workloads to this scaling policy. (see [below for nested schema](#nestedblock--assignment_rules))
 - `confidence` (Block List, Max: 1) Defines the confidence settings for applying recommendations. (see [below for nested schema](#nestedblock--confidence))
 - `downscaling` (Block List, Max: 1) (see [below for nested schema](#nestedblock--downscaling))
 - `memory_event` (Block List, Max: 1) (see [below for nested schema](#nestedblock--memory_event))
@@ -202,6 +224,59 @@ Optional:
 
 - `consider_anti_affinity` (Boolean) Defines if anti-affinity should be considered when scaling the workload.
 	If enabled, requiring host ports, or having anti-affinity on hostname will force all recommendations to be deferred.
+
+
+<a id="nestedblock--assignment_rules"></a>
+### Nested Schema for `assignment_rules`
+
+Optional:
+
+- `rules` (Block List) (see [below for nested schema](#nestedblock--assignment_rules--rules))
+
+<a id="nestedblock--assignment_rules--rules"></a>
+### Nested Schema for `assignment_rules.rules`
+
+Optional:
+
+- `namespace` (Block List, Max: 1) Allows assigning a scaling policy based on the workload's namespace. (see [below for nested schema](#nestedblock--assignment_rules--rules--namespace))
+- `workload` (Block List, Max: 1) Allows assigning a scaling policy based on the workload's metadata. (see [below for nested schema](#nestedblock--assignment_rules--rules--workload))
+
+<a id="nestedblock--assignment_rules--rules--namespace"></a>
+### Nested Schema for `assignment_rules.rules.namespace`
+
+Optional:
+
+- `all` (Boolean) Defines matching all namespaces. Cannot be set together with other matchers.
+- `names` (List of String) Defines matching by namespace names.
+
+
+<a id="nestedblock--assignment_rules--rules--workload"></a>
+### Nested Schema for `assignment_rules.rules.workload`
+
+Optional:
+
+- `all` (Boolean) Defines matching all workloads. Cannot be set together with other matchers.
+- `gvk` (List of String) Group, version, and kind for Kubernetes resources. Format: kind[.version][.group].
+It can be either:
+ - only kind, e.g. "Deployment"
+ - group and kind: e.g."Deployment.apps"
+ - group, version and kind: e.g."Deployment.v1.apps"
+- `labels_expressions` (Block List) Defines matching by label selector requirements. (see [below for nested schema](#nestedblock--assignment_rules--rules--workload--labels_expressions))
+
+<a id="nestedblock--assignment_rules--rules--workload--labels_expressions"></a>
+### Nested Schema for `assignment_rules.rules.workload.labels_expressions`
+
+Required:
+
+- `key` (String) The label key to match.
+- `operator` (String) The operator to use for matching the label.
+
+Optional:
+
+- `values` (List of String) A list of values to match against the label key. Allowed for `In` and `NotIn` operators.
+
+
+
 
 
 <a id="nestedblock--confidence"></a>

--- a/examples/resources/castai_workload_scaling_policy/resource.tf
+++ b/examples/resources/castai_workload_scaling_policy/resource.tf
@@ -3,6 +3,27 @@ resource "castai_workload_scaling_policy" "services" {
   cluster_id        = castai_gke_cluster.dev.id
   apply_type        = "IMMEDIATE"
   management_option = "MANAGED"
+  assignment_rules {
+    rules {
+      namespace {
+        names = ["default", "kube-system"]
+      }
+    }
+    rules {
+      workload {
+        gvk = ["Deployment", "StatefulSet"]
+        labels_expressions {
+          key      = "region"
+          operator = "NotIn"
+          values = ["eu-west-1", "eu-west-2"]
+        }
+        labels_expressions {
+          key      = "helm.sh/chart"
+          operator = "Exists"
+        }
+      }
+    }
+  }
   cpu {
     function = "QUANTILE"
     overhead = 0.15


### PR DESCRIPTION
**Description**

1. Should we nest as in `assignment_rules`, or keep the “duplicate” style like in `labels_expressions`?
   ```tf
   assignment_rules {
   	rules {
   		namespace {
   			names = ["default", "kube-system"]
   			labels_expressions {
   				key      = "foo"
   				operator = "NotIn"
   				values   = ["a", "b"]
   			}
   			labels_expressions {
   				key      = "test"
   				operator = "Exists"
   			}
   		}
   	}
   }
   ```
   IMO the grouping in `assignment_rules` is more readable.
2.	Should we map operators to Kubernetes label selector terms or keep the current ones?
	 - e.g. `KUBERNETES_LABEL_SELECTOR_OP_IN` -> `In`, `KUBERNETES_LABEL_SELECTOR_OP_NOT_IN` -> `NotIn`, `KUBERNETES_LABEL_SELECTOR_OP_EXISTS` -> `Exists`, `KUBERNETES_LABEL_SELECTOR_OP_DOES_NOT_EXIST` -> `DoesNotExist`
   I know that we wanted to have it as close as possible to the API syntax, but who uses API directly? Maybe we can make it more user-friendly for the end users who will use the Terraform provider?
   With our _great_ grcp->rest translation, is hard to have such naming.
