### PR TITLE
feat(examples): add GKE example with Private Service Connect

### DIFF
--- a/examples/gke/gke_private_service_connect/README.MD
+++ b/examples/gke/gke_private_service_connect/README.MD
@@ -1,0 +1,33 @@
+# GKE and CAST AI example with connecting via GCP Private Service Connect
+
+Following example shows how to onboard GKE cluster to CAST AI, configure [Autoscaler policies](https://docs.cast.ai/reference/policiesapi_upsertclusterpolicies) and additional [Node Configurations](https://docs.cast.ai/docs/node-configuration/).
+
+IAM policies required to connect the cluster to CAST AI in the example are created by [castai/gke-role-iam/castai module](https://github.com/castai/terraform-castai-gke-iam).
+
+Example configuration should be analysed in the following order:
+1. Create VPC - `vpc.tf`
+2. Private Service Connect - `private-service-connect.tf`
+3. Create GKE cluster - `gke.tf`
+4. Create IAM and other CAST AI related resources to connect GKE cluster to CAST AI, configure Autoscaler and Node Configurations  - `castai.tf`
+
+## What is unique about this example
+
+This example connects the GKE cluster to Cast AI through GCP Private Service Connect.
+
+## Usage
+1. Rename `tf.vars.example` to `tf.vars`
+2. Update `tf.vars` file necessary variables.
+3. Initialize Terraform. Under example root folder run:
+```
+terraform init
+```
+4. Run Terraform apply:
+```
+terraform apply -var-file=tf.vars
+```
+5. To destroy resources created by this example:
+```
+terraform destroy -var-file=tf.vars
+```
+
+Please refer to this guide if you run into any issues https://docs.cast.ai/docs/terraform-troubleshooting

--- a/examples/gke/gke_private_service_connect/castai.tf
+++ b/examples/gke/gke_private_service_connect/castai.tf
@@ -1,0 +1,184 @@
+# 5. Connect GKE cluster to CAST AI
+
+# Configure Data sources and providers required for CAST AI connection.
+
+data "google_client_config" "default" {}
+
+provider "castai" {
+  api_url   = var.castai_public_api_url
+  api_token = var.castai_api_token
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = "https://${module.gke.endpoint}"
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(module.gke.ca_certificate)
+  }
+}
+
+# Configure GKE cluster connection using CAST AI gke-cluster module.
+module "castai-gke-iam" {
+  source  = "castai/gke-iam/castai"
+  version = "~> 0.5"
+
+  project_id       = var.project_id
+  gke_cluster_name = var.cluster_name
+}
+
+module "castai-gke-cluster" {
+  source  = "castai/gke-cluster/castai"
+  version = "~> 9.1"
+
+  api_url                = var.castai_public_api_url
+  castware_api_url       = "https://api.psc.${var.castai_api_private_domain}"
+  castai_api_token       = var.castai_api_token
+  grpc_url               = "grpc.psc.${var.castai_api_private_domain}:443"
+  wait_for_cluster_ready = true
+
+  project_id           = var.project_id
+  gke_cluster_name     = var.cluster_name
+  gke_cluster_location = module.gke.location
+
+  gke_credentials            = module.castai-gke-iam.private_key
+  delete_nodes_on_disconnect = var.delete_nodes_on_disconnect
+
+  default_node_configuration_name = "default"
+
+  node_configurations = {
+    default = {
+      disk_cpu_ratio = 25
+      subnets        = [module.vpc.subnets_ids[0]]
+      tags           = var.tags
+    }
+
+    test_node_config = {
+      disk_cpu_ratio    = 10
+      subnets           = [module.vpc.subnets_ids[0]]
+      tags              = var.tags
+      max_pods_per_node = 40
+      disk_type         = "pd-ssd",
+      network_tags      = ["dev"]
+    }
+
+  }
+
+  node_templates = {
+    default_by_castai = {
+      name               = "default-by-castai"
+      configuration_name = "default"
+      is_default         = true
+      is_enabled         = true
+      should_taint       = false
+
+      constraints = {
+        on_demand          = true
+        spot               = true
+        use_spot_fallbacks = true
+
+        enable_spot_diversity                       = false
+        spot_diversity_price_increase_limit_percent = 20
+      }
+    }
+
+    spot_tmpl = {
+      configuration_id = module.castai-gke-cluster.castai_node_configurations["default"]
+      is_enabled       = true
+      should_taint     = true
+
+      custom_labels = {
+        custom-label-key-1 = "custom-label-value-1"
+        custom-label-key-2 = "custom-label-value-2"
+      }
+
+      custom_taints = [
+        {
+          key    = "custom-taint-key-1"
+          value  = "custom-taint-value-1"
+          effect = "NoSchedule"
+        },
+        {
+          key    = "custom-taint-key-2"
+          value  = "custom-taint-value-2"
+          effect = "NoSchedule"
+        }
+      ]
+
+      constraints = {
+        fallback_restore_rate_seconds = 1800
+        spot                          = true
+        use_spot_fallbacks            = true
+        min_cpu                       = 4
+        max_cpu                       = 100
+        instance_families = {
+          exclude = ["e2"]
+        }
+        compute_optimized_state = "disabled"
+        storage_optimized_state = "disabled"
+        # Optional: define custom priority for instances selection.
+        #
+        # 1. Prioritize C2D and C2 spot instances above all else, regardless of price.
+        # 2. If C2D and C2 is not available, try C3D family.
+        custom_priority = [
+          {
+            instance_families = ["c2d", "c2"]
+            spot              = true
+          },
+          {
+            instance_families = ["c3d"]
+            spot              = true
+          }
+          # 3. instances not matching any of custom priority groups will be tried after
+          # nothing matches from priority groups.
+        ]
+      }
+      custom_instances_enabled = true
+    }
+  }
+
+  autoscaler_settings = {
+    enabled                                 = true
+    node_templates_partial_matching_enabled = false
+
+    unschedulable_pods = {
+      enabled = true
+    }
+
+    node_downscaler = {
+      enabled = true
+
+      empty_nodes = {
+        enabled = true
+      }
+
+      evictor = {
+        aggressive_mode           = false
+        cycle_interval            = "5m10s"
+        dry_run                   = false
+        enabled                   = true
+        node_grace_period_minutes = 10
+        scoped_mode               = false
+      }
+    }
+
+    cluster_limits = {
+      enabled = true
+
+      cpu = {
+        max_cores = 20
+        min_cores = 1
+      }
+    }
+  }
+
+  depends_on = [
+    // depends_on helps terraform with creating proper dependencies graph in case of resource creation and in this case destroy
+    // module "castai-gke-cluster" has to be destroyed before module "castai-gke-iam" and "module.gke"
+    module.gke,
+    module.castai-gke-iam,
+    // DNS record must be created before onboarding to Cast AI
+    google_dns_record_set.a,
+    // Private Service Connect Endpoint must be created before onboarding to Cast AI
+    google_compute_forwarding_rule.cast_ai_private_api
+  ]
+}

--- a/examples/gke/gke_private_service_connect/gke.tf
+++ b/examples/gke/gke_private_service_connect/gke.tf
@@ -1,0 +1,37 @@
+# 4. Create GKE cluster.
+
+module "gke" {
+  source                     = "terraform-google-modules/kubernetes-engine/google"
+  version                    = "33.1.0"
+  project_id                 = var.project_id
+  name                       = var.cluster_name
+  region                     = var.cluster_region
+  zones                      = var.cluster_zones
+  network                    = module.vpc.network_name
+  subnetwork                 = module.vpc.subnets_names[0]
+  ip_range_pods              = local.ip_range_pods
+  ip_range_services          = local.ip_range_services
+  http_load_balancing        = false
+  network_policy             = false
+  horizontal_pod_autoscaling = true
+  filestore_csi_driver       = false
+
+  node_pools = [
+    {
+      name               = "default-node-pool"
+      machine_type       = "e2-standard-2"
+      min_count          = 0
+      max_count          = 10
+      local_ssd_count    = 0
+      disk_size_gb       = 100
+      disk_type          = "pd-standard"
+      image_type         = "COS_CONTAINERD"
+      auto_repair        = true
+      auto_upgrade       = true
+      preemptible        = false
+      initial_node_count = 2 # has to be >=2 to successfully deploy CAST AI controller
+    },
+  ]
+
+  deletion_protection = false
+}

--- a/examples/gke/gke_private_service_connect/private-service-connect.tf
+++ b/examples/gke/gke_private_service_connect/private-service-connect.tf
@@ -1,0 +1,49 @@
+# 2. PSC Endpoint setup
+
+resource "google_compute_address" "cast_ai_private_api" {
+  project      = var.project_id
+  name         = "cast-ai-private-api"
+  region       = module.vpc.subnets_regions[1]
+  address_type = "INTERNAL"
+  subnetwork   = module.vpc.subnets_self_links[1]
+  address      = cidrhost(module.vpc.subnets_ips[1], 2)
+}
+
+resource "google_compute_forwarding_rule" "cast_ai_private_api" {
+  project                 = var.project_id
+  name                    = "cast-ai-private-api"
+  target                  = var.cast_api_service_attachment_uri
+  network                 = module.vpc.network_id
+  region                  = module.vpc.subnets_regions[1]
+  ip_address              = google_compute_address.cast_ai_private_api.id
+  load_balancing_scheme   = ""
+  allow_psc_global_access = var.allow_psc_global_access
+}
+
+
+# 3. DNS setup
+
+resource "google_dns_managed_zone" "psc_zone" {
+  name        = "cast-ai-psc-zone"
+  project     = var.project_id
+  dns_name    = "${var.castai_api_private_domain}."
+  description = "Cast AI Private Service Connect zone"
+
+  visibility = "private"
+
+  private_visibility_config {
+    networks {
+      network_url = module.vpc.network_id
+    }
+  }
+}
+
+resource "google_dns_record_set" "a" {
+  name         = "*.psc.${google_dns_managed_zone.psc_zone.dns_name}"
+  project      = var.project_id
+  managed_zone = google_dns_managed_zone.psc_zone.name
+  type         = "A"
+  ttl          = 300
+
+  rrdatas = [google_compute_address.cast_ai_private_api.address]
+}

--- a/examples/gke/gke_private_service_connect/tf.vars.example
+++ b/examples/gke/gke_private_service_connect/tf.vars.example
@@ -1,0 +1,8 @@
+project_id       = "<place-holder>"
+cluster_name     = "<place-holder>"
+cluster_region   = "<place-holder>"
+cluster_zones    = ["<place-holder>", "<place-holder>"]
+castai_public_api_url   = "https://api.prod-master.cast.ai"
+castai_api_private_domain = "prod-master.cast.ai"
+castai_api_token = "<place-holder>"
+cast_api_service_attachment_uri = "<place-holder>"

--- a/examples/gke/gke_private_service_connect/variables.tf
+++ b/examples/gke/gke_private_service_connect/variables.tf
@@ -1,0 +1,62 @@
+# GKE module variables.
+variable "cluster_name" {
+  type        = string
+  description = "GKE cluster name in GCP project."
+}
+
+variable "cluster_region" {
+  type        = string
+  description = "The region to create the cluster."
+}
+
+variable "cluster_zones" {
+  type        = list(string)
+  description = "The zones to create the cluster."
+  default     = []
+}
+
+variable "project_id" {
+  type        = string
+  description = "GCP project ID in which GKE cluster would be created."
+}
+
+variable "castai_public_api_url" {
+  type        = string
+  description = "URL of public CAST AI API"
+  default     = "https://api.cast.ai"
+}
+
+variable "castai_api_token" {
+  type        = string
+  description = "CAST AI API token created in console.cast.ai API Access keys section."
+}
+
+variable "castai_api_private_domain" {
+  type        = string
+  description = "Private domain used to access Cast AI via Private Service Connect"
+  default     = "prod-master.cast.ai"
+}
+
+variable "cast_api_service_attachment_uri" {
+  type        = string
+  description = "Service Attachment URI to connect to."
+  default     = "projects/prod-master-scl0/regions/us-east4/serviceAttachments/castware-psc"
+}
+
+variable "allow_psc_global_access" {
+  type        = bool
+  description = "Allow global access to the Private Service Connect Endpoint. If set to false, the cluster must be in the same region as the Service Attachment."
+  default     = true
+}
+
+variable "delete_nodes_on_disconnect" {
+  type        = bool
+  description = "Optional parameter, if set to true - CAST AI provisioned nodes will be deleted from cloud on cluster disconnection. For production use it is recommended to set it to false."
+  default     = true
+}
+
+variable "tags" {
+  type        = map(any)
+  description = "Optional tags for new cluster nodes. This parameter applies only to new nodes - tags for old nodes are not reconciled."
+  default     = {}
+}

--- a/examples/gke/gke_private_service_connect/version.tf
+++ b/examples/gke/gke_private_service_connect/version.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    castai = {
+      source = "castai/castai"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    google = {
+      source = "hashicorp/google"
+    }
+    google-beta = {
+      source = "hashicorp/google-beta"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+  }
+  required_version = ">= 1.3.2"
+}

--- a/examples/gke/gke_private_service_connect/vpc.tf
+++ b/examples/gke/gke_private_service_connect/vpc.tf
@@ -1,0 +1,45 @@
+# 1. Create VPC.
+
+locals {
+  ip_range_pods     = "${var.cluster_name}-ip-range-pods"
+  ip_range_services = "${var.cluster_name}-ip-range-services"
+  ip_range_nodes    = "${var.cluster_name}-ip-range-nodes"
+
+  # Parse region from Service Attachment identifier
+  psc_region = split("/", var.cast_api_service_attachment_uri)[3]
+}
+
+module "vpc" {
+  source       = "terraform-google-modules/network/google"
+  version      = "9.3.0"
+  project_id   = var.project_id
+  network_name = var.cluster_name
+  subnets = [
+    {
+      subnet_name           = local.ip_range_nodes
+      subnet_ip             = "10.0.0.0/16"
+      subnet_region         = var.cluster_region
+      subnet_private_access = "true"
+    },
+    // Subnet for the IP address of the Private Service Connect endpoint
+    {
+      subnet_name           = "private-service-connect-endpoint"
+      subnet_ip             = "10.1.0.0/24"
+      subnet_region         = local.psc_region
+      subnet_private_access = "true"
+    },
+  ]
+
+  secondary_ranges = {
+    (local.ip_range_nodes) = [
+      {
+        range_name    = local.ip_range_pods
+        ip_cidr_range = "10.20.0.0/16"
+      },
+      {
+        range_name    = local.ip_range_services
+        ip_cidr_range = "10.30.0.0/24"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adding a new example that showcases a complete setup of a GKE cluster connecting to Cast AI via Private Service Connect. Going to reference this from public documentation soon.

## Proof of Work

I was able to `tofu apply` this example without issues:
<img width="1419" height="378" alt="2025-09-25_17-58" src="https://github.com/user-attachments/assets/f052cbb7-2f2f-4f2a-8938-55e9f6cd62f0" />


It can also be `tofu destroy`'ed:
<img width="2503" height="570" alt="2025-09-25_18-24" src="https://github.com/user-attachments/assets/3717b23b-46d0-4276-bdb9-7d2fedbf9ccb" />


The cluster was successfully created and onboarded to Cast AI:
<img width="1541" height="474" alt="image" src="https://github.com/user-attachments/assets/928a4af6-6911-4e7d-a6bb-66eec27b2fed" />
