### PR TITLE
chore: make generate

### DIFF
--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -445,6 +445,13 @@ const (
 	Worker          ExternalclusterV1NodeType = "worker"
 )
 
+// Defines values for ExternalclusterV1OperationMode.
+const (
+	ExternalclusterV1OperationModeOPERATIONMODEDEFAULT     ExternalclusterV1OperationMode = "OPERATION_MODE_DEFAULT"
+	ExternalclusterV1OperationModeOPERATIONMODEDRYRUN      ExternalclusterV1OperationMode = "OPERATION_MODE_DRY_RUN"
+	ExternalclusterV1OperationModeOPERATIONMODEUNSPECIFIED ExternalclusterV1OperationMode = "OPERATION_MODE_UNSPECIFIED"
+)
+
 // Defines values for K8sSelectorV1Operator.
 const (
 	K8sSelectorV1OperatorDoesNotExist  K8sSelectorV1Operator = "DoesNotExist"
@@ -790,6 +797,12 @@ const (
 	WorkloadoptimizationV1GetHPAV2MigrationEligibilityResponseMigrationStatusUNSPECIFIED WorkloadoptimizationV1GetHPAV2MigrationEligibilityResponseMigrationStatus = "UNSPECIFIED"
 )
 
+// Defines values for WorkloadoptimizationV1HPAConverterType.
+const (
+	AVERAGEVALUEFROMORIGINALREQUESTS WorkloadoptimizationV1HPAConverterType = "AVERAGE_VALUE_FROM_ORIGINAL_REQUESTS"
+	HPACONVERTERTYPEUNSPECIFIED      WorkloadoptimizationV1HPAConverterType = "HPA_CONVERTER_TYPE_UNSPECIFIED"
+)
+
 // Defines values for WorkloadoptimizationV1HPALegacyUnsupportedReasonType.
 const (
 	HPALEGACYUNSUPPORTEDREASONHASNATIVEHPA        WorkloadoptimizationV1HPALegacyUnsupportedReasonType = "HPA_LEGACY_UNSUPPORTED_REASON_HAS_NATIVE_HPA"
@@ -1117,6 +1130,13 @@ const (
 	InstallEvictor                   ExternalClusterAPIGetCredentialsScriptParamsKentParams = "install_evictor"
 )
 
+// Defines values for ExternalClusterAPITriggerHibernateClusterParamsMode.
+const (
+	ExternalClusterAPITriggerHibernateClusterParamsModeOPERATIONMODEDEFAULT     ExternalClusterAPITriggerHibernateClusterParamsMode = "OPERATION_MODE_DEFAULT"
+	ExternalClusterAPITriggerHibernateClusterParamsModeOPERATIONMODEDRYRUN      ExternalClusterAPITriggerHibernateClusterParamsMode = "OPERATION_MODE_DRY_RUN"
+	ExternalClusterAPITriggerHibernateClusterParamsModeOPERATIONMODEUNSPECIFIED ExternalClusterAPITriggerHibernateClusterParamsMode = "OPERATION_MODE_UNSPECIFIED"
+)
+
 // Defines values for ExternalClusterAPIListNodesParamsNodeStatus.
 const (
 	ExternalClusterAPIListNodesParamsNodeStatusCordoned              ExternalClusterAPIListNodesParamsNodeStatus = "cordoned"
@@ -1138,6 +1158,13 @@ const (
 	ExternalClusterAPIListNodesParamsLifecycleTypeLifecycleTypeUnspecified ExternalClusterAPIListNodesParamsLifecycleType = "lifecycle_type_unspecified"
 	ExternalClusterAPIListNodesParamsLifecycleTypeOnDemand                 ExternalClusterAPIListNodesParamsLifecycleType = "on_demand"
 	ExternalClusterAPIListNodesParamsLifecycleTypeSpot                     ExternalClusterAPIListNodesParamsLifecycleType = "spot"
+)
+
+// Defines values for ExternalClusterAPITriggerResumeClusterParamsMode.
+const (
+	OPERATIONMODEDEFAULT     ExternalClusterAPITriggerResumeClusterParamsMode = "OPERATION_MODE_DEFAULT"
+	OPERATIONMODEDRYRUN      ExternalClusterAPITriggerResumeClusterParamsMode = "OPERATION_MODE_DRY_RUN"
+	OPERATIONMODEUNSPECIFIED ExternalClusterAPITriggerResumeClusterParamsMode = "OPERATION_MODE_UNSPECIFIED"
 )
 
 // Defines values for RbacServiceAPIListRoleBindingsParamsScopeType.
@@ -6161,6 +6188,13 @@ type ExternalclusterV1OpenshiftClusterParams struct {
 	Region *string `json:"region,omitempty"`
 }
 
+// ExternalclusterV1OperationMode OperationMode defines the execution mode for hibernate/resume operations.
+//
+//   - OPERATION_MODE_UNSPECIFIED: Default value.
+//   - OPERATION_MODE_DEFAULT: Normal operation - executes the hibernate/resume.
+//   - OPERATION_MODE_DRY_RUN: Dry-run mode - validates only without executing.
+type ExternalclusterV1OperationMode string
+
 // ExternalclusterV1RaidConfig RaidConfig allow You have two or more devices, of approximately the same size, and you want to combine their storage capacity
 // and also combine their performance by accessing them in parallel.
 type ExternalclusterV1RaidConfig struct {
@@ -6273,19 +6307,33 @@ type ExternalclusterV1Taint struct {
 
 // ExternalclusterV1TriggerHibernateClusterResponse TriggerHibernateClusterResponse is the result of HibernateClusterRequest.
 type ExternalclusterV1TriggerHibernateClusterResponse struct {
-	// ClusterId The ID of the node.
+	// ClusterId The ID of the cluster.
 	ClusterId string `json:"clusterId"`
 
-	// OperationId Add node operation ID.
+	// Mode OperationMode defines the execution mode for hibernate/resume operations.
+	//
+	//  - OPERATION_MODE_UNSPECIFIED: Default value.
+	//  - OPERATION_MODE_DEFAULT: Normal operation - executes the hibernate/resume.
+	//  - OPERATION_MODE_DRY_RUN: Dry-run mode - validates only without executing.
+	Mode ExternalclusterV1OperationMode `json:"mode"`
+
+	// OperationId Hibernate operation ID. Empty when mode is dry-run.
 	OperationId string `json:"operationId"`
 }
 
 // ExternalclusterV1TriggerResumeClusterResponse TriggerResumeClusterResponse is the result of ResumeClusterRequest.
 type ExternalclusterV1TriggerResumeClusterResponse struct {
-	// ClusterId The ID of the node.
+	// ClusterId The ID of the cluster.
 	ClusterId string `json:"clusterId"`
 
-	// OperationId Add node operation ID.
+	// Mode OperationMode defines the execution mode for hibernate/resume operations.
+	//
+	//  - OPERATION_MODE_UNSPECIFIED: Default value.
+	//  - OPERATION_MODE_DEFAULT: Normal operation - executes the hibernate/resume.
+	//  - OPERATION_MODE_DRY_RUN: Dry-run mode - validates only without executing.
+	Mode ExternalclusterV1OperationMode `json:"mode"`
+
+	// OperationId Resume operation ID. Empty when mode is dry-run.
 	OperationId string `json:"operationId"`
 }
 
@@ -9170,6 +9218,19 @@ type WorkloadoptimizationV1HPAConfigUpdate struct {
 	UseNative *bool `json:"useNative"`
 }
 
+// WorkloadoptimizationV1HPAConverterType HPAConverterType defines the strategy for converting HPA.
+//
+//   - AVERAGE_VALUE_FROM_ORIGINAL_REQUESTS: Converts HPA utilization (%) targets to AverageValue using workload container requests.
+type WorkloadoptimizationV1HPAConverterType string
+
+// WorkloadoptimizationV1HPAConverters defines model for workloadoptimization.v1.HPAConverters.
+type WorkloadoptimizationV1HPAConverters struct {
+	// Type HPAConverterType defines the strategy for converting HPA.
+	//
+	//  - AVERAGE_VALUE_FROM_ORIGINAL_REQUESTS: Converts HPA utilization (%) targets to AverageValue using workload container requests.
+	Type WorkloadoptimizationV1HPAConverterType `json:"type"`
+}
+
 // WorkloadoptimizationV1HPALegacyConfig HPALegacyConfig holds the resolved configuration for legacy CAST AI HPA.
 type WorkloadoptimizationV1HPALegacyConfig struct {
 	// ManagementOption Defines possible options for workload management.
@@ -9868,7 +9929,11 @@ type WorkloadoptimizationV1RecommendationPolicies struct {
 	Cpu                WorkloadoptimizationV1ResourcePolicies          `json:"cpu"`
 	Downscaling        *WorkloadoptimizationV1DownscalingSettings      `json:"downscaling,omitempty"`
 	ExcludedContainers *[]string                                       `json:"excludedContainers,omitempty"`
-	Jvm                *WorkloadoptimizationV1JVMSettings              `json:"jvm,omitempty"`
+
+	// HpaConverters Configuration for converting existing HPAs when VPA is the sole optimization.
+	// If HPA management is enabled, it takes precedence over this setting.
+	HpaConverters *[]WorkloadoptimizationV1HPAConverters `json:"hpaConverters,omitempty"`
+	Jvm           *WorkloadoptimizationV1JVMSettings     `json:"jvm,omitempty"`
 
 	// ManagementOption Defines possible options for workload management.
 	// READ_ONLY - workload watched (metrics collected), but no actions may be performed by CAST AI.
@@ -10243,6 +10308,9 @@ type WorkloadoptimizationV1Resources struct {
 
 // WorkloadoptimizationV1RolloutBehaviorSettings defines model for workloadoptimization.v1.RolloutBehaviorSettings.
 type WorkloadoptimizationV1RolloutBehaviorSettings struct {
+	// DelaySeconds Number of seconds to delay before applying the recommendation rollout. Must be between 0 and 3600.
+	DelaySeconds *int32 `json:"delaySeconds"`
+
 	// PreferOneByOne If true, prefer rolling out recommendations one pod at a time.
 	PreferOneByOne *bool `json:"preferOneByOne"`
 
@@ -10493,6 +10561,10 @@ type WorkloadoptimizationV1VPAConfig struct {
 	Downscaling        *WorkloadoptimizationV1DownscalingSettings `json:"downscaling,omitempty"`
 	ExcludedContainers *[]string                                  `json:"excludedContainers,omitempty"`
 
+	// HpaConverters Configuration for converting existing HPAs when VPA is the sole optimization.
+	// If HPA management is enabled, it takes precedence over this setting.
+	HpaConverters *[]WorkloadoptimizationV1HPAConverters `json:"hpaConverters,omitempty"`
+
 	// Jvm JVMRuntimeConfiguration defines set of settings that enables and configures for JVM optimization.
 	Jvm *WorkloadoptimizationV1JVMRuntimeConfiguration `json:"jvm,omitempty"`
 
@@ -10544,6 +10616,10 @@ type WorkloadoptimizationV1VerticalOverrides struct {
 
 	// ExcludedContainers Containers to exclude from optimization.
 	ExcludedContainers *[]string `json:"excludedContainers,omitempty"`
+
+	// HpaConverters Configuration for converting existing HPAs when VPA is the sole optimization.
+	// If HPA management is enabled, it takes precedence over this setting.
+	HpaConverters *[]WorkloadoptimizationV1HPAConverters `json:"hpaConverters,omitempty"`
 
 	// Jvm JVMRuntimeConfiguration defines set of settings that enables and configures for JVM optimization.
 	Jvm *WorkloadoptimizationV1JVMRuntimeConfiguration `json:"jvm,omitempty"`
@@ -11455,6 +11531,19 @@ type ExternalClusterAPIGetCredentialsScriptParams struct {
 // ExternalClusterAPIGetCredentialsScriptParamsKentParams defines parameters for ExternalClusterAPIGetCredentialsScript.
 type ExternalClusterAPIGetCredentialsScriptParamsKentParams string
 
+// ExternalClusterAPITriggerHibernateClusterParams defines parameters for ExternalClusterAPITriggerHibernateCluster.
+type ExternalClusterAPITriggerHibernateClusterParams struct {
+	// Mode Mode of the operation.
+	//
+	//  - OPERATION_MODE_UNSPECIFIED: Default value.
+	//  - OPERATION_MODE_DEFAULT: Normal operation - executes the hibernate/resume.
+	//  - OPERATION_MODE_DRY_RUN: Dry-run mode - validates only without executing.
+	Mode *ExternalClusterAPITriggerHibernateClusterParamsMode `form:"mode,omitempty" json:"mode,omitempty"`
+}
+
+// ExternalClusterAPITriggerHibernateClusterParamsMode defines parameters for ExternalClusterAPITriggerHibernateCluster.
+type ExternalClusterAPITriggerHibernateClusterParamsMode string
+
 // ExternalClusterAPIListNodesParams defines parameters for ExternalClusterAPIListNodes.
 type ExternalClusterAPIListNodesParams struct {
 	PageLimit *string `form:"page.limit,omitempty" json:"page.limit,omitempty"`
@@ -11497,6 +11586,19 @@ type ExternalClusterAPIReconcileClusterParams struct {
 	// SkipAksInitData Whether to skip AKS refresh of instance-template.
 	SkipAksInitData *bool `form:"skipAksInitData,omitempty" json:"skipAksInitData,omitempty"`
 }
+
+// ExternalClusterAPITriggerResumeClusterParams defines parameters for ExternalClusterAPITriggerResumeCluster.
+type ExternalClusterAPITriggerResumeClusterParams struct {
+	// Mode Mode of the operation.
+	//
+	//  - OPERATION_MODE_UNSPECIFIED: Default value.
+	//  - OPERATION_MODE_DEFAULT: Normal operation - executes the hibernate/resume.
+	//  - OPERATION_MODE_DRY_RUN: Dry-run mode - validates only without executing.
+	Mode *ExternalClusterAPITriggerResumeClusterParamsMode `form:"mode,omitempty" json:"mode,omitempty"`
+}
+
+// ExternalClusterAPITriggerResumeClusterParamsMode defines parameters for ExternalClusterAPITriggerResumeCluster.
+type ExternalClusterAPITriggerResumeClusterParamsMode string
 
 // ExternalClusterAPIUpdateClusterTagsJSONBody defines parameters for ExternalClusterAPIUpdateClusterTags.
 type ExternalClusterAPIUpdateClusterTagsJSONBody map[string]string
@@ -11987,6 +12089,9 @@ type RuntimeSecurityAPIGetClusterWorkloadsNetflowParams struct {
 	StartTime     *time.Time `form:"startTime,omitempty" json:"startTime,omitempty"`
 	EndTime       *time.Time `form:"endTime,omitempty" json:"endTime,omitempty"`
 	UsePodDetails *bool      `form:"usePodDetails,omitempty" json:"usePodDetails,omitempty"`
+
+	// IncludeDstAddrs Controls whether destination addresses are included in the response. Defaults to true.
+	IncludeDstAddrs *bool `form:"includeDstAddrs,omitempty" json:"includeDstAddrs,omitempty"`
 }
 
 // WorkloadOptimizationAPIListWorkloadEventsParams defines parameters for WorkloadOptimizationAPIListWorkloadEvents.

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -508,7 +508,7 @@ type ClientInterface interface {
 	ExternalClusterAPIDisableGKESA(ctx context.Context, clusterId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ExternalClusterAPITriggerHibernateCluster request
-	ExternalClusterAPITriggerHibernateCluster(ctx context.Context, clusterId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ExternalClusterAPITriggerHibernateCluster(ctx context.Context, clusterId string, params *ExternalClusterAPITriggerHibernateClusterParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ExternalClusterAPIIngestInstanceLogsWithBody request with any body
 	ExternalClusterAPIIngestInstanceLogsWithBody(ctx context.Context, clusterId string, instanceId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -546,9 +546,9 @@ type ClientInterface interface {
 	ExternalClusterAPIReconcileCluster(ctx context.Context, clusterId string, params *ExternalClusterAPIReconcileClusterParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ExternalClusterAPITriggerResumeClusterWithBody request with any body
-	ExternalClusterAPITriggerResumeClusterWithBody(ctx context.Context, clusterId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ExternalClusterAPITriggerResumeClusterWithBody(ctx context.Context, clusterId string, params *ExternalClusterAPITriggerResumeClusterParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	ExternalClusterAPITriggerResumeCluster(ctx context.Context, clusterId string, body ExternalClusterAPITriggerResumeClusterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ExternalClusterAPITriggerResumeCluster(ctx context.Context, clusterId string, params *ExternalClusterAPITriggerResumeClusterParams, body ExternalClusterAPITriggerResumeClusterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ExternalClusterAPIUpdateClusterTagsWithBody request with any body
 	ExternalClusterAPIUpdateClusterTagsWithBody(ctx context.Context, clusterId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2866,8 +2866,8 @@ func (c *Client) ExternalClusterAPIDisableGKESA(ctx context.Context, clusterId s
 	return c.Client.Do(req)
 }
 
-func (c *Client) ExternalClusterAPITriggerHibernateCluster(ctx context.Context, clusterId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewExternalClusterAPITriggerHibernateClusterRequest(c.Server, clusterId)
+func (c *Client) ExternalClusterAPITriggerHibernateCluster(ctx context.Context, clusterId string, params *ExternalClusterAPITriggerHibernateClusterParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewExternalClusterAPITriggerHibernateClusterRequest(c.Server, clusterId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3034,8 +3034,8 @@ func (c *Client) ExternalClusterAPIReconcileCluster(ctx context.Context, cluster
 	return c.Client.Do(req)
 }
 
-func (c *Client) ExternalClusterAPITriggerResumeClusterWithBody(ctx context.Context, clusterId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewExternalClusterAPITriggerResumeClusterRequestWithBody(c.Server, clusterId, contentType, body)
+func (c *Client) ExternalClusterAPITriggerResumeClusterWithBody(ctx context.Context, clusterId string, params *ExternalClusterAPITriggerResumeClusterParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewExternalClusterAPITriggerResumeClusterRequestWithBody(c.Server, clusterId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3046,8 +3046,8 @@ func (c *Client) ExternalClusterAPITriggerResumeClusterWithBody(ctx context.Cont
 	return c.Client.Do(req)
 }
 
-func (c *Client) ExternalClusterAPITriggerResumeCluster(ctx context.Context, clusterId string, body ExternalClusterAPITriggerResumeClusterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewExternalClusterAPITriggerResumeClusterRequest(c.Server, clusterId, body)
+func (c *Client) ExternalClusterAPITriggerResumeCluster(ctx context.Context, clusterId string, params *ExternalClusterAPITriggerResumeClusterParams, body ExternalClusterAPITriggerResumeClusterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewExternalClusterAPITriggerResumeClusterRequest(c.Server, clusterId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -12407,7 +12407,7 @@ func NewExternalClusterAPIDisableGKESARequest(server string, clusterId string) (
 }
 
 // NewExternalClusterAPITriggerHibernateClusterRequest generates requests for ExternalClusterAPITriggerHibernateCluster
-func NewExternalClusterAPITriggerHibernateClusterRequest(server string, clusterId string) (*http.Request, error) {
+func NewExternalClusterAPITriggerHibernateClusterRequest(server string, clusterId string, params *ExternalClusterAPITriggerHibernateClusterParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -12430,6 +12430,28 @@ func NewExternalClusterAPITriggerHibernateClusterRequest(server string, clusterI
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Mode != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "mode", runtime.ParamLocationQuery, *params.Mode); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), nil)
@@ -13140,18 +13162,18 @@ func NewExternalClusterAPIReconcileClusterRequest(server string, clusterId strin
 }
 
 // NewExternalClusterAPITriggerResumeClusterRequest calls the generic ExternalClusterAPITriggerResumeCluster builder with application/json body
-func NewExternalClusterAPITriggerResumeClusterRequest(server string, clusterId string, body ExternalClusterAPITriggerResumeClusterJSONRequestBody) (*http.Request, error) {
+func NewExternalClusterAPITriggerResumeClusterRequest(server string, clusterId string, params *ExternalClusterAPITriggerResumeClusterParams, body ExternalClusterAPITriggerResumeClusterJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewExternalClusterAPITriggerResumeClusterRequestWithBody(server, clusterId, "application/json", bodyReader)
+	return NewExternalClusterAPITriggerResumeClusterRequestWithBody(server, clusterId, params, "application/json", bodyReader)
 }
 
 // NewExternalClusterAPITriggerResumeClusterRequestWithBody generates requests for ExternalClusterAPITriggerResumeCluster with any type of body
-func NewExternalClusterAPITriggerResumeClusterRequestWithBody(server string, clusterId string, contentType string, body io.Reader) (*http.Request, error) {
+func NewExternalClusterAPITriggerResumeClusterRequestWithBody(server string, clusterId string, params *ExternalClusterAPITriggerResumeClusterParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -13174,6 +13196,28 @@ func NewExternalClusterAPITriggerResumeClusterRequestWithBody(server string, clu
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Mode != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "mode", runtime.ParamLocationQuery, *params.Mode); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), body)
@@ -18821,6 +18865,22 @@ func NewRuntimeSecurityAPIGetClusterWorkloadsNetflowRequest(server string, clust
 
 		}
 
+		if params.IncludeDstAddrs != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "includeDstAddrs", runtime.ParamLocationQuery, *params.IncludeDstAddrs); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 
@@ -21971,7 +22031,7 @@ type ClientWithResponsesInterface interface {
 	ExternalClusterAPIDisableGKESAWithResponse(ctx context.Context, clusterId string) (*ExternalClusterAPIDisableGKESAResponse, error)
 
 	// ExternalClusterAPITriggerHibernateCluster request
-	ExternalClusterAPITriggerHibernateClusterWithResponse(ctx context.Context, clusterId string) (*ExternalClusterAPITriggerHibernateClusterResponse, error)
+	ExternalClusterAPITriggerHibernateClusterWithResponse(ctx context.Context, clusterId string, params *ExternalClusterAPITriggerHibernateClusterParams) (*ExternalClusterAPITriggerHibernateClusterResponse, error)
 
 	// ExternalClusterAPIIngestInstanceLogs request  with any body
 	ExternalClusterAPIIngestInstanceLogsWithBodyWithResponse(ctx context.Context, clusterId string, instanceId string, contentType string, body io.Reader) (*ExternalClusterAPIIngestInstanceLogsResponse, error)
@@ -22009,9 +22069,9 @@ type ClientWithResponsesInterface interface {
 	ExternalClusterAPIReconcileClusterWithResponse(ctx context.Context, clusterId string, params *ExternalClusterAPIReconcileClusterParams) (*ExternalClusterAPIReconcileClusterResponse, error)
 
 	// ExternalClusterAPITriggerResumeCluster request  with any body
-	ExternalClusterAPITriggerResumeClusterWithBodyWithResponse(ctx context.Context, clusterId string, contentType string, body io.Reader) (*ExternalClusterAPITriggerResumeClusterResponse, error)
+	ExternalClusterAPITriggerResumeClusterWithBodyWithResponse(ctx context.Context, clusterId string, params *ExternalClusterAPITriggerResumeClusterParams, contentType string, body io.Reader) (*ExternalClusterAPITriggerResumeClusterResponse, error)
 
-	ExternalClusterAPITriggerResumeClusterWithResponse(ctx context.Context, clusterId string, body ExternalClusterAPITriggerResumeClusterJSONRequestBody) (*ExternalClusterAPITriggerResumeClusterResponse, error)
+	ExternalClusterAPITriggerResumeClusterWithResponse(ctx context.Context, clusterId string, params *ExternalClusterAPITriggerResumeClusterParams, body ExternalClusterAPITriggerResumeClusterJSONRequestBody) (*ExternalClusterAPITriggerResumeClusterResponse, error)
 
 	// ExternalClusterAPIUpdateClusterTags request  with any body
 	ExternalClusterAPIUpdateClusterTagsWithBodyWithResponse(ctx context.Context, clusterId string, contentType string, body io.Reader) (*ExternalClusterAPIUpdateClusterTagsResponse, error)
@@ -31737,8 +31797,8 @@ func (c *ClientWithResponses) ExternalClusterAPIDisableGKESAWithResponse(ctx con
 }
 
 // ExternalClusterAPITriggerHibernateClusterWithResponse request returning *ExternalClusterAPITriggerHibernateClusterResponse
-func (c *ClientWithResponses) ExternalClusterAPITriggerHibernateClusterWithResponse(ctx context.Context, clusterId string) (*ExternalClusterAPITriggerHibernateClusterResponse, error) {
-	rsp, err := c.ExternalClusterAPITriggerHibernateCluster(ctx, clusterId)
+func (c *ClientWithResponses) ExternalClusterAPITriggerHibernateClusterWithResponse(ctx context.Context, clusterId string, params *ExternalClusterAPITriggerHibernateClusterParams) (*ExternalClusterAPITriggerHibernateClusterResponse, error) {
+	rsp, err := c.ExternalClusterAPITriggerHibernateCluster(ctx, clusterId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -31859,16 +31919,16 @@ func (c *ClientWithResponses) ExternalClusterAPIReconcileClusterWithResponse(ctx
 }
 
 // ExternalClusterAPITriggerResumeClusterWithBodyWithResponse request with arbitrary body returning *ExternalClusterAPITriggerResumeClusterResponse
-func (c *ClientWithResponses) ExternalClusterAPITriggerResumeClusterWithBodyWithResponse(ctx context.Context, clusterId string, contentType string, body io.Reader) (*ExternalClusterAPITriggerResumeClusterResponse, error) {
-	rsp, err := c.ExternalClusterAPITriggerResumeClusterWithBody(ctx, clusterId, contentType, body)
+func (c *ClientWithResponses) ExternalClusterAPITriggerResumeClusterWithBodyWithResponse(ctx context.Context, clusterId string, params *ExternalClusterAPITriggerResumeClusterParams, contentType string, body io.Reader) (*ExternalClusterAPITriggerResumeClusterResponse, error) {
+	rsp, err := c.ExternalClusterAPITriggerResumeClusterWithBody(ctx, clusterId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
 	return ParseExternalClusterAPITriggerResumeClusterResponse(rsp)
 }
 
-func (c *ClientWithResponses) ExternalClusterAPITriggerResumeClusterWithResponse(ctx context.Context, clusterId string, body ExternalClusterAPITriggerResumeClusterJSONRequestBody) (*ExternalClusterAPITriggerResumeClusterResponse, error) {
-	rsp, err := c.ExternalClusterAPITriggerResumeCluster(ctx, clusterId, body)
+func (c *ClientWithResponses) ExternalClusterAPITriggerResumeClusterWithResponse(ctx context.Context, clusterId string, params *ExternalClusterAPITriggerResumeClusterParams, body ExternalClusterAPITriggerResumeClusterJSONRequestBody) (*ExternalClusterAPITriggerResumeClusterResponse, error) {
+	rsp, err := c.ExternalClusterAPITriggerResumeCluster(ctx, clusterId, params, body)
 	if err != nil {
 		return nil, err
 	}

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -2956,9 +2956,9 @@ func (mr *MockClientInterfaceMockRecorder) ExternalClusterAPIRegisterClusterWith
 }
 
 // ExternalClusterAPITriggerHibernateCluster mocks base method.
-func (m *MockClientInterface) ExternalClusterAPITriggerHibernateCluster(ctx context.Context, clusterId string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+func (m *MockClientInterface) ExternalClusterAPITriggerHibernateCluster(ctx context.Context, clusterId string, params *sdk.ExternalClusterAPITriggerHibernateClusterParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterId}
+	varargs := []interface{}{ctx, clusterId, params}
 	for _, a := range reqEditors {
 		varargs = append(varargs, a)
 	}
@@ -2969,16 +2969,16 @@ func (m *MockClientInterface) ExternalClusterAPITriggerHibernateCluster(ctx cont
 }
 
 // ExternalClusterAPITriggerHibernateCluster indicates an expected call of ExternalClusterAPITriggerHibernateCluster.
-func (mr *MockClientInterfaceMockRecorder) ExternalClusterAPITriggerHibernateCluster(ctx, clusterId interface{}, reqEditors ...interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) ExternalClusterAPITriggerHibernateCluster(ctx, clusterId, params interface{}, reqEditors ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterId}, reqEditors...)
+	varargs := append([]interface{}{ctx, clusterId, params}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerHibernateCluster", reflect.TypeOf((*MockClientInterface)(nil).ExternalClusterAPITriggerHibernateCluster), varargs...)
 }
 
 // ExternalClusterAPITriggerResumeCluster mocks base method.
-func (m *MockClientInterface) ExternalClusterAPITriggerResumeCluster(ctx context.Context, clusterId string, body sdk.ExternalClusterAPITriggerResumeClusterJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+func (m *MockClientInterface) ExternalClusterAPITriggerResumeCluster(ctx context.Context, clusterId string, params *sdk.ExternalClusterAPITriggerResumeClusterParams, body sdk.ExternalClusterAPITriggerResumeClusterJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterId, body}
+	varargs := []interface{}{ctx, clusterId, params, body}
 	for _, a := range reqEditors {
 		varargs = append(varargs, a)
 	}
@@ -2989,16 +2989,16 @@ func (m *MockClientInterface) ExternalClusterAPITriggerResumeCluster(ctx context
 }
 
 // ExternalClusterAPITriggerResumeCluster indicates an expected call of ExternalClusterAPITriggerResumeCluster.
-func (mr *MockClientInterfaceMockRecorder) ExternalClusterAPITriggerResumeCluster(ctx, clusterId, body interface{}, reqEditors ...interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) ExternalClusterAPITriggerResumeCluster(ctx, clusterId, params, body interface{}, reqEditors ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterId, body}, reqEditors...)
+	varargs := append([]interface{}{ctx, clusterId, params, body}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerResumeCluster", reflect.TypeOf((*MockClientInterface)(nil).ExternalClusterAPITriggerResumeCluster), varargs...)
 }
 
 // ExternalClusterAPITriggerResumeClusterWithBody mocks base method.
-func (m *MockClientInterface) ExternalClusterAPITriggerResumeClusterWithBody(ctx context.Context, clusterId, contentType string, body io.Reader, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+func (m *MockClientInterface) ExternalClusterAPITriggerResumeClusterWithBody(ctx context.Context, clusterId string, params *sdk.ExternalClusterAPITriggerResumeClusterParams, contentType string, body io.Reader, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterId, contentType, body}
+	varargs := []interface{}{ctx, clusterId, params, contentType, body}
 	for _, a := range reqEditors {
 		varargs = append(varargs, a)
 	}
@@ -3009,9 +3009,9 @@ func (m *MockClientInterface) ExternalClusterAPITriggerResumeClusterWithBody(ctx
 }
 
 // ExternalClusterAPITriggerResumeClusterWithBody indicates an expected call of ExternalClusterAPITriggerResumeClusterWithBody.
-func (mr *MockClientInterfaceMockRecorder) ExternalClusterAPITriggerResumeClusterWithBody(ctx, clusterId, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) ExternalClusterAPITriggerResumeClusterWithBody(ctx, clusterId, params, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterId, contentType, body}, reqEditors...)
+	varargs := append([]interface{}{ctx, clusterId, params, contentType, body}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerResumeClusterWithBody", reflect.TypeOf((*MockClientInterface)(nil).ExternalClusterAPITriggerResumeClusterWithBody), varargs...)
 }
 
@@ -12139,9 +12139,9 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPIRegist
 }
 
 // ExternalClusterAPITriggerHibernateCluster mocks base method.
-func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerHibernateCluster(ctx context.Context, clusterId string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerHibernateCluster(ctx context.Context, clusterId string, params *sdk.ExternalClusterAPITriggerHibernateClusterParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterId}
+	varargs := []interface{}{ctx, clusterId, params}
 	for _, a := range reqEditors {
 		varargs = append(varargs, a)
 	}
@@ -12152,31 +12152,31 @@ func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerHibernateClu
 }
 
 // ExternalClusterAPITriggerHibernateCluster indicates an expected call of ExternalClusterAPITriggerHibernateCluster.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPITriggerHibernateCluster(ctx, clusterId interface{}, reqEditors ...interface{}) *gomock.Call {
+func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPITriggerHibernateCluster(ctx, clusterId, params interface{}, reqEditors ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterId}, reqEditors...)
+	varargs := append([]interface{}{ctx, clusterId, params}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerHibernateCluster", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ExternalClusterAPITriggerHibernateCluster), varargs...)
 }
 
 // ExternalClusterAPITriggerHibernateClusterWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerHibernateClusterWithResponse(ctx context.Context, clusterId string) (*sdk.ExternalClusterAPITriggerHibernateClusterResponse, error) {
+func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerHibernateClusterWithResponse(ctx context.Context, clusterId string, params *sdk.ExternalClusterAPITriggerHibernateClusterParams) (*sdk.ExternalClusterAPITriggerHibernateClusterResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExternalClusterAPITriggerHibernateClusterWithResponse", ctx, clusterId)
+	ret := m.ctrl.Call(m, "ExternalClusterAPITriggerHibernateClusterWithResponse", ctx, clusterId, params)
 	ret0, _ := ret[0].(*sdk.ExternalClusterAPITriggerHibernateClusterResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ExternalClusterAPITriggerHibernateClusterWithResponse indicates an expected call of ExternalClusterAPITriggerHibernateClusterWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPITriggerHibernateClusterWithResponse(ctx, clusterId interface{}) *gomock.Call {
+func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPITriggerHibernateClusterWithResponse(ctx, clusterId, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerHibernateClusterWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ExternalClusterAPITriggerHibernateClusterWithResponse), ctx, clusterId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerHibernateClusterWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ExternalClusterAPITriggerHibernateClusterWithResponse), ctx, clusterId, params)
 }
 
 // ExternalClusterAPITriggerResumeCluster mocks base method.
-func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerResumeCluster(ctx context.Context, clusterId string, body sdk.ExternalClusterAPITriggerResumeClusterJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerResumeCluster(ctx context.Context, clusterId string, params *sdk.ExternalClusterAPITriggerResumeClusterParams, body sdk.ExternalClusterAPITriggerResumeClusterJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterId, body}
+	varargs := []interface{}{ctx, clusterId, params, body}
 	for _, a := range reqEditors {
 		varargs = append(varargs, a)
 	}
@@ -12187,16 +12187,16 @@ func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerResumeCluste
 }
 
 // ExternalClusterAPITriggerResumeCluster indicates an expected call of ExternalClusterAPITriggerResumeCluster.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPITriggerResumeCluster(ctx, clusterId, body interface{}, reqEditors ...interface{}) *gomock.Call {
+func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPITriggerResumeCluster(ctx, clusterId, params, body interface{}, reqEditors ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterId, body}, reqEditors...)
+	varargs := append([]interface{}{ctx, clusterId, params, body}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerResumeCluster", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ExternalClusterAPITriggerResumeCluster), varargs...)
 }
 
 // ExternalClusterAPITriggerResumeClusterWithBody mocks base method.
-func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerResumeClusterWithBody(ctx context.Context, clusterId, contentType string, body io.Reader, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerResumeClusterWithBody(ctx context.Context, clusterId string, params *sdk.ExternalClusterAPITriggerResumeClusterParams, contentType string, body io.Reader, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterId, contentType, body}
+	varargs := []interface{}{ctx, clusterId, params, contentType, body}
 	for _, a := range reqEditors {
 		varargs = append(varargs, a)
 	}
@@ -12207,40 +12207,40 @@ func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerResumeCluste
 }
 
 // ExternalClusterAPITriggerResumeClusterWithBody indicates an expected call of ExternalClusterAPITriggerResumeClusterWithBody.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPITriggerResumeClusterWithBody(ctx, clusterId, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
+func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPITriggerResumeClusterWithBody(ctx, clusterId, params, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterId, contentType, body}, reqEditors...)
+	varargs := append([]interface{}{ctx, clusterId, params, contentType, body}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerResumeClusterWithBody", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ExternalClusterAPITriggerResumeClusterWithBody), varargs...)
 }
 
 // ExternalClusterAPITriggerResumeClusterWithBodyWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerResumeClusterWithBodyWithResponse(ctx context.Context, clusterId, contentType string, body io.Reader) (*sdk.ExternalClusterAPITriggerResumeClusterResponse, error) {
+func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerResumeClusterWithBodyWithResponse(ctx context.Context, clusterId string, params *sdk.ExternalClusterAPITriggerResumeClusterParams, contentType string, body io.Reader) (*sdk.ExternalClusterAPITriggerResumeClusterResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExternalClusterAPITriggerResumeClusterWithBodyWithResponse", ctx, clusterId, contentType, body)
+	ret := m.ctrl.Call(m, "ExternalClusterAPITriggerResumeClusterWithBodyWithResponse", ctx, clusterId, params, contentType, body)
 	ret0, _ := ret[0].(*sdk.ExternalClusterAPITriggerResumeClusterResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ExternalClusterAPITriggerResumeClusterWithBodyWithResponse indicates an expected call of ExternalClusterAPITriggerResumeClusterWithBodyWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPITriggerResumeClusterWithBodyWithResponse(ctx, clusterId, contentType, body interface{}) *gomock.Call {
+func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPITriggerResumeClusterWithBodyWithResponse(ctx, clusterId, params, contentType, body interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerResumeClusterWithBodyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ExternalClusterAPITriggerResumeClusterWithBodyWithResponse), ctx, clusterId, contentType, body)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerResumeClusterWithBodyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ExternalClusterAPITriggerResumeClusterWithBodyWithResponse), ctx, clusterId, params, contentType, body)
 }
 
 // ExternalClusterAPITriggerResumeClusterWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerResumeClusterWithResponse(ctx context.Context, clusterId string, body sdk.ExternalClusterAPITriggerResumeClusterJSONRequestBody) (*sdk.ExternalClusterAPITriggerResumeClusterResponse, error) {
+func (m *MockClientWithResponsesInterface) ExternalClusterAPITriggerResumeClusterWithResponse(ctx context.Context, clusterId string, params *sdk.ExternalClusterAPITriggerResumeClusterParams, body sdk.ExternalClusterAPITriggerResumeClusterJSONRequestBody) (*sdk.ExternalClusterAPITriggerResumeClusterResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExternalClusterAPITriggerResumeClusterWithResponse", ctx, clusterId, body)
+	ret := m.ctrl.Call(m, "ExternalClusterAPITriggerResumeClusterWithResponse", ctx, clusterId, params, body)
 	ret0, _ := ret[0].(*sdk.ExternalClusterAPITriggerResumeClusterResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ExternalClusterAPITriggerResumeClusterWithResponse indicates an expected call of ExternalClusterAPITriggerResumeClusterWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPITriggerResumeClusterWithResponse(ctx, clusterId, body interface{}) *gomock.Call {
+func (mr *MockClientWithResponsesInterfaceMockRecorder) ExternalClusterAPITriggerResumeClusterWithResponse(ctx, clusterId, params, body interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerResumeClusterWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ExternalClusterAPITriggerResumeClusterWithResponse), ctx, clusterId, body)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalClusterAPITriggerResumeClusterWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ExternalClusterAPITriggerResumeClusterWithResponse), ctx, clusterId, params, body)
 }
 
 // ExternalClusterAPIUpdateCluster mocks base method.


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Regenerates the CAST AI SDK to support new API capabilities: dry-run mode for cluster hibernate/resume operations, HPA converter configuration for workload optimization, rollout delay settings, and runtime security netflow filtering.

### Key changes
- **`castai/sdk/api.gen.go`**: 
  - Added `ExternalclusterV1OperationMode` enum (`OPERATION_MODE_DRY_RUN`, `OPERATION_MODE_DEFAULT`) and integrated `Mode` field into `ExternalClusterAPITriggerHibernateClusterParams`, `ExternalClusterAPITriggerResumeClusterParams`, and their response types to enable validation-only execution.
  - Added `WorkloadoptimizationV1HPAConverterType` enum and `HpaConverters` field to `WorkloadoptimizationV1RecommendationPolicies`, `WorkloadoptimizationV1VPAConfig`, and `WorkloadoptimizationV1VerticalOverrides` for HPA utilization-to-average-value conversion strategies.
  - Added `DelaySeconds` field to `WorkloadoptimizationV1RolloutBehaviorSettings` for configurable recommendation rollout delays.
  - Added `IncludeDstAddrs` parameter to `RuntimeSecurityAPIGetClusterWorkloadsNetflowParams` to control destination address inclusion in netflow responses.
- **`castai/sdk/client.gen.go`**: Updated `ExternalClusterAPITriggerHibernateCluster` and `ExternalClusterAPITriggerResumeCluster` method signatures to accept the new params structs with query parameter support.
- **`castai/sdk/mock/client.go`**: Synchronized mock interfaces with updated method signatures.

### Impact
**Breaking change**: The `ExternalClusterAPITriggerHibernateCluster` and `ExternalClusterAPITriggerResumeCluster` methods now require a `params` argument (can be `nil`). Code calling these methods must be updated to pass the new parameter.