### PR TITLE
chore: make generate-sdk

### DIFF
--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -754,6 +754,14 @@ const (
 	WorkloadOptimizationAPIListWorkloadEventsParamsTypeEVENTTYPESURGE                      WorkloadOptimizationAPIListWorkloadEventsParamsType = "EVENT_TYPE_SURGE"
 )
 
+// Defines values for WorkloadOptimizationAPIListWorkloadsParamsSortOrder.
+const (
+	ASC  WorkloadOptimizationAPIListWorkloadsParamsSortOrder = "ASC"
+	Asc  WorkloadOptimizationAPIListWorkloadsParamsSortOrder = "asc"
+	DESC WorkloadOptimizationAPIListWorkloadsParamsSortOrder = "DESC"
+	Desc WorkloadOptimizationAPIListWorkloadsParamsSortOrder = "desc"
+)
+
 // Defines values for WorkloadOptimizationAPIGetInstallCmdParamsCmePresets.
 const (
 	WorkloadOptimizationAPIGetInstallCmdParamsCmePresetsCODAHALE      WorkloadOptimizationAPIGetInstallCmdParamsCmePresets = "CODAHALE"
@@ -2530,6 +2538,9 @@ type CastaiSsoV1beta1CreateSSOConnection struct {
 
 	// Okta Okta represents a Okta connector.
 	Okta *CastaiSsoV1beta1Okta `json:"okta,omitempty"`
+
+	// Saml SAML represents a SAML connector.
+	Saml *CastaiSsoV1beta1SAML `json:"saml,omitempty"`
 }
 
 // CastaiSsoV1beta1DeleteSSOConnectionResponse Defines the container for the sso delete response.
@@ -2587,6 +2598,24 @@ type CastaiSsoV1beta1Okta struct {
 	OktaDomain string `json:"oktaDomain"`
 }
 
+// CastaiSsoV1beta1SAML SAML represents a SAML connector.
+type CastaiSsoV1beta1SAML struct {
+	// CallbackUrl CallbackUrl is the callback url (Assertion Consumer Service URL) of the SAML service provider (Auth0).
+	CallbackUrl *string `json:"callbackUrl"`
+
+	// EntityId EntityId is the entity id of the SAML service provider (Auth0).
+	EntityId *string `json:"entityId"`
+
+	// MetadataUrl MetadataUrl is the URL to the SAML metadata document of the SAML service provider (Auth0).
+	MetadataUrl *string `json:"metadataUrl"`
+
+	// SignInUrl SignInUrl is the URL where the SAML authentication request is sent.
+	SignInUrl string `json:"signInUrl"`
+
+	// X509Certificate X509Certificate is the x509 certificate used to sign the SAML authentication request.
+	X509Certificate string `json:"x509Certificate"`
+}
+
 // CastaiSsoV1beta1SSOConnection SSOConnection represents a sso connection.
 type CastaiSsoV1beta1SSOConnection struct {
 	// Aad AzureAAD represents a Azure AAD connector.
@@ -2619,6 +2648,9 @@ type CastaiSsoV1beta1SSOConnection struct {
 
 	// Okta Okta represents a Okta connector.
 	Okta *CastaiSsoV1beta1Okta `json:"okta,omitempty"`
+
+	// Saml SAML represents a SAML connector.
+	Saml *CastaiSsoV1beta1SAML `json:"saml,omitempty"`
 
 	// Status Status is the status of the connection.
 	//
@@ -2670,6 +2702,9 @@ type CastaiSsoV1beta1UpdateSSOConnection struct {
 
 	// Okta Okta represents a Okta connector.
 	Okta *CastaiSsoV1beta1Okta `json:"okta,omitempty"`
+
+	// Saml SAML represents a SAML connector.
+	Saml *CastaiSsoV1beta1SAML `json:"saml,omitempty"`
 }
 
 // CastaiUsersV1beta1AddUserToOrganizationResponse Defines the response for adding a user to an organization.
@@ -6279,6 +6314,9 @@ type WorkloadoptimizationV1ContainerResourceMetricSource struct {
 
 // WorkloadoptimizationV1Costs defines model for workloadoptimization.v1.Costs.
 type WorkloadoptimizationV1Costs struct {
+	// OriginalRequested Cost of resources configured in original workload template.
+	OriginalRequested *float64 `json:"originalRequested"`
+
 	// Recommended Cost of recommended resources.
 	Recommended *float64 `json:"recommended"`
 
@@ -6653,7 +6691,9 @@ type WorkloadoptimizationV1ListWorkloadScalingPoliciesResponse struct {
 
 // WorkloadoptimizationV1ListWorkloadsResponse defines model for workloadoptimization.v1.ListWorkloadsResponse.
 type WorkloadoptimizationV1ListWorkloadsResponse struct {
-	Workloads []WorkloadoptimizationV1Workload `json:"workloads"`
+	// NextCursor The token to request the next page of results.
+	NextCursor *string                          `json:"nextCursor"`
+	Workloads  []WorkloadoptimizationV1Workload `json:"workloads"`
 }
 
 // WorkloadoptimizationV1ManagedBy Defines sources that can manage the workload.
@@ -7827,6 +7867,10 @@ type RbacServiceAPIListRoleBindingsParams struct {
 	// SubjectType Filter by subject type. Multiple values can be passed as query parameters
 	// (e.g., &subject_type=x&subject_type=y)
 	SubjectType *[]RbacServiceAPIListRoleBindingsParamsSubjectType `form:"subjectType,omitempty" json:"subjectType,omitempty"`
+
+	// SubjectId Filter by subject ID. Multiple values can be passed as query parameters
+	// (e.g., &subject_id=x&subject_id=y)
+	SubjectId *[]string `form:"subjectId,omitempty" json:"subjectId,omitempty"`
 }
 
 // RbacServiceAPIListRoleBindingsParamsScopeType defines parameters for RbacServiceAPIListRoleBindings.
@@ -8312,6 +8356,37 @@ type WorkloadOptimizationAPIGetWorkloadEventParams struct {
 	// CreatedAt The creation time of the event.
 	CreatedAt time.Time `form:"createdAt" json:"createdAt"`
 }
+
+// WorkloadOptimizationAPIListWorkloadsParams defines parameters for WorkloadOptimizationAPIListWorkloads.
+type WorkloadOptimizationAPIListWorkloadsParams struct {
+	WorkloadIds        *[]string `form:"workloadIds,omitempty" json:"workloadIds,omitempty"`
+	WorkloadNames      *[]string `form:"workloadNames,omitempty" json:"workloadNames,omitempty"`
+	Namespaces         *[]string `form:"namespaces,omitempty" json:"namespaces,omitempty"`
+	ScalingPolicyNames *[]string `form:"scalingPolicyNames,omitempty" json:"scalingPolicyNames,omitempty"`
+	Kinds              *[]string `form:"kinds,omitempty" json:"kinds,omitempty"`
+	ManagementOptions  *[]string `form:"managementOptions,omitempty" json:"managementOptions,omitempty"`
+	ConfiguredBy       *[]string `form:"configuredBy,omitempty" json:"configuredBy,omitempty"`
+	SearchQuery        *string   `form:"searchQuery,omitempty" json:"searchQuery,omitempty"`
+	PageLimit          *string   `form:"page.limit,omitempty" json:"page.limit,omitempty"`
+
+	// PageCursor Cursor that defines token indicating where to start the next page.
+	// Empty value indicates to start from beginning of the dataset.
+	PageCursor *string `form:"page.cursor,omitempty" json:"page.cursor,omitempty"`
+
+	// SortField Name of the field you want to sort
+	SortField *string `form:"sort.field,omitempty" json:"sort.field,omitempty"`
+
+	// SortOrder The sort order, possible values ASC or DESC, if not provided asc is the default
+	//
+	//  - ASC: ASC
+	//  - asc: desc
+	//  - DESC: ASC
+	//  - desc: desc
+	SortOrder *WorkloadOptimizationAPIListWorkloadsParamsSortOrder `form:"sort.order,omitempty" json:"sort.order,omitempty"`
+}
+
+// WorkloadOptimizationAPIListWorkloadsParamsSortOrder defines parameters for WorkloadOptimizationAPIListWorkloads.
+type WorkloadOptimizationAPIListWorkloadsParamsSortOrder string
 
 // WorkloadOptimizationAPIGetWorkloadsSummaryParams defines parameters for WorkloadOptimizationAPIGetWorkloadsSummary.
 type WorkloadOptimizationAPIGetWorkloadsSummaryParams struct {

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -817,7 +817,7 @@ type ClientInterface interface {
 	WorkloadOptimizationAPIGetWorkloadEvent(ctx context.Context, clusterId string, eventId string, params *WorkloadOptimizationAPIGetWorkloadEventParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// WorkloadOptimizationAPIListWorkloads request
-	WorkloadOptimizationAPIListWorkloads(ctx context.Context, clusterId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	WorkloadOptimizationAPIListWorkloads(ctx context.Context, clusterId string, params *WorkloadOptimizationAPIListWorkloadsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// WorkloadOptimizationAPIGetWorkloadsSummary request
 	WorkloadOptimizationAPIGetWorkloadsSummary(ctx context.Context, clusterId string, params *WorkloadOptimizationAPIGetWorkloadsSummaryParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4034,8 +4034,8 @@ func (c *Client) WorkloadOptimizationAPIGetWorkloadEvent(ctx context.Context, cl
 	return c.Client.Do(req)
 }
 
-func (c *Client) WorkloadOptimizationAPIListWorkloads(ctx context.Context, clusterId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewWorkloadOptimizationAPIListWorkloadsRequest(c.Server, clusterId)
+func (c *Client) WorkloadOptimizationAPIListWorkloads(ctx context.Context, clusterId string, params *WorkloadOptimizationAPIListWorkloadsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewWorkloadOptimizationAPIListWorkloadsRequest(c.Server, clusterId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -9890,6 +9890,22 @@ func NewRbacServiceAPIListRoleBindingsRequest(server string, organizationId stri
 
 		}
 
+		if params.SubjectId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "subjectId", runtime.ParamLocationQuery, *params.SubjectId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 
@@ -15510,7 +15526,7 @@ func NewWorkloadOptimizationAPIGetWorkloadEventRequest(server string, clusterId 
 }
 
 // NewWorkloadOptimizationAPIListWorkloadsRequest generates requests for WorkloadOptimizationAPIListWorkloads
-func NewWorkloadOptimizationAPIListWorkloadsRequest(server string, clusterId string) (*http.Request, error) {
+func NewWorkloadOptimizationAPIListWorkloadsRequest(server string, clusterId string, params *WorkloadOptimizationAPIListWorkloadsParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -15533,6 +15549,204 @@ func NewWorkloadOptimizationAPIListWorkloadsRequest(server string, clusterId str
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.WorkloadIds != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "workloadIds", runtime.ParamLocationQuery, *params.WorkloadIds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.WorkloadNames != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "workloadNames", runtime.ParamLocationQuery, *params.WorkloadNames); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Namespaces != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "namespaces", runtime.ParamLocationQuery, *params.Namespaces); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ScalingPolicyNames != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "scalingPolicyNames", runtime.ParamLocationQuery, *params.ScalingPolicyNames); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Kinds != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "kinds", runtime.ParamLocationQuery, *params.Kinds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ManagementOptions != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "managementOptions", runtime.ParamLocationQuery, *params.ManagementOptions); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ConfiguredBy != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "configuredBy", runtime.ParamLocationQuery, *params.ConfiguredBy); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.SearchQuery != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "searchQuery", runtime.ParamLocationQuery, *params.SearchQuery); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PageLimit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.limit", runtime.ParamLocationQuery, *params.PageLimit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PageCursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.cursor", runtime.ParamLocationQuery, *params.PageCursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.SortField != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "sort.field", runtime.ParamLocationQuery, *params.SortField); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.SortOrder != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "sort.order", runtime.ParamLocationQuery, *params.SortOrder); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -16943,7 +17157,7 @@ type ClientWithResponsesInterface interface {
 	WorkloadOptimizationAPIGetWorkloadEventWithResponse(ctx context.Context, clusterId string, eventId string, params *WorkloadOptimizationAPIGetWorkloadEventParams) (*WorkloadOptimizationAPIGetWorkloadEventResponse, error)
 
 	// WorkloadOptimizationAPIListWorkloads request
-	WorkloadOptimizationAPIListWorkloadsWithResponse(ctx context.Context, clusterId string) (*WorkloadOptimizationAPIListWorkloadsResponse, error)
+	WorkloadOptimizationAPIListWorkloadsWithResponse(ctx context.Context, clusterId string, params *WorkloadOptimizationAPIListWorkloadsParams) (*WorkloadOptimizationAPIListWorkloadsResponse, error)
 
 	// WorkloadOptimizationAPIGetWorkloadsSummary request
 	WorkloadOptimizationAPIGetWorkloadsSummaryWithResponse(ctx context.Context, clusterId string, params *WorkloadOptimizationAPIGetWorkloadsSummaryParams) (*WorkloadOptimizationAPIGetWorkloadsSummaryResponse, error)
@@ -25513,8 +25727,8 @@ func (c *ClientWithResponses) WorkloadOptimizationAPIGetWorkloadEventWithRespons
 }
 
 // WorkloadOptimizationAPIListWorkloadsWithResponse request returning *WorkloadOptimizationAPIListWorkloadsResponse
-func (c *ClientWithResponses) WorkloadOptimizationAPIListWorkloadsWithResponse(ctx context.Context, clusterId string) (*WorkloadOptimizationAPIListWorkloadsResponse, error) {
-	rsp, err := c.WorkloadOptimizationAPIListWorkloads(ctx, clusterId)
+func (c *ClientWithResponses) WorkloadOptimizationAPIListWorkloadsWithResponse(ctx context.Context, clusterId string, params *WorkloadOptimizationAPIListWorkloadsParams) (*WorkloadOptimizationAPIListWorkloadsResponse, error) {
+	rsp, err := c.WorkloadOptimizationAPIListWorkloads(ctx, clusterId, params)
 	if err != nil {
 		return nil, err
 	}

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -5456,9 +5456,9 @@ func (mr *MockClientInterfaceMockRecorder) WorkloadOptimizationAPIListWorkloadSc
 }
 
 // WorkloadOptimizationAPIListWorkloads mocks base method.
-func (m *MockClientInterface) WorkloadOptimizationAPIListWorkloads(ctx context.Context, clusterId string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+func (m *MockClientInterface) WorkloadOptimizationAPIListWorkloads(ctx context.Context, clusterId string, params *sdk.WorkloadOptimizationAPIListWorkloadsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterId}
+	varargs := []interface{}{ctx, clusterId, params}
 	for _, a := range reqEditors {
 		varargs = append(varargs, a)
 	}
@@ -5469,9 +5469,9 @@ func (m *MockClientInterface) WorkloadOptimizationAPIListWorkloads(ctx context.C
 }
 
 // WorkloadOptimizationAPIListWorkloads indicates an expected call of WorkloadOptimizationAPIListWorkloads.
-func (mr *MockClientInterfaceMockRecorder) WorkloadOptimizationAPIListWorkloads(ctx, clusterId interface{}, reqEditors ...interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) WorkloadOptimizationAPIListWorkloads(ctx, clusterId, params interface{}, reqEditors ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterId}, reqEditors...)
+	varargs := append([]interface{}{ctx, clusterId, params}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIListWorkloads", reflect.TypeOf((*MockClientInterface)(nil).WorkloadOptimizationAPIListWorkloads), varargs...)
 }
 
@@ -15074,9 +15074,9 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIL
 }
 
 // WorkloadOptimizationAPIListWorkloads mocks base method.
-func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIListWorkloads(ctx context.Context, clusterId string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIListWorkloads(ctx context.Context, clusterId string, params *sdk.WorkloadOptimizationAPIListWorkloadsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterId}
+	varargs := []interface{}{ctx, clusterId, params}
 	for _, a := range reqEditors {
 		varargs = append(varargs, a)
 	}
@@ -15087,25 +15087,25 @@ func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIListWorkloads(
 }
 
 // WorkloadOptimizationAPIListWorkloads indicates an expected call of WorkloadOptimizationAPIListWorkloads.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIListWorkloads(ctx, clusterId interface{}, reqEditors ...interface{}) *gomock.Call {
+func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIListWorkloads(ctx, clusterId, params interface{}, reqEditors ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterId}, reqEditors...)
+	varargs := append([]interface{}{ctx, clusterId, params}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIListWorkloads", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIListWorkloads), varargs...)
 }
 
 // WorkloadOptimizationAPIListWorkloadsWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIListWorkloadsWithResponse(ctx context.Context, clusterId string) (*sdk.WorkloadOptimizationAPIListWorkloadsResponse, error) {
+func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIListWorkloadsWithResponse(ctx context.Context, clusterId string, params *sdk.WorkloadOptimizationAPIListWorkloadsParams) (*sdk.WorkloadOptimizationAPIListWorkloadsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIListWorkloadsWithResponse", ctx, clusterId)
+	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIListWorkloadsWithResponse", ctx, clusterId, params)
 	ret0, _ := ret[0].(*sdk.WorkloadOptimizationAPIListWorkloadsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WorkloadOptimizationAPIListWorkloadsWithResponse indicates an expected call of WorkloadOptimizationAPIListWorkloadsWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIListWorkloadsWithResponse(ctx, clusterId interface{}) *gomock.Call {
+func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIListWorkloadsWithResponse(ctx, clusterId, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIListWorkloadsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIListWorkloadsWithResponse), ctx, clusterId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIListWorkloadsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIListWorkloadsWithResponse), ctx, clusterId, params)
 }
 
 // WorkloadOptimizationAPIPatchWorkloadV2 mocks base method.


### PR DESCRIPTION
Running `make generate-sdk` on the repository because it causes PRs to fail ([example](https://github.com/castai/terraform-provider-castai/pull/568)).