### PR TITLE
feat: add auto_instrument field to jvm scaling policy block

### DIFF
--- a/castai/resource_workload_scaling_policy.go
+++ b/castai/resource_workload_scaling_policy.go
@@ -335,6 +335,11 @@ It can be either:
 				Description: "JVM optimization settings.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"auto_instrument": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "When true, JMX exporter will be automatically injected into pods where JVM runtime is detected.",
+						},
 						"memory": {
 							Type:        schema.TypeList,
 							Optional:    true,
@@ -1590,6 +1595,9 @@ func toJvm(m map[string]any) *sdk.WorkloadoptimizationV1JVMSettings {
 		return nil
 	}
 	result := &sdk.WorkloadoptimizationV1JVMSettings{}
+	if v, ok := m["auto_instrument"].(bool); ok {
+		result.AutoInstrument = lo.ToPtr(v)
+	}
 	if mem := getFirstElem(m, "memory"); mem != nil {
 		result.Memory = &sdk.WorkloadoptimizationV1JVMMemorySettings{}
 		if v, ok := mem["optimization"].(bool); ok {
@@ -1604,6 +1612,9 @@ func toJvmMap(s *sdk.WorkloadoptimizationV1JVMSettings) []map[string]any {
 		return nil
 	}
 	m := map[string]any{}
+	if s.AutoInstrument != nil {
+		m["auto_instrument"] = *s.AutoInstrument
+	}
 	if s.Memory != nil {
 		m["memory"] = []map[string]any{{
 			"optimization": s.Memory.Optimization,

--- a/castai/resource_workload_scaling_policy_test.go
+++ b/castai/resource_workload_scaling_policy_test.go
@@ -954,6 +954,30 @@ func Test_toJvm(t *testing.T) {
 				},
 			},
 		},
+		"should return jvm settings with auto instrument enabled": {
+			args: map[string]any{
+				"auto_instrument": true,
+			},
+			exp: &sdk.WorkloadoptimizationV1JVMSettings{
+				AutoInstrument: lo.ToPtr(true),
+			},
+		},
+		"should return jvm settings with auto instrument disabled": {
+			args: map[string]any{
+				"auto_instrument": false,
+				"memory": []any{
+					map[string]any{
+						"optimization": true,
+					},
+				},
+			},
+			exp: &sdk.WorkloadoptimizationV1JVMSettings{
+				AutoInstrument: lo.ToPtr(false),
+				Memory: &sdk.WorkloadoptimizationV1JVMMemorySettings{
+					Optimization: true,
+				},
+			},
+		},
 		"should return nil on empty map": {
 			args: map[string]any{},
 			exp:  nil,
@@ -985,6 +1009,32 @@ func Test_toJvmMap(t *testing.T) {
 			},
 			exp: []map[string]any{
 				{
+					"memory": []map[string]any{{
+						"optimization": true,
+					}},
+				},
+			},
+		},
+		"should return jvm map with auto instrument enabled": {
+			args: &sdk.WorkloadoptimizationV1JVMSettings{
+				AutoInstrument: lo.ToPtr(true),
+			},
+			exp: []map[string]any{
+				{
+					"auto_instrument": true,
+				},
+			},
+		},
+		"should return jvm map with auto instrument disabled": {
+			args: &sdk.WorkloadoptimizationV1JVMSettings{
+				AutoInstrument: lo.ToPtr(false),
+				Memory: &sdk.WorkloadoptimizationV1JVMMemorySettings{
+					Optimization: true,
+				},
+			},
+			exp: []map[string]any{
+				{
+					"auto_instrument": false,
 					"memory": []map[string]any{{
 						"optimization": true,
 					}},

--- a/docs/resources/workload_scaling_policy.md
+++ b/docs/resources/workload_scaling_policy.md
@@ -369,6 +369,7 @@ Optional:
 
 Optional:
 
+- `auto_instrument` (Boolean) When true, JMX exporter will be automatically injected into pods where JVM runtime is detected.
 - `memory` (Block List, Max: 1) JVM memory optimization settings. (see [below for nested schema](#nestedblock--jvm--memory))
 
 <a id="nestedblock--jvm--memory"></a>


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Added `auto_instrument` boolean attribute to the `jvm` block of the `castai_workload_scaling_policy` resource. When set to `true`, CAST AI automatically injects the JMX exporter into pods where JVM runtime is detected.

### Why
Enables automated JVM monitoring by allowing the platform to automatically instrument pods with the JMX exporter, removing the need for manual configuration.

### Key changes
- `castai/resource_workload_scaling_policy.go`: Added `auto_instrument` schema field to the `jvm` configuration block; updated `toJvm()` and `toJvmMap()` helper functions to map the new field to the SDK's `AutoInstrument` field
- `castai/resource_workload_scaling_policy_test.go`: Added test coverage for `toJvm()` and `toJvmMap()` with `auto_instrument` enabled and disabled
- `docs/resources/workload_scaling_policy.md`: Documented the new `auto_instrument` argument

### Impact
No breaking changes. The new field is optional and defaults to unspecified/nil behavior in the provider.