### PR TITLE
chore: move to helm provider v3 in examples

### DIFF
--- a/examples/aks/aks_cluster/castai.tf
+++ b/examples/aks/aks_cluster/castai.tf
@@ -9,7 +9,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = azurerm_kubernetes_cluster.this.kube_config.0.host
     client_certificate     = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_certificate)
     client_key             = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_key)

--- a/examples/aks/aks_cluster/castai.tf
+++ b/examples/aks/aks_cluster/castai.tf
@@ -20,7 +20,7 @@ provider "helm" {
 # Configure AKS cluster connection to CAST AI using CAST AI aks-cluster module.
 module "castai-aks-cluster" {
   source  = "castai/aks/castai"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/aks/aks_cluster/versions.tf
+++ b/examples/aks/aks_cluster/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/aks/aks_cluster_arm_template/castai.tf
+++ b/examples/aks/aks_cluster_arm_template/castai.tf
@@ -9,7 +9,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = azurerm_kubernetes_cluster.this.kube_config.0.host
     client_certificate     = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_certificate)
     client_key             = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_key)

--- a/examples/aks/aks_cluster_arm_template/castai.tf
+++ b/examples/aks/aks_cluster_arm_template/castai.tf
@@ -20,7 +20,7 @@ provider "helm" {
 # Configure AKS cluster connection to CAST AI using CAST AI aks-cluster module.
 module "castai-aks-cluster" {
   source  = "castai/aks/castai"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/aks/aks_cluster_arm_template/versions.tf
+++ b/examples/aks/aks_cluster_arm_template/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/aks/aks_cluster_autoscaler_policies/castai.tf
+++ b/examples/aks/aks_cluster_autoscaler_policies/castai.tf
@@ -9,7 +9,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = azurerm_kubernetes_cluster.this.kube_config.0.host
     client_certificate     = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_certificate)
     client_key             = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_key)

--- a/examples/aks/aks_cluster_autoscaler_policies/castai.tf
+++ b/examples/aks/aks_cluster_autoscaler_policies/castai.tf
@@ -20,7 +20,7 @@ provider "helm" {
 # Configure AKS cluster connection to CAST AI using CAST AI aks-cluster module.
 module "castai-aks-cluster" {
   source  = "castai/aks/castai"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/aks/aks_cluster_autoscaler_policies/versions.tf
+++ b/examples/aks/aks_cluster_autoscaler_policies/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/aks/aks_cluster_azure_cni/castai.tf
+++ b/examples/aks/aks_cluster_azure_cni/castai.tf
@@ -9,7 +9,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = azurerm_kubernetes_cluster.this.kube_config.0.host
     client_certificate     = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_certificate)
     client_key             = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_key)

--- a/examples/aks/aks_cluster_azure_cni/castai.tf
+++ b/examples/aks/aks_cluster_azure_cni/castai.tf
@@ -20,7 +20,7 @@ provider "helm" {
 # Configure AKS cluster connection to CAST AI using CAST AI aks-cluster module.
 module "castai-aks-cluster" {
   source  = "castai/aks/castai"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/aks/aks_cluster_azure_cni/versions.tf
+++ b/examples/aks/aks_cluster_azure_cni/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/aks/aks_cluster_existing/castai.tf
+++ b/examples/aks/aks_cluster_existing/castai.tf
@@ -9,7 +9,7 @@ data "azurerm_kubernetes_cluster" "example" {
 # Configure AKS cluster connection to CAST AI using CAST AI aks-cluster module.
 module "castai-aks-cluster" {
   source  = "castai/aks/castai"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/aks/aks_cluster_existing/providers.tf
+++ b/examples/aks/aks_cluster_existing/providers.tf
@@ -14,7 +14,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.azurerm_kubernetes_cluster.example.kube_config.0.host
     client_certificate     = base64decode(data.azurerm_kubernetes_cluster.example.kube_config.0.client_certificate)
     client_key             = base64decode(data.azurerm_kubernetes_cluster.example.kube_config.0.client_key)

--- a/examples/aks/aks_cluster_existing/versions.tf
+++ b/examples/aks/aks_cluster_existing/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/aks/aks_cluster_extension_agent/providers.tf
+++ b/examples/aks/aks_cluster_extension_agent/providers.tf
@@ -13,7 +13,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = azurerm_kubernetes_cluster.this.kube_config.0.host
     client_certificate     = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_certificate)
     client_key             = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_key)

--- a/examples/aks/aks_cluster_extension_agent/versions.tf
+++ b/examples/aks/aks_cluster_extension_agent/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/aks/aks_cluster_read_only/castai.tf
+++ b/examples/aks/aks_cluster_read_only/castai.tf
@@ -8,7 +8,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.azurerm_kubernetes_cluster.this.kube_config.0.host
     client_certificate     = base64decode(data.azurerm_kubernetes_cluster.this.kube_config.0.client_certificate)
     client_key             = base64decode(data.azurerm_kubernetes_cluster.this.kube_config.0.client_key)
@@ -24,19 +24,23 @@ resource "helm_release" "castai_agent" {
   create_namespace = true
   cleanup_on_fail  = true
 
-  set {
-    name  = "provider"
-    value = "aks"
-  }
-  set_sensitive {
-    name  = "apiKey"
-    value = var.castai_api_token
-  }
+  set = [
+    {
+      name  = "provider"
+      value = "aks"
+    },
+    # Required until https://github.com/castai/helm-charts/issues/135 is fixed.
+    {
+      name  = "createNamespace"
+      value = "false"
+    },
+  ]
+  set_sensitive = [
+    {
+      name  = "apiKey"
+      value = var.castai_api_token
+    },
+  ]
 
-  # Required until https://github.com/castai/helm-charts/issues/135 is fixed.
-  set {
-    name  = "createNamespace"
-    value = "false"
-  }
 }
 

--- a/examples/aks/aks_cluster_read_only/versions.tf
+++ b/examples/aks/aks_cluster_read_only/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/aks/aks_cluster_with_proxy/castai.tf
+++ b/examples/aks/aks_cluster_with_proxy/castai.tf
@@ -7,7 +7,7 @@ locals {
 
 module "castai-aks-cluster" {
   source  = "castai/aks/castai"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/aks/aks_cluster_with_proxy/providers.tf
+++ b/examples/aks/aks_cluster_with_proxy/providers.tf
@@ -13,7 +13,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = azurerm_kubernetes_cluster.aks.kube_config.0.host
     client_certificate     = base64decode(azurerm_kubernetes_cluster.aks.kube_config.0.client_certificate)
     client_key             = base64decode(azurerm_kubernetes_cluster.aks.kube_config.0.client_key)

--- a/examples/aks/aks_cluster_with_proxy/versions.tf
+++ b/examples/aks/aks_cluster_with_proxy/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/aks/aks_cluster_with_security/castai.tf
+++ b/examples/aks/aks_cluster_with_security/castai.tf
@@ -6,7 +6,7 @@ data "azurerm_subscription" "current" {}
 # Configure AKS cluster connection to CAST AI using CAST AI aks-cluster module with enabled Kvisor security agent.
 module "castai-aks-cluster" {
   source  = "castai/aks/castai"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   kvisor_grpc_addr = var.kvisor_grpc_addr
 

--- a/examples/aks/aks_cluster_with_security/providers.tf
+++ b/examples/aks/aks_cluster_with_security/providers.tf
@@ -14,7 +14,7 @@ provider "azuread" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = azurerm_kubernetes_cluster.this.kube_config.0.host
     client_certificate     = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_certificate)
     client_key             = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_key)

--- a/examples/aks/aks_cluster_with_security/versions.tf
+++ b/examples/aks/aks_cluster_with_security/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/aks/aks_cluster_with_security_runtime_rules/castai.tf
+++ b/examples/aks/aks_cluster_with_security_runtime_rules/castai.tf
@@ -6,7 +6,7 @@ data "azurerm_subscription" "current" {}
 # Configure AKS cluster connection to CAST AI using CAST AI aks-cluster module with enabled Kvisor security agent.
 module "castai-aks-cluster" {
   source  = "castai/aks/castai"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   kvisor_grpc_addr = var.kvisor_grpc_addr
 

--- a/examples/aks/aks_cluster_with_security_runtime_rules/providers.tf
+++ b/examples/aks/aks_cluster_with_security_runtime_rules/providers.tf
@@ -14,7 +14,7 @@ provider "azuread" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = azurerm_kubernetes_cluster.this.kube_config.0.host
     client_certificate     = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_certificate)
     client_key             = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_key)

--- a/examples/aks/aks_cluster_with_security_runtime_rules/versions.tf
+++ b/examples/aks/aks_cluster_with_security_runtime_rules/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/eks/eks_cluster_access_entries/castai.tf
+++ b/examples/eks/eks_cluster_access_entries/castai.tf
@@ -17,10 +17,10 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed.

--- a/examples/eks/eks_cluster_access_entries/castai.tf
+++ b/examples/eks/eks_cluster_access_entries/castai.tf
@@ -53,7 +53,7 @@ resource "castai_eks_clusterid" "cluster_id" {
 
 module "castai-eks-cluster" {
   source                 = "castai/eks-cluster/castai"
-  version                = "~> 12.0"
+  version                = "~> 13.0"
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token
   grpc_url               = var.castai_grpc_url

--- a/examples/eks/eks_cluster_access_entries/versions.tf
+++ b/examples/eks/eks_cluster_access_entries/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/eks/eks_cluster_assumerole/castai.tf
+++ b/examples/eks/eks_cluster_assumerole/castai.tf
@@ -17,10 +17,10 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed.

--- a/examples/eks/eks_cluster_assumerole/castai.tf
+++ b/examples/eks/eks_cluster_assumerole/castai.tf
@@ -53,7 +53,7 @@ resource "castai_eks_clusterid" "cluster_id" {
 
 module "castai-eks-cluster" {
   source                 = "castai/eks-cluster/castai"
-  version                = "~> 12.0"
+  version                = "~> 13.0"
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token
   grpc_url               = var.castai_grpc_url

--- a/examples/eks/eks_cluster_assumerole/versions.tf
+++ b/examples/eks/eks_cluster_assumerole/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/eks/eks_cluster_autoscaler_policies/castai.tf
+++ b/examples/eks/eks_cluster_autoscaler_policies/castai.tf
@@ -18,10 +18,10 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed.

--- a/examples/eks/eks_cluster_autoscaler_policies/castai.tf
+++ b/examples/eks/eks_cluster_autoscaler_policies/castai.tf
@@ -54,7 +54,7 @@ resource "castai_eks_clusterid" "cluster_id" {
 
 module "castai-eks-cluster" {
   source  = "castai/eks-cluster/castai"
-  version = "~> 12.0"
+  version = "~> 13.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/eks/eks_cluster_autoscaler_policies/versions.tf
+++ b/examples/eks/eks_cluster_autoscaler_policies/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/eks/eks_cluster_custom_iam/castai.tf
+++ b/examples/eks/eks_cluster_custom_iam/castai.tf
@@ -35,7 +35,7 @@ resource "castai_eks_clusterid" "cluster_id" {
 
 module "castai-eks-cluster" {
   source  = "castai/eks-cluster/castai"
-  version = "~> 12.0"
+  version = "~> 13.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/eks/eks_cluster_custom_iam/castai.tf
+++ b/examples/eks/eks_cluster_custom_iam/castai.tf
@@ -13,10 +13,10 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed.

--- a/examples/eks/eks_cluster_custom_iam/versions.tf
+++ b/examples/eks/eks_cluster_custom_iam/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/eks/eks_cluster_existing/castai.tf
+++ b/examples/eks/eks_cluster_existing/castai.tf
@@ -44,7 +44,7 @@ resource "castai_eks_clusterid" "cluster_id" {
 
 module "castai-eks-cluster" {
   source  = "castai/eks-cluster/castai"
-  version = "~> 12.0"
+  version = "~> 13.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/eks/eks_cluster_existing/providers.tf
+++ b/examples/eks/eks_cluster_existing/providers.tf
@@ -21,10 +21,10 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.existing_cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.existing_cluster.certificate_authority.0.data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed.

--- a/examples/eks/eks_cluster_existing/versions.tf
+++ b/examples/eks/eks_cluster_existing/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/eks/eks_cluster_ipv6/castai.tf
+++ b/examples/eks/eks_cluster_ipv6/castai.tf
@@ -17,10 +17,10 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed.

--- a/examples/eks/eks_cluster_ipv6/castai.tf
+++ b/examples/eks/eks_cluster_ipv6/castai.tf
@@ -53,7 +53,7 @@ resource "castai_eks_clusterid" "cluster_id" {
 
 module "castai-eks-cluster" {
   source                 = "castai/eks-cluster/castai"
-  version                = "~> 12.0"
+  version                = "~> 13.0"
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token
   grpc_url               = var.castai_grpc_url

--- a/examples/eks/eks_cluster_ipv6/versions.tf
+++ b/examples/eks/eks_cluster_ipv6/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/eks/eks_cluster_live_migration/module/castai/castai.tf
+++ b/examples/eks/eks_cluster_live_migration/module/castai/castai.tf
@@ -160,25 +160,24 @@ resource "helm_release" "live-helm" {
   create_namespace  = true
   dependency_update = true
 
-  set {
-    name  = "castai-aws-vpc-cni.enabled"
-    value = "true"
-  }
-
-  set {
-    name  = "castai.clusterID"
-    value = castai_eks_clusterid.cluster_id.id
-  }
-
-  set {
-    name  = "castai.apiKey"
-    value = var.castai_api_token
-  }
-
-  set {
-    name  = "castai.apiURL"
-    value = var.castai_api_url
-  }
+  set = [
+    {
+      name  = "castai-aws-vpc-cni.enabled"
+      value = "true"
+    },
+    {
+      name  = "castai.clusterID"
+      value = castai_eks_clusterid.cluster_id.id
+    },
+    {
+      name  = "castai.apiKey"
+      value = var.castai_api_token
+    },
+    {
+      name  = "castai.apiURL"
+      value = var.castai_api_url
+    },
+  ]
 
   wait = false
 

--- a/examples/eks/eks_cluster_live_migration/module/castai/castai.tf
+++ b/examples/eks/eks_cluster_live_migration/module/castai/castai.tf
@@ -87,7 +87,7 @@ resource "castai_eks_clusterid" "cluster_id" {
 
 module "castai-eks-cluster" {
   source  = "castai/eks-cluster/castai"
-  version = "~> 12.0"
+  version = "~> 13.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/eks/eks_cluster_live_migration/module/castai/versions.tf
+++ b/examples/eks/eks_cluster_live_migration/module/castai/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/eks/eks_cluster_live_migration/providers.tf
+++ b/examples/eks/eks_cluster_live_migration/providers.tf
@@ -20,10 +20,10 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed.

--- a/examples/eks/eks_cluster_live_migration/versions.tf
+++ b/examples/eks/eks_cluster_live_migration/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/eks/eks_cluster_optional_readonly/versions.tf
+++ b/examples/eks/eks_cluster_optional_readonly/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/eks/eks_cluster_readonly/castai.tf
+++ b/examples/eks/eks_cluster_readonly/castai.tf
@@ -9,10 +9,10 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed.
@@ -37,18 +37,28 @@ resource "helm_release" "castai_agent" {
   create_namespace = true
   cleanup_on_fail  = true
 
-  set {
-    name  = "provider"
-    value = "eks"
-  }
-  set_sensitive {
-    name  = "apiKey"
-    value = castai_eks_cluster.this.cluster_token
-  }
+  set = concat(
+    [
+      {
+        name  = "provider"
+        value = "eks"
+      },
+      {
+        # Required until https://github.com/castai/helm-charts/issues/135 is fixed.
+        name  = "createNamespace"
+        value = "false"
+      },
+    ],
+    var.castai_api_url != "" ? [{
+      name  = "apiURL"
+      value = var.castai_api_url
+    }] : [],
+  )
 
-  # Required until https://github.com/castai/helm-charts/issues/135 is fixed.
-  set {
-    name  = "createNamespace"
-    value = "false"
-  }
+  set_sensitive = [
+    {
+      name  = "apiKey"
+      value = castai_eks_cluster.this.cluster_token
+    },
+  ]
 }

--- a/examples/eks/eks_cluster_readonly/versions.tf
+++ b/examples/eks/eks_cluster_readonly/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/eks/eks_cluster_with_security/castai.tf
+++ b/examples/eks/eks_cluster_with_security/castai.tf
@@ -32,7 +32,7 @@ module "castai-eks-role-iam" {
 # Install CAST AI with enabled Kvisor security agent.
 module "castai-eks-cluster" {
   source  = "castai/eks-cluster/castai"
-  version = "~> 12.0"
+  version = "~> 13.0"
 
   kvisor_grpc_addr = var.kvisor_grpc_addr
 

--- a/examples/eks/eks_cluster_with_security/providers.tf
+++ b/examples/eks/eks_cluster_with_security/providers.tf
@@ -21,10 +21,10 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed.

--- a/examples/eks/eks_cluster_with_security/versions.tf
+++ b/examples/eks/eks_cluster_with_security/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/eks/eks_cluster_with_security_runtime_rules/castai.tf
+++ b/examples/eks/eks_cluster_with_security_runtime_rules/castai.tf
@@ -32,7 +32,7 @@ module "castai-eks-role-iam" {
 # Install CAST AI with enabled Kvisor security agent.
 module "castai-eks-cluster" {
   source  = "castai/eks-cluster/castai"
-  version = "~> 12.0"
+  version = "~> 13.0"
 
   kvisor_grpc_addr = var.kvisor_grpc_addr
 

--- a/examples/eks/eks_cluster_with_security_runtime_rules/providers.tf
+++ b/examples/eks/eks_cluster_with_security_runtime_rules/providers.tf
@@ -21,10 +21,10 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed.

--- a/examples/eks/eks_cluster_with_security_runtime_rules/versions.tf
+++ b/examples/eks/eks_cluster_with_security_runtime_rules/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/eks/eks_clusters/module/castai/castai.tf
+++ b/examples/eks/eks_clusters/module/castai/castai.tf
@@ -122,7 +122,7 @@ resource "castai_eks_clusterid" "cluster_id" {
 
 module "castai-eks-cluster" {
   source  = "castai/eks-cluster/castai"
-  version = "~> 12.0"
+  version = "~> 13.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/eks/eks_clusters/module/castai/versions.tf
+++ b/examples/eks/eks_clusters/module/castai/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/eks/eks_clusters/providers.tf
+++ b/examples/eks/eks_clusters/providers.tf
@@ -20,10 +20,10 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed.

--- a/examples/eks/eks_clusters/versions.tf
+++ b/examples/eks/eks_clusters/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/gke/gke_cluster_autoscaler_policies/castai.tf
+++ b/examples/gke/gke_cluster_autoscaler_policies/castai.tf
@@ -28,7 +28,7 @@ module "castai-gke-iam" {
 
 module "castai-gke-cluster" {
   source  = "castai/gke-cluster/castai"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/gke/gke_cluster_autoscaler_policies/castai.tf
+++ b/examples/gke/gke_cluster_autoscaler_policies/castai.tf
@@ -10,7 +10,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = "https://${module.gke.endpoint}"
     token                  = data.google_client_config.default.access_token
     cluster_ca_certificate = base64decode(module.gke.ca_certificate)

--- a/examples/gke/gke_cluster_autoscaler_policies/version.tf
+++ b/examples/gke/gke_cluster_autoscaler_policies/version.tf
@@ -14,7 +14,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/gke/gke_cluster_existing/castai.tf
+++ b/examples/gke/gke_cluster_existing/castai.tf
@@ -21,7 +21,7 @@ module "castai-gke-iam" {
 
 module "castai-gke-cluster" {
   source  = "castai/gke-cluster/castai"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/gke/gke_cluster_existing/providers.tf
+++ b/examples/gke/gke_cluster_existing/providers.tf
@@ -4,7 +4,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = "https://${data.google_container_cluster.my_cluster.endpoint}"
     token                  = data.google_client_config.default.access_token
     cluster_ca_certificate = base64decode(data.google_container_cluster.my_cluster.master_auth.0.cluster_ca_certificate)

--- a/examples/gke/gke_cluster_existing/version.tf
+++ b/examples/gke/gke_cluster_existing/version.tf
@@ -14,7 +14,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/gke/gke_cluster_readonly/version.tf
+++ b/examples/gke/gke_cluster_readonly/version.tf
@@ -14,7 +14,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/gke/gke_cluster_with_security/castai.tf
+++ b/examples/gke/gke_cluster_with_security/castai.tf
@@ -13,7 +13,7 @@ module "castai-gke-iam" {
 # Configure GKE cluster connection to CAST AI with enabled Kvisor security agent.
 module "castai-gke-cluster" {
   source  = "castai/gke-cluster/castai"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   wait_for_cluster_ready = true
   kvisor_grpc_addr       = var.kvisor_grpc_addr

--- a/examples/gke/gke_cluster_with_security/providers.tf
+++ b/examples/gke/gke_cluster_with_security/providers.tf
@@ -5,7 +5,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = "https://${google_container_cluster.my-k8s-cluster.endpoint}"
     token                  = data.google_client_config.default.access_token
     cluster_ca_certificate = base64decode(google_container_cluster.my-k8s-cluster.master_auth[0].cluster_ca_certificate)

--- a/examples/gke/gke_cluster_with_security/version.tf
+++ b/examples/gke/gke_cluster_with_security/version.tf
@@ -14,7 +14,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/gke/gke_cluster_with_security_runtime_rules/castai.tf
+++ b/examples/gke/gke_cluster_with_security_runtime_rules/castai.tf
@@ -12,7 +12,7 @@ module "castai-gke-iam" {
 # Configure GKE cluster connection to CAST AI with enabled Kvisor security agent.
 module "castai-gke-cluster" {
   source  = "castai/gke-cluster/castai"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   wait_for_cluster_ready = true
   kvisor_grpc_addr       = var.kvisor_grpc_addr

--- a/examples/gke/gke_cluster_with_security_runtime_rules/providers.tf
+++ b/examples/gke/gke_cluster_with_security_runtime_rules/providers.tf
@@ -5,7 +5,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = "https://${google_container_cluster.my-k8s-cluster.endpoint}"
     token                  = data.google_client_config.default.access_token
     cluster_ca_certificate = base64decode(google_container_cluster.my-k8s-cluster.master_auth[0].cluster_ca_certificate)

--- a/examples/gke/gke_cluster_with_security_runtime_rules/version.tf
+++ b/examples/gke/gke_cluster_with_security_runtime_rules/version.tf
@@ -14,7 +14,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/gke/gke_cluster_zonal_autoscaler/castai.tf
+++ b/examples/gke/gke_cluster_zonal_autoscaler/castai.tf
@@ -28,7 +28,7 @@ module "castai-gke-iam" {
 
 module "castai-gke-cluster" {
   source  = "castai/gke-cluster/castai"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/gke/gke_cluster_zonal_autoscaler/castai.tf
+++ b/examples/gke/gke_cluster_zonal_autoscaler/castai.tf
@@ -10,7 +10,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = "https://${module.gke.endpoint}"
     token                  = data.google_client_config.default.access_token
     cluster_ca_certificate = base64decode(module.gke.ca_certificate)

--- a/examples/gke/gke_cluster_zonal_autoscaler/version.tf
+++ b/examples/gke/gke_cluster_zonal_autoscaler/version.tf
@@ -14,7 +14,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/gke/gke_clusters_with_workspaces/providers.tf
+++ b/examples/gke/gke_clusters_with_workspaces/providers.tf
@@ -4,7 +4,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     config_path    = "~/.kube/config"
     config_context = var.kube_config_context
   }

--- a/examples/gke/gke_clusters_with_workspaces/versions.tf
+++ b/examples/gke/gke_clusters_with_workspaces/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/examples/gke/gke_impersonate/castai.tf
+++ b/examples/gke/gke_impersonate/castai.tf
@@ -15,7 +15,7 @@ module "iam-impersonate" {
 
 module "castai-gke-cluster" {
   source  = "castai/gke-cluster/castai"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/gke/gke_impersonate/providers.tf
+++ b/examples/gke/gke_impersonate/providers.tf
@@ -7,7 +7,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = "https://${module.gke.endpoint}"
     token                  = data.google_client_config.default.access_token
     cluster_ca_certificate = base64decode(module.gke.ca_certificate)

--- a/examples/gke/gke_impersonate/version.tf
+++ b/examples/gke/gke_impersonate/version.tf
@@ -15,7 +15,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"

--- a/examples/gke/gke_live_migration/castai.tf
+++ b/examples/gke/gke_live_migration/castai.tf
@@ -32,7 +32,7 @@ module "castai-gke-iam" {
 
 module "castai-gke-cluster" {
   source  = "castai/gke-cluster/castai"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token

--- a/examples/gke/gke_live_migration/castai.tf
+++ b/examples/gke/gke_live_migration/castai.tf
@@ -14,7 +14,7 @@ provider "castai" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = "https://${module.gke.endpoint}"
     token                  = data.google_client_config.default.access_token
     cluster_ca_certificate = base64decode(module.gke.ca_certificate)

--- a/examples/gke/gke_live_migration/version.tf
+++ b/examples/gke/gke_live_migration/version.tf
@@ -14,7 +14,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.3.2"


### PR DESCRIPTION
Updating all the examples under `examples/{aks,eks,gke}` to use the latest major version of the Cast AI cluster modules. Those versions were upgraded to support v3 of the `helm` provider in the following PRs:
- https://github.com/castai/terraform-castai-eks-cluster/pull/133
- https://github.com/castai/terraform-castai-gke-cluster/pull/114
- https://github.com/castai/terraform-castai-aks/pull/111

The [v3 release of the Helm provider](https://github.com/hashicorp/terraform-provider-helm/releases/tag/v3.0.0) came with a set of breaking changes around certain attributes becoming nested objects instead of individual blocks (e.g. set and set_sensitive). This PR adapts the affected examples to these changes following the [migration guide](https://github.com/hashicorp/terraform-provider-helm/blob/v3.0.0/docs/guides/v3-upgrade-guide.md) of the helm provider.

## Proof of Work

CI checks for the examples are passing.