### PR TITLE
chore: fix Cluster is not ready after 10 minutes

### DIFF
--- a/examples/eks/eks_clusters/castai.tf
+++ b/examples/eks/eks_clusters/castai.tf
@@ -1,3 +1,9 @@
+resource "time_sleep" "wait_for_nat_gateway" {
+  depends_on = [module.vpc]
+
+  create_duration = "30s"
+}
+
 module "cluster" {
   source = "./module/castai"
   count  = var.enable_castai ? 1 : 0
@@ -12,4 +18,7 @@ module "cluster" {
     aws_security_group.additional.id,
   ]
   subnets = module.vpc.private_subnets
+  depends_on = [
+    time_sleep.wait_for_nat_gateway
+  ]
 }

--- a/examples/eks/eks_clusters/castai.tf
+++ b/examples/eks/eks_clusters/castai.tf
@@ -1,14 +1,8 @@
-resource "time_sleep" "wait_for_nat_gateway" {
-  depends_on = [module.vpc]
-
-  create_duration = "30s"
-}
-
 module "cluster" {
   source = "./module/castai"
   count  = var.enable_castai ? 1 : 0
 
-  cluster_name     = var.cluster_name
+  cluster_name     = module.eks.cluster_name
   castai_api_token = var.castai_api_token
   cluster_region   = var.cluster_region
   vpc_id           = module.vpc.vpc_id
@@ -18,7 +12,4 @@ module "cluster" {
     aws_security_group.additional.id,
   ]
   subnets = module.vpc.private_subnets
-  depends_on = [
-    time_sleep.wait_for_nat_gateway
-  ]
 }

--- a/examples/eks/eks_clusters/eks.tf
+++ b/examples/eks/eks_clusters/eks.tf
@@ -62,8 +62,6 @@ module "eks" {
       }
     }
   }
-
-  #depends_on = [module.vpc]
 }
 
 # Example additional security group.

--- a/examples/eks/eks_clusters/eks.tf
+++ b/examples/eks/eks_clusters/eks.tf
@@ -81,5 +81,4 @@ resource "aws_security_group" "additional" {
   }
 
   depends_on = [module.vpc]
-
 }

--- a/examples/eks/eks_clusters/eks.tf
+++ b/examples/eks/eks_clusters/eks.tf
@@ -80,5 +80,4 @@ resource "aws_security_group" "additional" {
     ]
   }
 
-  depends_on = [module.vpc]
 }

--- a/examples/eks/eks_clusters/eks.tf
+++ b/examples/eks/eks_clusters/eks.tf
@@ -62,6 +62,8 @@ module "eks" {
       }
     }
   }
+
+  depends_on = [module.vpc]
 }
 
 # Example additional security group.
@@ -77,4 +79,7 @@ resource "aws_security_group" "additional" {
       "10.0.0.0/8",
     ]
   }
+
+  depends_on = [module.vpc]
+
 }

--- a/examples/eks/eks_clusters/eks.tf
+++ b/examples/eks/eks_clusters/eks.tf
@@ -79,5 +79,4 @@ resource "aws_security_group" "additional" {
       "10.0.0.0/8",
     ]
   }
-
 }

--- a/examples/eks/eks_clusters/eks.tf
+++ b/examples/eks/eks_clusters/eks.tf
@@ -63,7 +63,7 @@ module "eks" {
     }
   }
 
-  depends_on = [module.vpc]
+  #depends_on = [module.vpc]
 }
 
 # Example additional security group.


### PR DESCRIPTION
```
│ echo "Cluster is not ready after 10 minutes"
│ exit 1
│ ': exit status 1. Output: Cluster is not ready after 10 minutes
```

We have a dependency problem with eks module and the resource creation must be completed before cast ai module runs

Tested this change and working fine,
`
Apply complete! Resources: 90 added, 0 changed, 0 destroyed.`