### PR TITLE
allow imds_hop_limit=1

### DIFF
--- a/castai/resource_node_configuration.go
+++ b/castai/resource_node_configuration.go
@@ -251,8 +251,8 @@ func resourceNodeConfiguration() *schema.Resource {
 							Type:             schema.TypeInt,
 							Optional:         true,
 							Default:          2,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(2)),
-							Description:      "Allow configure the IMDSv2 hop limit, the default is 2",
+							ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
+							Description:      "Allow configure the IMDSv2 hop limit, the default is 2. Setting to 1 disables access to most pods except pods running on host network.",
 						},
 						"volume_kms_key_arn": {
 							Type:             schema.TypeString,

--- a/docs/resources/node_configuration.md
+++ b/docs/resources/node_configuration.md
@@ -158,7 +158,7 @@ Optional:
 
 - `dns_cluster_ip` (String) IP address to use for DNS queries within the cluster
 - `eks_image_family` (String) Image OS Family to use when provisioning node in EKS. If both image and family are provided, the system will use provided image and provisioning logic for given family. If only image family is provided, the system will attempt to resolve the latest image from that family based on kubernetes version and node architecture. If image family is omitted, a default family (based on cloud provider) will be used. See Cast.ai documentation for details. Possible values: (al2,al2023,bottlerocket)
-- `imds_hop_limit` (Number) Allow configure the IMDSv2 hop limit, the default is 2
+- `imds_hop_limit` (Number) Allow configure the IMDSv2 hop limit, the default is 2. Setting to 1 disables access to most pods except pods running on host network.
 - `imds_v1` (Boolean) When the value is true both IMDSv1 and IMDSv2 are enabled. Setting the value to false disables permanently IMDSv1 and might affect legacy workloads running on the node created with this configuration. The default is true if the flag isn't provided
 - `ips_per_prefix` (Number) Number of IPs per prefix to be used for calculating max pods. For IPv4 it should be 16. More info: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-prefix-eni.html#ec2-prefix-basics
 - `key_pair_id` (String) AWS key pair ID to be used for CAST provisioned nodes. Has priority over ssh_public_key


### PR DESCRIPTION
API allows setting imds_hop_limit to `1` but terraform doesn't. Terraform sets it to `2` which allows all pods in EKS access to the service. Setting to `1` disable the access for most pods allowing only to the pods running on `host` network. 

---
### Kimchi Summary
### What changed
Relaxes the minimum validation constraint for `imds_hop_limit` from 2 to 1 in EKS node configurations, allowing users to configure stricter IMDSv2 hop limits. Updates documentation to clarify that setting the value to 1 restricts instance metadata access to host-network pods only.

### Why
Enables users to secure their clusters by setting the IMDSv2 hop limit to 1, which prevents most pods from accessing the EC2 instance metadata service and reduces potential attack vectors.

### Key changes
- `castai/resource_node_configuration.go`: Changed `imds_hop_limit` validation from `validation.IntAtLeast(2)` to `validation.IntAtLeast(1)`
- `castai/resource_node_configuration.go`: Updated field description to document that value 1 restricts IMDS access to host-network pods only
- `docs/resources/node_configuration.md`: Synchronized documentation with the updated schema description

### Impact
- **Validation**: Configurations with `imds_hop_limit = 1` are now accepted (previously rejected)
- **Security**: Users can now set hop limit to 1 to disable IMDS access for non-host-network pods
- **Compatibility**: No breaking changes; existing configurations with values ≥ 2 remain valid and the default remains 2