### PR TITLE
fix: align Go version to 1.24.0 across all CI workflows and fix Makefile

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.23.6
+          go-version: 1.24.0
       - uses: actions/checkout@v4  # Updated to use Node.js 20
       - name: Check SDK
         run: | 
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.23.6
+          go-version: 1.24.0
       - uses: actions/checkout@v4  # Updated to use Node.js 20
       - name: Check Documentation
         run: | 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.23.6
+          go-version: 1.24.0
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ build:
 .PHONY: lint
 lint:
 	@echo "==> Running lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-	golangci-lint run
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@$(HOME)/go/bin/golangci-lint run
 
 .PHONY: test
 test: build


### PR DESCRIPTION
# Description
This PR fixes inconsistencies in the CI/CD configuration and resolves the Makefile lint target execution issue.
## Problem
1. **Go Version Mismatch**: The CI workflows were using Go 1.23.6 while `go.mod` specifies Go 1.24.0, causing potential compatibility issues during builds and tests.
2. **Lint Target Failure**: The `make lint` command fails with "golangci-lint: No such file or directory" because the installed binary is not in the PATH.
## Solution
- Updated Go version to `1.24.0` in all CI workflow files to align with `go.mod`
- Fixed the Makefile lint target to use the explicit path `$(HOME)/go/bin/golangci-lint`
## Files Changed
| File | Change |
|------|--------|
| `.github/workflows/golangci-lint.yml` | Go version: 1.23.6 → 1.24.0 |
| `.github/workflows/doc.yaml` | Go version: 1.23.6 → 1.24.0 (2 occurrences) |
| `Makefile` | Added explicit path for golangci-lint binary |
## Verification
- ✅ Unit tests pass
- ✅ Lint passes
- ✅ Terraform format check passes