### PR TITLE
fix: don't require replace for OMNI agent version and podcidr

### DIFF
--- a/castai/resource_omni_cluster.go
+++ b/castai/resource_omni_cluster.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/samber/lo"
 
 	"github.com/castai/terraform-provider-castai/castai/sdk/omni"
 )
@@ -75,16 +76,10 @@ func (r *omniClusterResource) Schema(_ context.Context, _ resource.SchemaRequest
 					"omni_agent_version": schema.StringAttribute{
 						Required:    true,
 						Description: "Version of the omni agent running on the cluster.",
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.RequiresReplace(),
-						},
 					},
 					"pod_cidr": schema.StringAttribute{
 						Required:    true,
 						Description: "Pod CIDR of the cluster.",
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.RequiresReplace(),
-						},
 					},
 				},
 			},
@@ -185,7 +180,39 @@ func (r *omniClusterResource) Read(ctx context.Context, req resource.ReadRequest
 }
 
 func (r *omniClusterResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// No update operation - all fields require replacement
+	var plan omniClusterModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := r.client.omniAPI
+	organizationID := plan.OrganizationID.ValueString()
+	clusterID := plan.ClusterID.ValueString()
+
+	body := omni.ReportStatusRequest{
+		Cluster: &omni.ReportStatusRequestCluster{},
+	}
+	if plan.Status != nil {
+		body.Cluster.AgentVersion = lo.ToPtr(plan.Status.OmniAgentVersion.ValueString())
+		body.Cluster.PodCidr = lo.ToPtr(plan.Status.PodCIDR.ValueString())
+	}
+
+	apiResp, err := client.ClustersAPIReportStatusWithResponse(ctx, organizationID, clusterID, body)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to report omni cluster status", err.Error())
+		return
+	}
+
+	if apiResp.StatusCode() != http.StatusOK {
+		resp.Diagnostics.AddError(
+			"Failed to report omni cluster status",
+			fmt.Sprintf("unexpected status code: %d, body: %s", apiResp.StatusCode(), string(apiResp.Body)),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
 func (r *omniClusterResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/castai/resource_omni_cluster.go
+++ b/castai/resource_omni_cluster.go
@@ -10,8 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/samber/lo"
-
 	"github.com/castai/terraform-provider-castai/castai/sdk/omni"
 )
 
@@ -190,23 +188,23 @@ func (r *omniClusterResource) Update(ctx context.Context, req resource.UpdateReq
 	organizationID := plan.OrganizationID.ValueString()
 	clusterID := plan.ClusterID.ValueString()
 
-	body := omni.ReportStatusRequest{
-		Cluster: &omni.ReportStatusRequestCluster{},
-	}
+	body := omni.RegisteredCluster{}
 	if plan.Status != nil {
-		body.Cluster.AgentVersion = lo.ToPtr(plan.Status.OmniAgentVersion.ValueString())
-		body.Cluster.PodCidr = lo.ToPtr(plan.Status.PodCIDR.ValueString())
+		body.Status = &omni.RegisteredClusterStatus{
+			OmniAgentVersion: plan.Status.OmniAgentVersion.ValueString(),
+			PodCidr:          plan.Status.PodCIDR.ValueString(),
+		}
 	}
 
-	apiResp, err := client.ClustersAPIReportStatusWithResponse(ctx, organizationID, clusterID, body)
+	apiResp, err := client.ClustersAPIRegisterClusterWithResponse(ctx, organizationID, clusterID, body)
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to report omni cluster status", err.Error())
+		resp.Diagnostics.AddError("Failed to update omni cluster", err.Error())
 		return
 	}
 
 	if apiResp.StatusCode() != http.StatusOK {
 		resp.Diagnostics.AddError(
-			"Failed to report omni cluster status",
+			"Failed to update omni cluster",
 			fmt.Sprintf("unexpected status code: %d, body: %s", apiResp.StatusCode(), string(apiResp.Body)),
 		)
 		return

--- a/castai/resource_omni_cluster.go
+++ b/castai/resource_omni_cluster.go
@@ -78,6 +78,9 @@ func (r *omniClusterResource) Schema(_ context.Context, _ resource.SchemaRequest
 					"pod_cidr": schema.StringAttribute{
 						Required:    true,
 						Description: "Pod CIDR of the cluster.",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(),
+						},
 					},
 				},
 			},


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Removes the force-replace behavior for `omni_agent_version` changes and implements the `Update` method for the `omni_cluster` resource.

### Why
Previously, changes to the `omni_agent_version` field triggered a resource replacement (destroy and recreate). This was overly aggressive since the Omni API allows in-place updates to this field. Additionally, the empty `Update` implementation meant that any update caused the resource to drift out of sync with the remote state.

### Key changes
- Removes the `RequiresReplace` plan modifier from the `omni_agent_version` attribute in `resource_omni_cluster.go`, allowing in-place updates
- Implements the `Update` method to update the cluster registration with Omni, calling the registration API

### Impact
This allows `omni_cluster` resources to be updated in place rather than replaced.