### PR TITLE
fix: fix allowed rules operators, check response code on policy order changes

### DIFF
--- a/castai/resource_workload_scaling_policy.go
+++ b/castai/resource_workload_scaling_policy.go
@@ -285,6 +285,7 @@ func k8sLabelExpressionsSchema() *schema.Schema {
 					Description: "The operator to use for matching the label.",
 					ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
 						K8sLabelInOperator, K8sLabelNotInOperator, K8sLabelExistsOperator, K8sLabelDoesNotExistOperator,
+						K8sLabelRegexOperator, K8sLabelContainsOperator,
 					}, false)),
 				},
 				"values": {

--- a/castai/resource_workload_scaling_policy_order.go
+++ b/castai/resource_workload_scaling_policy_order.go
@@ -92,9 +92,9 @@ func resourceWorkloadScalingPolicyOrderSet(ctx context.Context, d *schema.Resour
 		PolicyIds: &policyIds,
 	}
 
-	_, err := client.WorkloadOptimizationAPISetScalingPoliciesOrderWithResponse(ctx, clusterId, req)
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("error setting scaling policy order: %w", err))
+	resp, err := client.WorkloadOptimizationAPISetScalingPoliciesOrderWithResponse(ctx, clusterId, req)
+	if err := sdk.CheckOKResponse(resp, err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.SetId(clusterId)

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -3150,6 +3150,9 @@ type ExternalclusterV1GPUConfig struct {
 	// Count Number of GPUs. N1 GCP machines allow attaching custom number of GPUs.
 	Count *int32 `json:"count,omitempty"`
 
+	// MigConfig MIGConfig configures MIG slicing on NVIDIA GPUs.
+	MigConfig *ExternalclusterV1MIGConfig `json:"migConfig,omitempty"`
+
 	// TimeSharing GPUTimeSharing configures sharing strategy by splitting time of single GPU to several processes.
 	TimeSharing *ExternalclusterV1GPUTimeSharing `json:"timeSharing,omitempty"`
 
@@ -3234,6 +3237,12 @@ type ExternalclusterV1ListClustersResponse struct {
 type ExternalclusterV1ListNodesResponse struct {
 	Items      *[]ExternalclusterV1Node `json:"items,omitempty"`
 	NextCursor *string                  `json:"nextCursor,omitempty"`
+}
+
+// ExternalclusterV1MIGConfig MIGConfig configures MIG slicing on NVIDIA GPUs.
+type ExternalclusterV1MIGConfig struct {
+	GpuMemoryGb    *int32    `json:"gpuMemoryGb"`
+	PartitionSizes *[]string `json:"partitionSizes,omitempty"`
 }
 
 // ExternalclusterV1Node Node represents a single VM that run as Kubernetes master or worker.


### PR DESCRIPTION
**Description**

1. without checking the err code  TF detects state drift during plan, but apply doesn't fail (it passes)
2. We forgot to allow the regex/contains operator on https://github.com/castai/terraform-provider-castai/pull/512