### PR TITLE
fix: make key optional for labels matcher in assignment rules

### DIFF
--- a/castai/resource_workload_scaling_policy.go
+++ b/castai/resource_workload_scaling_policy.go
@@ -1385,10 +1385,7 @@ func toKubernetesLabelExpressionMatcher(namespaceMap map[string]any) (*[]sdk.Wor
 	expressions := make([]sdk.WorkloadoptimizationV1KubernetesLabelExpressionMatcher, len(*exprs))
 	for j, expr := range *exprs {
 		exprMap := expr.(map[string]any)
-		key, err := mustGetValue[string](exprMap, "key")
-		if err != nil {
-			return nil, err
-		}
+		key := readOptionalValue[string](exprMap, "key")
 
 		operator, err := mustGetValue[string](exprMap, "operator")
 		if err != nil {
@@ -1396,7 +1393,7 @@ func toKubernetesLabelExpressionMatcher(namespaceMap map[string]any) (*[]sdk.Wor
 		}
 
 		expressions[j] = sdk.WorkloadoptimizationV1KubernetesLabelExpressionMatcher{
-			Key:      *key,
+			Key:      key,
 			Operator: toLabelSelectorOperator(*operator),
 		}
 

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -5667,7 +5667,7 @@ type WorkloadoptimizationV1KeyValuePair struct {
 // WorkloadoptimizationV1KubernetesLabelExpressionMatcher defines model for workloadoptimization.v1.KubernetesLabelExpressionMatcher.
 type WorkloadoptimizationV1KubernetesLabelExpressionMatcher struct {
 	// Key Key is the label key that the selector applies to.
-	Key string `json:"key"`
+	Key *string `json:"key"`
 
 	// Operator KubernetesLabelSelectorOperator defines the set of operators for a selector requirement.
 	//


### PR DESCRIPTION
**Description**

Tested with local TF:

```tf
provider "castai" {
  api_url   = var.castai_api_url
  api_token = var.castai_api_token
}

resource "castai_workload_scaling_policy" "services" {
	name              = "services-v4"
	cluster_id        = var.castai_gke_cluster_id
	apply_type        = "IMMEDIATE"
	management_option = "MANAGED"
	assignment_rules {
		rules {
			namespace {
				names = ["kube-.*"]
			}
		}
		rules {
			workload {
				gvk = ["Deployment", "StatefulSet"]
				labels_expressions {
					key      = "app.kubernetes.io/managed-by"
					operator = "Regex"
					values   = ["B.*"]
				}
			}
		}
		rules {
			workload {
				gvk = ["Deployment", "StatefulSet"]
				labels_expressions {
					operator = "Regex"
					values   = ["B.*"]
				}
			}
		}
	}
	cpu {
		function = "QUANTILE"
		overhead = 0.15
		apply_threshold_strategy {
			type       = "PERCENTAGE"
			percentage = 0.1
		}
		args                     = ["0.9"]
		look_back_period_seconds = 172800
		min                      = 0.1
		max                      = 1
	}
	memory {
		function = "MAX"
		overhead = 0.35
		apply_threshold_strategy {
			type = "DEFAULT_ADAPTIVE"
		}
		limit {
			type       = "MULTIPLIER"
			multiplier = 1.5
		}
		management_option = "READ_ONLY"
	}
	startup {
		period_seconds = 240
	}
	downscaling {
		apply_type = "DEFERRED"
	}
	memory_event {
		apply_type = "IMMEDIATE"
	}
	anti_affinity {
		consider_anti_affinity = false
	}
	confidence {
		threshold = 0.9
	}
}

```