### PR TITLE
chore: bump default EKS version in examples to 1.34

### DIFF
--- a/examples/eks/eks_cluster_access_entries/variables.tf
+++ b/examples/eks/eks_cluster_access_entries/variables.tf
@@ -6,8 +6,8 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   type        = string
-  description = "EKS cluster name version."
-  default     = "1.33"
+  description = "EKS cluster version."
+  default     = "1.34"
 }
 
 variable "cluster_region" {

--- a/examples/eks/eks_cluster_assumerole/variables.tf
+++ b/examples/eks/eks_cluster_assumerole/variables.tf
@@ -6,8 +6,8 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   type        = string
-  description = "EKS cluster name version."
-  default     = "1.33"
+  description = "EKS cluster version."
+  default     = "1.34"
 }
 
 variable "cluster_region" {

--- a/examples/eks/eks_cluster_autoscaler_policies/variables.tf
+++ b/examples/eks/eks_cluster_autoscaler_policies/variables.tf
@@ -12,7 +12,7 @@ variable "cluster_region" {
 variable "cluster_version" {
   type        = string
   description = "EKS cluster version."
-  default     = "1.33"
+  default     = "1.34"
 }
 
 variable "castai_api_url" {

--- a/examples/eks/eks_cluster_custom_iam/variables.tf
+++ b/examples/eks/eks_cluster_custom_iam/variables.tf
@@ -12,7 +12,7 @@ variable "cluster_region" {
 variable "cluster_version" {
   type        = string
   description = "EKS cluster version."
-  default     = "1.33"
+  default     = "1.34"
 }
 
 variable "castai_api_url" {

--- a/examples/eks/eks_cluster_ipv6/variables.tf
+++ b/examples/eks/eks_cluster_ipv6/variables.tf
@@ -6,8 +6,8 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   type        = string
-  description = "EKS cluster name version."
-  default     = "1.33"
+  description = "EKS cluster version."
+  default     = "1.34"
 }
 
 variable "cluster_region" {

--- a/examples/eks/eks_cluster_live_migration/variables.tf
+++ b/examples/eks/eks_cluster_live_migration/variables.tf
@@ -12,7 +12,7 @@ variable "cluster_region" {
 variable "cluster_version" {
   type        = string
   description = "EKS cluster version."
-  default     = "1.33"
+  default     = "1.34"
 }
 
 variable "castai_api_url" {

--- a/examples/eks/eks_cluster_optional_readonly/variables.tf
+++ b/examples/eks/eks_cluster_optional_readonly/variables.tf
@@ -12,7 +12,7 @@ variable "cluster_region" {
 variable "cluster_version" {
   type        = string
   description = "EKS cluster version."
-  default     = "1.33"
+  default     = "1.34"
 }
 
 # Variables required for connecting EKS cluster to CAST AI

--- a/examples/eks/eks_cluster_readonly/variables.tf
+++ b/examples/eks/eks_cluster_readonly/variables.tf
@@ -12,7 +12,7 @@ variable "cluster_region" {
 variable "cluster_version" {
   type        = string
   description = "EKS cluster version."
-  default     = "1.33"
+  default     = "1.34"
 }
 
 # Variables required for connecting EKS cluster to CAST AI

--- a/examples/eks/eks_cluster_with_security/variables.tf
+++ b/examples/eks/eks_cluster_with_security/variables.tf
@@ -12,7 +12,7 @@ variable "cluster_region" {
 variable "cluster_version" {
   type        = string
   description = "EKS cluster version."
-  default     = "1.33"
+  default     = "1.34"
 }
 
 variable "castai_api_token" {

--- a/examples/eks/eks_cluster_with_security_runtime_rules/variables.tf
+++ b/examples/eks/eks_cluster_with_security_runtime_rules/variables.tf
@@ -12,7 +12,7 @@ variable "cluster_region" {
 variable "cluster_version" {
   type        = string
   description = "EKS cluster version."
-  default     = "1.33"
+  default     = "1.34"
 }
 
 variable "castai_api_token" {

--- a/examples/eks/eks_clusters/variables.tf
+++ b/examples/eks/eks_clusters/variables.tf
@@ -12,7 +12,7 @@ variable "cluster_region" {
 variable "cluster_version" {
   type        = string
   description = "EKS cluster version."
-  default     = "1.33"
+  default     = "1.34"
 }
 
 variable "castai_api_url" {

--- a/examples/eks/eks_private_link/variables.tf
+++ b/examples/eks/eks_private_link/variables.tf
@@ -12,7 +12,7 @@ variable "cluster_region" {
 variable "cluster_version" {
   type        = string
   description = "EKS cluster version."
-  default     = "1.33"
+  default     = "1.34"
 }
 
 variable "castai_api_token" {


### PR DESCRIPTION
Bumping EKS examples from 1.33 to 1.34. Note, I've looked into removing this default so we don't have to keep updating it every few months, but it's not trivial, see https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3658