### PR TITLE
feat(eks-example): expose agent_values and cluster_controller_values for Helm customization

### DIFF
--- a/examples/eks/eks_cluster_existing/README.MD
+++ b/examples/eks/eks_cluster_existing/README.MD
@@ -9,17 +9,18 @@ Example configuration should be analysed in the following order:
 
 # Usage
 1. Copy `terraform.tfvars.example` to `terraform.tfvars`
-2. Update `terraform.tfvars` file with your cluster name, cluster region, vpc_id, cluster_security_group_id, node_security_group_id, subnets and CAST AI API token.
+2. Update `terraform.tfvars` file with your cluster name, cluster region, and CAST AI API token.
 
 | Variable | Description |
 | --- | --- |
-| cluster_name                = "" | Name of cluster |
-| cluster_region              = "" | Name of region of cluster |
-| castai_api_token            = "" | Cast api token |
-| vpc_id                      = "" | Virtual Private Cloud(VPC) id |
-| cluster_security_group_id   = "" | Cluster security group id |
-| node_security_group_id      = "" | Node security group id |
-| subnets                     = ["", ""] | Public subnets of cluster |
+| `cluster_name` | Name of the EKS cluster |
+| `cluster_region` | AWS region where the cluster runs |
+| `castai_api_token` | CAST AI API token from console.cast.ai → API Access keys |
+| `profile` | AWS CLI profile to use (default: `"default"`) |
+| `delete_nodes_on_disconnect` | Delete CAST AI-provisioned nodes on disconnect (default: `true`; set to `false` for production) |
+| `tags` | Optional map of tags applied to new nodes |
+| `agent_values` | Optional list of YAML Helm values for castai-agent. Example: `[<<-EOF\n  additionalEnv:\n    MY_VAR: "value"\nEOF\n]` — see [Customizing Helm values](#customizing-helm-values-additionalenv-and-more) |
+| `cluster_controller_values` | Optional list of YAML Helm values for castai-cluster-controller, same format as `agent_values` |
 
 3. Initialize Terraform. Under example root folder run:
 ```
@@ -43,5 +44,23 @@ AWS CLI profile is already set to default, override if only required.
 2. If your eks cluster authentication mode is CONFIGMAP - you need to also update [aws-auth](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html) configmap. In the configmap instance profile
 > used by CAST AI has to be present. Example of entry can be found [here](https://github.com/castai/terraform-provider-castai/blob/157babd57b0977f499eb162e9bee27bee51d292a/examples/eks/eks_cluster_autoscaler_polices/eks.tf#L28-L38).
 
+
+# Customizing Helm values (additionalEnv and more)
+
+The `agent_values` and `cluster_controller_values` variables accept lists of YAML-formatted Helm values that are merged into the respective CAST AI Helm chart releases. This is the recommended way to configure environment variables, proxy settings, resource limits, or any other chart-level option.
+
+Example `terraform.tfvars` entry to set environment variables on the agent:
+
+```hcl
+agent_values = [<<-EOF
+  additionalEnv:
+    HTTP_PROXY: "http://proxy.example.com:8080"
+    HTTPS_PROXY: "http://proxy.example.com:8080"
+    NO_PROXY: "169.254.169.254,localhost"
+EOF
+]
+```
+
+Use `cluster_controller_values` for the same pattern applied to the cluster-controller component.
 
 Please refer to this guide if you run into any issues https://docs.cast.ai/docs/terraform-troubleshooting

--- a/examples/eks/eks_cluster_existing/castai.tf
+++ b/examples/eks/eks_cluster_existing/castai.tf
@@ -190,6 +190,22 @@ module "castai_eks_cluster" {
   # Installs network monitor
   install_egressd = true
 
+  # Optional: pass additional Helm values to castai-agent and cluster-controller.
+  # This is useful for setting environment variables (additionalEnv), resource limits,
+  # pod annotations, proxy settings, etc.
+  #
+  # Example terraform.tfvars entry:
+  #
+  #   agent_values = [<<-EOF
+  #     additionalEnv:
+  #       MY_ENV_VAR: "my-value"
+  #       HTTP_PROXY: "http://proxy.example.com:8080"
+  #   EOF
+  #   ]
+  #
+  agent_values              = var.agent_values
+  cluster_controller_values = var.cluster_controller_values
+
   # depends_on helps Terraform with creating proper dependencies graph in case of resource creation and in this case destroy.
   # module "castai-eks-cluster" has to be destroyed before module "castai-eks-role-iam".
   depends_on = [module.castai_eks_role_iam]

--- a/examples/eks/eks_cluster_existing/terraform.tfvars.example
+++ b/examples/eks/eks_cluster_existing/terraform.tfvars.example
@@ -1,7 +1,4 @@
-cluster_name                = ""
-cluster_region              = ""
-castai_api_token            = ""
-grpc_url                    = ""
-vpc_id                      = ""
-subnets                     = ["", ""]
-profile                     = "default" # default aws cli profile is used, override if needed.
+cluster_name     = ""
+cluster_region   = ""
+castai_api_token = ""
+profile          = "default" # default aws cli profile is used, override if needed.

--- a/examples/eks/eks_cluster_existing/variables.tf
+++ b/examples/eks/eks_cluster_existing/variables.tf
@@ -44,3 +44,15 @@ variable "tags" {
   description = "Optional tags for new cluster nodes. This parameter applies only to new nodes - tags for old nodes are not reconciled."
   default     = {}
 }
+
+variable "agent_values" {
+  type        = list(string)
+  description = "List of YAML-formatted Helm values for the castai-agent chart. Use this to set additionalEnv, resource limits, pod annotations, etc."
+  default     = []
+}
+
+variable "cluster_controller_values" {
+  type        = list(string)
+  description = "List of YAML-formatted Helm values for the castai-cluster-controller chart. Use this to set additionalEnv, resource limits, pod annotations, etc."
+  default     = []
+}


### PR DESCRIPTION
## Summary

- Adds `agent_values` and `cluster_controller_values` variables to the `eks_cluster_existing` example, wired into the `castai/eks-cluster/castai` module call
- Enables users to pass arbitrary Helm values (e.g. `additionalEnv` environment variables) to the `castai-agent` and `cluster-controller` charts without modifying `castai.tf` directly
- Fixes stale variable references in `README.MD` (removed dead vars: `vpc_id`, `cluster_security_group_id`, `node_security_group_id`, `subnets`) and cleans up `terraform.tfvars.example`
- Adds a "Customizing Helm values" section to the README with a concrete `additionalEnv` example

## Test plan

- [ ] `terraform init` succeeds in `examples/eks/eks_cluster_existing/`
- [ ] `terraform validate` passes cleanly
- [ ] `terraform apply` with `agent_values` set confirms env vars appear on the `castai-agent` pod (`kubectl describe pod -n castai-agent`)
- [ ] `terraform apply` with empty `agent_values` (default) behaves identically to before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)