### PR TITLE
fix: specify required helm and aws provider versions

### DIFF
--- a/examples/aks/aks_cluster/versions.tf
+++ b/examples/aks/aks_cluster/versions.tf
@@ -9,6 +9,10 @@ terraform {
     castai = {
       source = "castai/castai"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
   }
   required_version = ">= 0.13"
 }

--- a/examples/eks/eks_clusters/versions.tf
+++ b/examples/eks/eks_clusters/versions.tf
@@ -7,10 +7,12 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     helm = {
-      source = "hashicorp/helm"
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
     }
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
**Description**

Currently the CI fails with the errors like:

```
╷
│ Error: Unsupported block type
│ 
│   on providers.tf line 23, in provider "helm":
│   23:   kubernetes ***
│ 
│ Blocks of type "kubernetes" are not expected here. Did you mean to define
│ argument "kubernetes"? If so, use the equals sign to assign it a value.
╵
╷
│ Error: Unsupported block type
│ 
│   on .terraform/modules/eks/modules/eks-managed-node-group/main.tf line 104, in resource "aws_launch_template" "this":
│  104:   dynamic "elastic_gpu_specifications" ***
│ 
│ Blocks of type "elastic_gpu_specifications" are not expected here.
```

example:  https://github.com/castai/terraform-provider-castai/actions/runs/15819500915/job/44585235272

The reason is that new Helm and AWS were released that have those breaking changes:
- https://registry.terraform.io/providers/hashicorp/helm/latest/docs/guides/v3-upgrade-guide#changes-to-provider-attributes
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-upgrade#data-source-aws_launch_template

There should be a follow-up PRs by the owners to update it to the latest version though.