### PR TITLE
WIRE-981: Remove UsersAPIUpdateOrganizationUser usage

### DIFF
--- a/castai/resource_organization_members.go
+++ b/castai/resource_organization_members.go
@@ -54,6 +54,7 @@ func resourceOrganizationMembers() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Description: "A list of email addresses corresponding to users who should be given owner access to the organization.",
+				Deprecated:  "The 'owners' field is deprecated. Use 'castai_role_bindings' resource instead for more granular role management. This field will be removed in a future version.",
 			},
 			FieldOrganizationMembersViewers: {
 				Type:     schema.TypeList,
@@ -62,6 +63,7 @@ func resourceOrganizationMembers() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Description: "A list of email addresses corresponding to users who should be given viewer access to the organization.",
+				Deprecated:  "The 'viewers' field is deprecated. Use 'castai_role_bindings' resource instead for more granular role management. This field will be removed in a future version.",
 			},
 			FieldOrganizationMembersMembers: {
 				Type:     schema.TypeList,
@@ -70,6 +72,7 @@ func resourceOrganizationMembers() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Description: "A list of email addresses corresponding to users who should be given member access to the organization.",
+				Deprecated:  "The 'members' field is deprecated. Use 'castai_role_bindings' resource instead for more granular role management. This field will be removed in a future version.",
 			},
 		},
 	}
@@ -259,16 +262,6 @@ func resourceOrganizationMembersUpdate(ctx context.Context, data *schema.Resourc
 		return diag.FromErr(
 			fmt.Errorf("can't delete user that is currently managing this organization: %s", lo.FromPtr(currentUserResp.JSON200.Email)),
 		)
-	}
-
-	for userID, role := range manipulations.membersToUpdate {
-		role := role
-		resp, err := client.UsersAPIUpdateOrganizationUserWithResponse(ctx, organizationID, userID, sdk.UsersAPIUpdateOrganizationUserJSONRequestBody{
-			Role: &role,
-		})
-		if err := sdk.CheckOKResponse(resp, err); err != nil {
-			return diag.FromErr(fmt.Errorf("updating user: %w", err))
-		}
 	}
 
 	for _, userID := range manipulations.membersToDelete {

--- a/castai/resource_organization_members_test.go
+++ b/castai/resource_organization_members_test.go
@@ -98,6 +98,23 @@ Tainted = false
 `, data.State().String())
 }
 
+func TestOrganizationResourceSchemaDeprecation(t *testing.T) {
+	t.Parallel()
+
+	r := require.New(t)
+	resource := resourceOrganizationMembers()
+	schema := resource.Schema
+
+	// Test that deprecated fields have deprecation warnings
+	r.NotEmpty(schema[FieldOrganizationMembersOwners].Deprecated)
+	r.NotEmpty(schema[FieldOrganizationMembersViewers].Deprecated)
+	r.NotEmpty(schema[FieldOrganizationMembersMembers].Deprecated)
+
+	// Test that deprecation messages mention role bindings
+	r.Contains(schema[FieldOrganizationMembersOwners].Deprecated, "castai_role_bindings")
+	r.Contains(schema[FieldOrganizationMembersViewers].Deprecated, "castai_role_bindings")
+	r.Contains(schema[FieldOrganizationMembersMembers].Deprecated, "castai_role_bindings")
+}
 func TestCompareRoleMembers(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
I don't see a reason to change the update logic to create role bindings instead, since the metrics for the endpoint are not showing any signs of life.

Use to see the details
```
<grafana-domain>/explore?schemaVersion=1&panes=%7B"r0p":%7B"datasource":"prometheus","queries":%5B%7B"datasource":%7B"type":"prometheus","uid":"prometheus"%7D,"editorMode":"builder","expr":"sum%28grpc_server_started_total%7Bnamespace%3D%5C"console%5C",%20pod%3D~%5C"users-.%2A%5C",%20grpc_method%3D%5C"UpdateOrganizationUser%5C"%7D%29","legendFormat":"__auto","range":true,"refId":"A","adhocFilters":%5B%5D,"interval":"","useBackend":false,"disableTextWrap":false,"fullMetaSearch":false,"includeNullMetadata":true%7D%5D,"range":%7B"from":"now-30d","to":"now"%7D%7D%7D&orgId=1
```
