### PR TITLE
chore: rebuild with `--clean` after validating signing is not buggy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
-          args: release --config=.github/.goreleaser.yml
+          args: release --clean --config=.github/.goreleaser.yml
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
goreleaser had signing bug. Current configuration build with skip=publish and validates if signature is correct. Then it build again with publish - excessive but safe.