### PR TITLE
PRICE-1638: Don't track filter ordering as a change

### DIFF
--- a/castai/resource_pod_mutation.go
+++ b/castai/resource_pod_mutation.go
@@ -106,6 +106,23 @@ var matcherSchema = &schema.Resource{
 	},
 }
 
+var labelMatcherElemSchema = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		FieldPodMutationLabelMatcherKey: {
+			Type:     schema.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem:     matcherSchema,
+		},
+		FieldPodMutationLabelMatcherValue: {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem:     matcherSchema,
+		},
+	},
+}
+
 var labelsFilterSchema = &schema.Resource{
 	Schema: map[string]*schema.Schema{
 		FieldPodMutationLabelsFilterOperator: {
@@ -115,24 +132,10 @@ var labelsFilterSchema = &schema.Resource{
 			Description:      "Logical operator to combine label matchers: AND or OR.",
 		},
 		FieldPodMutationLabelsFilterMatchers: {
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Required: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					FieldPodMutationLabelMatcherKey: {
-						Type:     schema.TypeList,
-						Required: true,
-						MaxItems: 1,
-						Elem:     matcherSchema,
-					},
-					FieldPodMutationLabelMatcherValue: {
-						Type:     schema.TypeList,
-						Optional: true,
-						MaxItems: 1,
-						Elem:     matcherSchema,
-					},
-				},
-			},
+			Set:      schema.HashResource(labelMatcherElemSchema),
+			Elem:     labelMatcherElemSchema,
 		},
 	},
 }
@@ -362,34 +365,40 @@ func resourcePodMutation() *schema.Resource {
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{
 								FieldPodMutationFilterNames: {
-									Type:     schema.TypeList,
+									Type:     schema.TypeSet,
 									Optional: true,
 									Elem:     matcherSchema,
+									Set:      schema.HashResource(matcherSchema),
 								},
 								FieldPodMutationFilterNamespaces: {
-									Type:     schema.TypeList,
+									Type:     schema.TypeSet,
 									Optional: true,
 									Elem:     matcherSchema,
+									Set:      schema.HashResource(matcherSchema),
 								},
 								FieldPodMutationFilterKinds: {
-									Type:     schema.TypeList,
+									Type:     schema.TypeSet,
 									Optional: true,
 									Elem:     matcherSchema,
+									Set:      schema.HashResource(matcherSchema),
 								},
 								FieldPodMutationFilterExcludeNames: {
-									Type:     schema.TypeList,
+									Type:     schema.TypeSet,
 									Optional: true,
 									Elem:     matcherSchema,
+									Set:      schema.HashResource(matcherSchema),
 								},
 								FieldPodMutationFilterExcludeNamespaces: {
-									Type:     schema.TypeList,
+									Type:     schema.TypeSet,
 									Optional: true,
 									Elem:     matcherSchema,
+									Set:      schema.HashResource(matcherSchema),
 								},
 								FieldPodMutationFilterExcludeKinds: {
-									Type:     schema.TypeList,
+									Type:     schema.TypeSet,
 									Optional: true,
 									Elem:     matcherSchema,
+									Set:      schema.HashResource(matcherSchema),
 								},
 							},
 						},
@@ -504,7 +513,7 @@ func validatePodMutationFilter(filterV2 []interface{}) error {
 	if wl, ok := fm[FieldPodMutationFilterWorkload].([]interface{}); ok && len(wl) > 0 && wl[0] != nil {
 		wm := wl[0].(map[string]interface{})
 		for _, f := range workloadFields {
-			if v, ok := wm[f].([]interface{}); ok && len(v) > 0 {
+			if set, ok := wm[f].(*schema.Set); ok && set.Len() > 0 {
 				return nil
 			}
 		}
@@ -844,38 +853,38 @@ func stateToObjectFilterV2(m map[string]interface{}) *patching_engine.ObjectFilt
 		wlList := wl.([]interface{})
 		if len(wlList) > 0 && wlList[0] != nil {
 			wm := wlList[0].(map[string]interface{})
-			if v, ok := wm[FieldPodMutationFilterNames]; ok {
-				matchers := stateToMatchers(v.([]interface{}))
+			if v, ok := wm[FieldPodMutationFilterNames].(*schema.Set); ok {
+				matchers := stateToMatchers(v)
 				if len(matchers) > 0 {
 					filter.Names = &matchers
 				}
 			}
-			if v, ok := wm[FieldPodMutationFilterNamespaces]; ok {
-				matchers := stateToMatchers(v.([]interface{}))
+			if v, ok := wm[FieldPodMutationFilterNamespaces].(*schema.Set); ok {
+				matchers := stateToMatchers(v)
 				if len(matchers) > 0 {
 					filter.Namespaces = &matchers
 				}
 			}
-			if v, ok := wm[FieldPodMutationFilterKinds]; ok {
-				matchers := stateToMatchers(v.([]interface{}))
+			if v, ok := wm[FieldPodMutationFilterKinds].(*schema.Set); ok {
+				matchers := stateToMatchers(v)
 				if len(matchers) > 0 {
 					filter.Kinds = &matchers
 				}
 			}
-			if v, ok := wm[FieldPodMutationFilterExcludeNames]; ok {
-				matchers := stateToMatchers(v.([]interface{}))
+			if v, ok := wm[FieldPodMutationFilterExcludeNames].(*schema.Set); ok {
+				matchers := stateToMatchers(v)
 				if len(matchers) > 0 {
 					filter.ExcludeNames = &matchers
 				}
 			}
-			if v, ok := wm[FieldPodMutationFilterExcludeNamespaces]; ok {
-				matchers := stateToMatchers(v.([]interface{}))
+			if v, ok := wm[FieldPodMutationFilterExcludeNamespaces].(*schema.Set); ok {
+				matchers := stateToMatchers(v)
 				if len(matchers) > 0 {
 					filter.ExcludeNamespaces = &matchers
 				}
 			}
-			if v, ok := wm[FieldPodMutationFilterExcludeKinds]; ok {
-				matchers := stateToMatchers(v.([]interface{}))
+			if v, ok := wm[FieldPodMutationFilterExcludeKinds].(*schema.Set); ok {
+				matchers := stateToMatchers(v)
 				if len(matchers) > 0 {
 					filter.ExcludeKinds = &matchers
 				}
@@ -906,7 +915,11 @@ func stateToObjectFilterV2(m map[string]interface{}) *patching_engine.ObjectFilt
 	return filter
 }
 
-func stateToMatchers(items []interface{}) []patching_engine.ObjectFilterV2Matcher {
+func stateToMatchers(set *schema.Set) []patching_engine.ObjectFilterV2Matcher {
+	if set == nil {
+		return nil
+	}
+	items := set.List()
 	matchers := make([]patching_engine.ObjectFilterV2Matcher, 0, len(items))
 	for _, item := range items {
 		if item == nil {
@@ -929,8 +942,8 @@ func stateToLabelsFilter(m map[string]interface{}) *patching_engine.ObjectFilter
 		Operator: &op,
 	}
 
-	if v, ok := m[FieldPodMutationLabelsFilterMatchers]; ok {
-		matchersList := v.([]interface{})
+	if set, ok := m[FieldPodMutationLabelsFilterMatchers].(*schema.Set); ok && set != nil {
+		matchersList := set.List()
 		matchers := make([]patching_engine.ObjectFilterV2LabelMatcher, 0, len(matchersList))
 		for _, item := range matchersList {
 			if item == nil {

--- a/castai/resource_pod_mutation_test.go
+++ b/castai/resource_pod_mutation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	tfterraform "github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -150,12 +151,12 @@ func TestPodMutation_ReadContext(t *testing.T) {
 		r.Len(workloadList, 1)
 		wm := workloadList[0].(map[string]interface{})
 
-		namespaces := wm[FieldPodMutationFilterNamespaces].([]interface{})
+		namespaces := wm[FieldPodMutationFilterNamespaces].(*schema.Set).List()
 		r.Len(namespaces, 1)
 		r.Equal("EXACT", namespaces[0].(map[string]interface{})[FieldPodMutationMatcherType])
 		r.Equal("default", namespaces[0].(map[string]interface{})[FieldPodMutationMatcherValue])
 
-		kinds := wm[FieldPodMutationFilterKinds].([]interface{})
+		kinds := wm[FieldPodMutationFilterKinds].(*schema.Set).List()
 		r.Len(kinds, 1)
 		r.Equal("EXACT", kinds[0].(map[string]interface{})[FieldPodMutationMatcherType])
 		r.Equal("Deployment", kinds[0].(map[string]interface{})[FieldPodMutationMatcherValue])
@@ -834,8 +835,8 @@ func TestStateToDistributionGroups(t *testing.T) {
 
 		items := []interface{}{
 			map[string]interface{}{
-				FieldPodMutationDistributionGroupName:   "bare-group",
-				FieldPodMutationDistributionGroupPct:    100,
+				FieldPodMutationDistributionGroupName:          "bare-group",
+				FieldPodMutationDistributionGroupPct:           100,
 				FieldPodMutationDistributionGroupConfiguration: []interface{}{},
 			},
 		}
@@ -961,16 +962,16 @@ func TestStateToObjectFilterV2(t *testing.T) {
 		state := map[string]interface{}{
 			FieldPodMutationFilterWorkload: []interface{}{
 				map[string]interface{}{
-					FieldPodMutationFilterNamespaces: []interface{}{
+					FieldPodMutationFilterNamespaces: matcherSet(
 						map[string]interface{}{FieldPodMutationMatcherType: "EXACT", FieldPodMutationMatcherValue: "prod"},
-					},
-					FieldPodMutationFilterKinds: []interface{}{
+					),
+					FieldPodMutationFilterKinds: matcherSet(
 						map[string]interface{}{FieldPodMutationMatcherType: "REGEX", FieldPodMutationMatcherValue: "^Deploy.*"},
-					},
-					FieldPodMutationFilterNames:             []interface{}{},
-					FieldPodMutationFilterExcludeNames:      []interface{}{},
-					FieldPodMutationFilterExcludeNamespaces: []interface{}{},
-					FieldPodMutationFilterExcludeKinds:      []interface{}{},
+					),
+					FieldPodMutationFilterNames:             matcherSet(),
+					FieldPodMutationFilterExcludeNames:      matcherSet(),
+					FieldPodMutationFilterExcludeNamespaces: matcherSet(),
+					FieldPodMutationFilterExcludeKinds:      matcherSet(),
 				},
 			},
 			FieldPodMutationFilterPod: []interface{}{},
@@ -1000,7 +1001,7 @@ func TestStateToObjectFilterV2(t *testing.T) {
 					FieldPodMutationFilterLabelsFilter: []interface{}{
 						map[string]interface{}{
 							FieldPodMutationLabelsFilterOperator: "AND",
-							FieldPodMutationLabelsFilterMatchers: []interface{}{
+							FieldPodMutationLabelsFilterMatchers: labelMatcherSet(
 								map[string]interface{}{
 									FieldPodMutationLabelMatcherKey: []interface{}{
 										map[string]interface{}{FieldPodMutationMatcherType: "EXACT", FieldPodMutationMatcherValue: "app"},
@@ -1009,7 +1010,7 @@ func TestStateToObjectFilterV2(t *testing.T) {
 										map[string]interface{}{FieldPodMutationMatcherType: "EXACT", FieldPodMutationMatcherValue: "web"},
 									},
 								},
-							},
+							),
 						},
 					},
 					FieldPodMutationFilterExcludeLabels: []interface{}{},
@@ -1035,18 +1036,18 @@ func TestStateToObjectFilterV2(t *testing.T) {
 		state := map[string]interface{}{
 			FieldPodMutationFilterWorkload: []interface{}{
 				map[string]interface{}{
-					FieldPodMutationFilterNamespaces: []interface{}{},
-					FieldPodMutationFilterKinds:      []interface{}{},
-					FieldPodMutationFilterNames:      []interface{}{},
-					FieldPodMutationFilterExcludeNamespaces: []interface{}{
+					FieldPodMutationFilterNamespaces: matcherSet(),
+					FieldPodMutationFilterKinds:      matcherSet(),
+					FieldPodMutationFilterNames:      matcherSet(),
+					FieldPodMutationFilterExcludeNamespaces: matcherSet(
 						map[string]interface{}{FieldPodMutationMatcherType: "EXACT", FieldPodMutationMatcherValue: "kube-system"},
-					},
-					FieldPodMutationFilterExcludeKinds: []interface{}{
+					),
+					FieldPodMutationFilterExcludeKinds: matcherSet(
 						map[string]interface{}{FieldPodMutationMatcherType: "EXACT", FieldPodMutationMatcherValue: "DaemonSet"},
-					},
-					FieldPodMutationFilterExcludeNames: []interface{}{
+					),
+					FieldPodMutationFilterExcludeNames: matcherSet(
 						map[string]interface{}{FieldPodMutationMatcherType: "REGEX", FieldPodMutationMatcherValue: "^skip-.*"},
-					},
+					),
 				},
 			},
 			FieldPodMutationFilterPod: []interface{}{},
@@ -1083,7 +1084,7 @@ func TestStateToObjectFilterV2(t *testing.T) {
 					FieldPodMutationFilterExcludeLabels: []interface{}{
 						map[string]interface{}{
 							FieldPodMutationLabelsFilterOperator: "OR",
-							FieldPodMutationLabelsFilterMatchers: []interface{}{
+							FieldPodMutationLabelsFilterMatchers: labelMatcherSet(
 								map[string]interface{}{
 									FieldPodMutationLabelMatcherKey: []interface{}{
 										map[string]interface{}{FieldPodMutationMatcherType: "EXACT", FieldPodMutationMatcherValue: "env"},
@@ -1092,7 +1093,7 @@ func TestStateToObjectFilterV2(t *testing.T) {
 										map[string]interface{}{FieldPodMutationMatcherType: "EXACT", FieldPodMutationMatcherValue: "dev"},
 									},
 								},
-							},
+							),
 						},
 					},
 				},
@@ -1482,9 +1483,9 @@ func TestPodMutationCustomizeDiff(t *testing.T) {
 				map[string]interface{}{
 					FieldPodMutationFilterWorkload: []interface{}{
 						map[string]interface{}{
-							FieldPodMutationFilterNamespaces: []interface{}{
+							FieldPodMutationFilterNamespaces: matcherSet(
 								map[string]interface{}{FieldPodMutationMatcherType: "EXACT", FieldPodMutationMatcherValue: "default"},
-							},
+							),
 						},
 					},
 					FieldPodMutationFilterPod: []interface{}{},
@@ -1501,13 +1502,13 @@ func TestPodMutationCustomizeDiff(t *testing.T) {
 							FieldPodMutationFilterLabelsFilter: []interface{}{
 								map[string]interface{}{
 									FieldPodMutationLabelsFilterOperator: "AND",
-									FieldPodMutationLabelsFilterMatchers: []interface{}{
+									FieldPodMutationLabelsFilterMatchers: labelMatcherSet(
 										map[string]interface{}{
 											FieldPodMutationLabelMatcherKey: []interface{}{
 												map[string]interface{}{FieldPodMutationMatcherType: "EXACT", FieldPodMutationMatcherValue: "app"},
 											},
 										},
-									},
+									),
 								},
 							},
 							FieldPodMutationFilterExcludeLabels: []interface{}{},
@@ -1532,12 +1533,12 @@ func TestPodMutationCustomizeDiff(t *testing.T) {
 				map[string]interface{}{
 					FieldPodMutationFilterWorkload: []interface{}{
 						map[string]interface{}{
-							FieldPodMutationFilterNames:             []interface{}{},
-							FieldPodMutationFilterNamespaces:        []interface{}{},
-							FieldPodMutationFilterKinds:             []interface{}{},
-							FieldPodMutationFilterExcludeNames:      []interface{}{},
-							FieldPodMutationFilterExcludeNamespaces: []interface{}{},
-							FieldPodMutationFilterExcludeKinds:      []interface{}{},
+							FieldPodMutationFilterNames:             matcherSet(),
+							FieldPodMutationFilterNamespaces:        matcherSet(),
+							FieldPodMutationFilterKinds:             matcherSet(),
+							FieldPodMutationFilterExcludeNames:      matcherSet(),
+							FieldPodMutationFilterExcludeNamespaces: matcherSet(),
+							FieldPodMutationFilterExcludeKinds:      matcherSet(),
 						},
 					},
 					FieldPodMutationFilterPod: []interface{}{},
@@ -1566,6 +1567,103 @@ func TestPodMutationCustomizeDiff(t *testing.T) {
 	}
 }
 
+func TestStateToObjectFilterV2_UnorderedSet(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	state := map[string]interface{}{
+		FieldPodMutationFilterWorkload: []interface{}{
+			map[string]interface{}{
+				FieldPodMutationFilterNamespaces: matcherSet(
+					map[string]interface{}{FieldPodMutationMatcherType: "EXACT", FieldPodMutationMatcherValue: "a"},
+					map[string]interface{}{FieldPodMutationMatcherType: "EXACT", FieldPodMutationMatcherValue: "b"},
+					map[string]interface{}{FieldPodMutationMatcherType: "EXACT", FieldPodMutationMatcherValue: "c"},
+				),
+			},
+		},
+	}
+
+	got := stateToObjectFilterV2(state)
+	r.NotNil(got.Namespaces)
+	r.Len(*got.Namespaces, 3)
+
+	values := map[string]bool{}
+	for _, m := range *got.Namespaces {
+		r.NotNil(m.Value)
+		values[*m.Value] = true
+	}
+	r.Equal(map[string]bool{"a": true, "b": true, "c": true}, values)
+}
+
+func TestPodMutation_ReadContext_RoundTrip_UnorderedNamespaces(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	mockClient := mock_patching_engine.NewMockClientInterface(gomock.NewController(t))
+	ctx := context.Background()
+	provider := &ProviderConfig{
+		patchingEngineClient: &patching_engine.ClientWithResponses{
+			ClientInterface: mockClient,
+		},
+	}
+
+	// Server returns namespaces in a different order than the user's config.
+	mutation := patching_engine.PodMutation{
+		Id:             lo.ToPtr(testMutationID),
+		Name:           lo.ToPtr("test-mutation"),
+		Enabled:        lo.ToPtr(true),
+		ClusterId:      lo.ToPtr(testClusterID),
+		OrganizationId: lo.ToPtr(testOrgID),
+		SpotType:       lo.ToPtr(patching_engine.PodMutationSpotTypeOPTIONALSPOT),
+		Source:         lo.ToPtr(patching_engine.API),
+		ObjectFilterV2: &patching_engine.ObjectFilterV2{
+			Namespaces: &[]patching_engine.ObjectFilterV2Matcher{
+				{Type: lo.ToPtr(patching_engine.EXACT), Value: lo.ToPtr("c")},
+				{Type: lo.ToPtr(patching_engine.EXACT), Value: lo.ToPtr("a")},
+				{Type: lo.ToPtr(patching_engine.EXACT), Value: lo.ToPtr("b")},
+			},
+		},
+	}
+	respBody, _ := json.Marshal(mutation)
+	mockClient.EXPECT().
+		PodMutationsAPIGetPodMutation(gomock.Any(), testOrgID, testClusterID, testMutationID).
+		Return(&http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(respBody)),
+			Header:     map[string][]string{"Content-Type": {"application/json"}},
+		}, nil)
+
+	stateValue := cty.ObjectVal(map[string]cty.Value{
+		"organization_id": cty.StringVal(testOrgID),
+		"cluster_id":      cty.StringVal(testClusterID),
+		"name":            cty.StringVal("test-mutation"),
+		"enabled":         cty.BoolVal(true),
+	})
+	state := terraform.NewInstanceStateShimmedFromValue(stateValue, 0)
+	state.ID = testMutationID
+
+	resource := resourcePodMutation()
+	data := resource.Data(state)
+
+	result := resource.ReadContext(ctx, data, provider)
+	r.Nil(result)
+
+	filterV2 := data.Get(FieldPodMutationFilterV2).([]interface{})
+	r.Len(filterV2, 1)
+	workloadList := filterV2[0].(map[string]interface{})[FieldPodMutationFilterWorkload].([]interface{})
+	r.Len(workloadList, 1)
+	wm := workloadList[0].(map[string]interface{})
+
+	namespaces := wm[FieldPodMutationFilterNamespaces].(*schema.Set).List()
+	r.Len(namespaces, 3)
+
+	values := map[string]bool{}
+	for _, n := range namespaces {
+		values[n.(map[string]interface{})[FieldPodMutationMatcherValue].(string)] = true
+	}
+	r.Equal(map[string]bool{"a": true, "b": true, "c": true}, values)
+}
+
 func TestAccCloudAgnostic_ResourcePodMutation(t *testing.T) {
 	rName := fmt.Sprintf("%v-pod-mutation-%v", ResourcePrefix, acctest.RandString(8))
 	resourceName := "castai_pod_mutation.test"
@@ -1586,10 +1684,14 @@ func TestAccCloudAgnostic_ResourcePodMutation(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "spot_config.0.spot_mode", "PREFERRED_SPOT"),
 					resource.TestCheckResourceAttr(resourceName, "spot_config.0.distribution_percentage", "80"),
-					resource.TestCheckResourceAttr(resourceName, "filter_v2.0.workload.0.namespaces.0.type", "EXACT"),
-					resource.TestCheckResourceAttr(resourceName, "filter_v2.0.workload.0.namespaces.0.value", "default"),
-					resource.TestCheckResourceAttr(resourceName, "filter_v2.0.workload.0.kinds.0.type", "EXACT"),
-					resource.TestCheckResourceAttr(resourceName, "filter_v2.0.workload.0.kinds.0.value", "Deployment"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filter_v2.0.workload.0.namespaces.*", map[string]string{
+						"type":  "EXACT",
+						"value": "default",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filter_v2.0.workload.0.kinds.*", map[string]string{
+						"type":  "EXACT",
+						"value": "Deployment",
+					}),
 					resource.TestCheckResourceAttr(resourceName, "tolerations.0.key", "scheduling.cast.ai/spot"),
 					resource.TestCheckResourceAttr(resourceName, "tolerations.0.operator", "Exists"),
 					resource.TestCheckResourceAttr(resourceName, "tolerations.0.effect", "NoSchedule"),
@@ -1604,8 +1706,10 @@ func TestAccCloudAgnostic_ResourcePodMutation(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "spot_config.0.spot_mode", "OPTIONAL_SPOT"),
 					resource.TestCheckResourceAttr(resourceName, "spot_config.0.distribution_percentage", "50"),
-					resource.TestCheckResourceAttr(resourceName, "filter_v2.0.workload.0.namespaces.0.type", "REGEX"),
-					resource.TestCheckResourceAttr(resourceName, "filter_v2.0.workload.0.namespaces.0.value", "^prod-.*$"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "filter_v2.0.workload.0.namespaces.*", map[string]string{
+						"type":  "REGEX",
+						"value": "^prod-.*$",
+					}),
 				),
 			},
 			{
@@ -1763,4 +1867,20 @@ resource "castai_pod_mutation" "test" {
   }
 }
 `, rName, clusterName, organizationID)
+}
+
+func matcherSet(items ...map[string]interface{}) *schema.Set {
+	raw := make([]interface{}, 0, len(items))
+	for _, it := range items {
+		raw = append(raw, it)
+	}
+	return schema.NewSet(schema.HashResource(matcherSchema), raw)
+}
+
+func labelMatcherSet(items ...map[string]interface{}) *schema.Set {
+	raw := make([]interface{}, 0, len(items))
+	for _, it := range items {
+		raw = append(raw, it)
+	}
+	return schema.NewSet(schema.HashResource(labelMatcherElemSchema), raw)
 }

--- a/castai/sdk/patching_engine/api.gen.go
+++ b/castai/sdk/patching_engine/api.gen.go
@@ -416,6 +416,12 @@ type PatchOptions struct {
 	Remove *map[string]string `json:"remove,omitempty"`
 }
 
+// PodEviction PodEviction defines eviction settings for enforcement of pod mutations.
+type PodEviction struct {
+	// Enabled Whether non-conforming pods are eligible for eviction.
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
 // PodMutation PodMutation represents a mutation that can be applied to pods in a cluster.
 type PodMutation struct {
 	// Affinity Affinity to apply to the pods.
@@ -480,6 +486,9 @@ type PodMutation struct {
 	//  For more detailed explanation read JSON patching section in kubernetes documentation:
 	//  https://kubernetes.io/docs/reference/kubectl/generated/kubectl_patch/
 	Patch *[]map[string]interface{} `json:"patch,omitempty"`
+
+	// PodEviction Eviction settings for enforcement of pod mutations.
+	PodEviction *PodEviction `json:"podEviction,omitempty"`
 
 	// RestartMatchingWorkloads Restart matching workloads when the pod mutation is applied.
 	RestartMatchingWorkloads *bool `json:"restartMatchingWorkloads,omitempty"`

--- a/docs/resources/pod_mutation.md
+++ b/docs/resources/pod_mutation.md
@@ -368,7 +368,7 @@ Optional:
 
 Required:
 
-- `matchers` (Block List, Min: 1) (see [below for nested schema](#nestedblock--filter_v2--pod--exclude_labels_filter--matchers))
+- `matchers` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--filter_v2--pod--exclude_labels_filter--matchers))
 - `operator` (String) Logical operator to combine label matchers: AND or OR.
 
 <a id="nestedblock--filter_v2--pod--exclude_labels_filter--matchers"></a>
@@ -407,7 +407,7 @@ Required:
 
 Required:
 
-- `matchers` (Block List, Min: 1) (see [below for nested schema](#nestedblock--filter_v2--pod--labels_filter--matchers))
+- `matchers` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--filter_v2--pod--labels_filter--matchers))
 - `operator` (String) Logical operator to combine label matchers: AND or OR.
 
 <a id="nestedblock--filter_v2--pod--labels_filter--matchers"></a>
@@ -447,12 +447,12 @@ Required:
 
 Optional:
 
-- `exclude_kinds` (Block List) (see [below for nested schema](#nestedblock--filter_v2--workload--exclude_kinds))
-- `exclude_names` (Block List) (see [below for nested schema](#nestedblock--filter_v2--workload--exclude_names))
-- `exclude_namespaces` (Block List) (see [below for nested schema](#nestedblock--filter_v2--workload--exclude_namespaces))
-- `kinds` (Block List) (see [below for nested schema](#nestedblock--filter_v2--workload--kinds))
-- `names` (Block List) (see [below for nested schema](#nestedblock--filter_v2--workload--names))
-- `namespaces` (Block List) (see [below for nested schema](#nestedblock--filter_v2--workload--namespaces))
+- `exclude_kinds` (Block Set) (see [below for nested schema](#nestedblock--filter_v2--workload--exclude_kinds))
+- `exclude_names` (Block Set) (see [below for nested schema](#nestedblock--filter_v2--workload--exclude_names))
+- `exclude_namespaces` (Block Set) (see [below for nested schema](#nestedblock--filter_v2--workload--exclude_namespaces))
+- `kinds` (Block Set) (see [below for nested schema](#nestedblock--filter_v2--workload--kinds))
+- `names` (Block Set) (see [below for nested schema](#nestedblock--filter_v2--workload--names))
+- `namespaces` (Block Set) (see [below for nested schema](#nestedblock--filter_v2--workload--namespaces))
 
 <a id="nestedblock--filter_v2--workload--exclude_kinds"></a>
 ### Nested Schema for `filter_v2.workload.exclude_kinds`


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Convert filter matcher fields in the `castai_pod_mutation` resource from ordered lists (`TypeList`) to unordered sets (`TypeSet`). This applies to workload filters (`names`, `namespaces`, `kinds`, and their exclusion counterparts) and label filter `matchers`.

### Why
Eliminates perpetual configuration drift when the CAST AI API returns filter matchers in a different order than defined in Terraform configuration. Sets ignore element ordering during state comparison, preventing unnecessary plan differences on every apply.

### Key changes
- `castai/resource_pod_mutation.go`:
  - Changed `FieldPodMutationLabelsFilterMatchers` from `TypeList` to `TypeSet` with `schema.HashResource(labelMatcherElemSchema)`.
  - Changed workload filter fields (`FieldPodMutationFilterNames`, `FieldPodMutationFilterNamespaces`, `FieldPodMutationFilterKinds`, `FieldPodMutationFilterExcludeNames`, `FieldPodMutationFilterExcludeNamespaces`, `FieldPodMutationFilterExcludeKinds`) from `TypeList` to `TypeSet`.
  - Extracted `labelMatcherElemSchema` variable to enable proper set hashing.
  - Updated `stateToMatchers` signature to accept `*schema.Set` and adjusted all state transformation logic to handle sets.
  - Updated `validatePodMutationFilter` to check set length via `*schema.Set` instead of slice length.
- `castai/resource_pod_mutation_test.go`:
  - Updated test assertions to use `(*schema.Set).List()` and introduced `matcherSet()`/`labelMatcherSet()` helper functions.
  - Added `TestStateToObjectFilterV2_UnorderedSet` and `TestPodMutation_ReadContext_RoundTrip_UnorderedNamespaces` to verify correct handling of unordered data.
  - Updated acceptance tests to use `TestCheckTypeSetElemNestedAttrs` for set element validation.
- `docs/resources/pod_mutation.md`: Updated field descriptions from "Block List" to "Block Set" for all affected filter fields.

### Testing

Testing on dev environment on GKE cluster. First applied TF state from master. Then built local TF with changes to 