### PR TITLE
REP-1293: Sets id on read as it needs to be set for importing

### DIFF
--- a/castai/resource_allocation_group.go
+++ b/castai/resource_allocation_group.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -231,6 +233,26 @@ func resourceAllocationGroupDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 	if err := sdk.StatusOk(response); err != nil {
 		return diag.FromErr(err)
+	}
+
+	// Poll until the resource no longer exists
+	err = retry.RetryContext(ctx, 2*time.Second, func() *retry.RetryError {
+		readresp, err := client.AllocationGroupAPIGetAllocationGroupWithResponse(ctx, d.Id())
+		if err != nil {
+			// Retryable error
+			return retry.RetryableError(err)
+		}
+		if readresp.StatusCode() == http.StatusNotFound {
+			// Resource is gone
+			return nil
+		}
+
+		// Still exists, retry
+		return retry.RetryableError(fmt.Errorf("resource %s still exists", d.Id()))
+	})
+
+	if err != nil {
+		return diag.Errorf("Error waiting for resource %s to be deleted: %s", d.Id(), err)
 	}
 
 	return nil

--- a/castai/resource_allocation_group_test.go
+++ b/castai/resource_allocation_group_test.go
@@ -63,8 +63,6 @@ func testAccCheckAllocationGroupDestroy(s *terraform.State) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	time.Sleep(100 * time.Millisecond)
-
 	client := testAccProvider.Meta().(*ProviderConfig).api
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "castai_allocation_group" {


### PR DESCRIPTION
When doing import with `ImportStatePassthroughContext` it seems that read method should set the id otherwise we get an error that no object exists with a given id