### PR TITLE
feat: add retry with backoff to http client

### DIFF
--- a/castai/sdk/client/client.go
+++ b/castai/sdk/client/client.go
@@ -9,8 +9,12 @@ import (
 )
 
 func GetHttpClient(apiToken, userAgent string) (*http.Client, []func(ctx context.Context, req *http.Request) error) {
+	transport := NewRetryTransport(
+		logging.NewSubsystemLoggingHTTPTransport("CAST.AI", http.DefaultTransport),
+		DefaultRetryTransportConfig(),
+	)
 	client := &http.Client{
-		Transport: logging.NewSubsystemLoggingHTTPTransport("CAST.AI", http.DefaultTransport),
+		Transport: transport,
 		Timeout:   1 * time.Minute,
 	}
 	requestEditors := []func(ctx context.Context, req *http.Request) error{

--- a/castai/sdk/client/retry_transport.go
+++ b/castai/sdk/client/retry_transport.go
@@ -2,10 +2,15 @@ package client
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"io"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -54,7 +59,7 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			return nil, err
 		}
-		req.Body.Close()
+		_ = req.Body.Close()
 		getBody = func() (io.ReadCloser, error) {
 			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
 		}
@@ -65,6 +70,7 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	var (
 		resp    *http.Response
 		attempt int
+		lastErr error
 	)
 
 	for {
@@ -77,13 +83,26 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			cloned.Body = body
 		}
 
-		var err error
-		resp, err = t.wrapped.RoundTrip(cloned)
-		if err != nil {
-			return nil, err
-		}
-
+		resp, lastErr = t.wrapped.RoundTrip(cloned)
 		attempt++
+
+		if lastErr != nil {
+			if !isRetryableError(lastErr) {
+				return nil, lastErr
+			}
+			wait := bo.NextBackOff()
+			if wait == backoff.Stop {
+				log.Printf("[WARN] Exhausted retries for error %v after %d attempts", lastErr, attempt)
+				return nil, lastErr
+			}
+			log.Printf("[WARN] Received transient error %v, retrying in %s (attempt %d)", lastErr, wait, attempt)
+			select {
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			case <-time.After(wait):
+			}
+			continue
+		}
 
 		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
 			wait := bo.NextBackOff()
@@ -118,15 +137,55 @@ func (t *retryTransport) newBackoff() backoff.BackOff {
 	return backoff.WithMaxRetries(b, t.cfg.MaxRetries)
 }
 
+func (t *retryTransport) CloseIdleConnections() {
+	if tr, ok := t.wrapped.(interface{ CloseIdleConnections() }); ok {
+		tr.CloseIdleConnections()
+	}
+}
+
 func parseRetryAfter(header string) time.Duration {
 	if header == "" {
 		return 0
 	}
 	secs, err := strconv.Atoi(header)
-	if err != nil {
-		return 0
+	if err == nil {
+		return time.Duration(secs) * time.Second
 	}
-	return time.Duration(secs) * time.Second
+	t, err := http.ParseTime(header)
+	if err == nil {
+		d := time.Until(t)
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+	return 0
+}
+
+func isRetryableError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var syscallErr syscall.Errno
+	if errors.As(err, &syscallErr) {
+		return syscallErr == syscall.ECONNREFUSED || syscallErr == syscall.ETIMEDOUT || syscallErr == syscall.ECONNRESET
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		if urlErr.Timeout() {
+			return true
+		}
+		return isRetryableError(urlErr.Err)
+	}
+
+	return false
 }
 
 // drainBody reads any remaining data from the response body and closes it.
@@ -135,6 +194,6 @@ func parseRetryAfter(header string) time.Duration {
 func drainBody(resp *http.Response) {
 	if resp != nil && resp.Body != nil {
 		_, _ = io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 }

--- a/castai/sdk/client/retry_transport.go
+++ b/castai/sdk/client/retry_transport.go
@@ -1,0 +1,140 @@
+package client
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+)
+
+const (
+	defaultMaxRetries      = 3
+	defaultInitialInterval = 100 * time.Millisecond
+	defaultMaxInterval     = 30 * time.Second
+)
+
+type RetryTransportConfig struct {
+	MaxRetries      uint64
+	InitialInterval time.Duration
+	MaxInterval     time.Duration
+}
+
+func DefaultRetryTransportConfig() RetryTransportConfig {
+	return RetryTransportConfig{
+		MaxRetries:      defaultMaxRetries,
+		InitialInterval: defaultInitialInterval,
+		MaxInterval:     defaultMaxInterval,
+	}
+}
+
+type retryTransport struct {
+	wrapped http.RoundTripper
+	cfg     RetryTransportConfig
+}
+
+func NewRetryTransport(wrapped http.RoundTripper, cfg RetryTransportConfig) http.RoundTripper {
+	return &retryTransport{
+		wrapped: wrapped,
+		cfg:     cfg,
+	}
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// GetBody is set by the standard library for retryable requests (e.g., from NewRequest).
+	// If not available, we need to buffer the body ourselves to allow retries.
+	var getBody func() (io.ReadCloser, error)
+	if req.GetBody != nil {
+		getBody = req.GetBody
+	} else if req.Body != nil && req.Body != http.NoBody {
+		bodyBytes, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body.Close()
+		getBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+		}
+	}
+
+	bo := t.newBackoff()
+
+	var (
+		resp    *http.Response
+		attempt int
+	)
+
+	for {
+		cloned := req.Clone(req.Context())
+		if getBody != nil {
+			body, err := getBody()
+			if err != nil {
+				return nil, err
+			}
+			cloned.Body = body
+		}
+
+		var err error
+		resp, err = t.wrapped.RoundTrip(cloned)
+		if err != nil {
+			return nil, err
+		}
+
+		attempt++
+
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			wait := bo.NextBackOff()
+			if wait == backoff.Stop {
+				log.Printf("[WARN] Exhausted retries for status %d after %d attempts", resp.StatusCode, attempt)
+				return resp, nil
+			}
+			if resp.StatusCode == http.StatusTooManyRequests {
+				if retryAfter := parseRetryAfter(resp.Header.Get("Retry-After")); retryAfter > 0 {
+					wait = retryAfter
+				}
+			}
+			log.Printf("[WARN] Received status %d, retrying in %s (attempt %d)", resp.StatusCode, wait, attempt)
+			drainBody(resp)
+			select {
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			case <-time.After(wait):
+			}
+			continue
+		}
+
+		return resp, nil
+	}
+}
+
+func (t *retryTransport) newBackoff() backoff.BackOff {
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = t.cfg.InitialInterval
+	b.MaxInterval = t.cfg.MaxInterval
+	b.Reset()
+	return backoff.WithMaxRetries(b, t.cfg.MaxRetries)
+}
+
+func parseRetryAfter(header string) time.Duration {
+	if header == "" {
+		return 0
+	}
+	secs, err := strconv.Atoi(header)
+	if err != nil {
+		return 0
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// drainBody reads any remaining data from the response body and closes it.
+// This is necessary to allow the underlying TCP connection to be reused.
+// See: https://golang.org/pkg/net/http/#Response
+func drainBody(resp *http.Response) {
+	if resp != nil && resp.Body != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+}

--- a/castai/sdk/client/retry_transport_test.go
+++ b/castai/sdk/client/retry_transport_test.go
@@ -1,0 +1,296 @@
+package client
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type mockRoundTripper struct {
+	responses []*http.Response
+	index     int
+	calls     int
+}
+
+func (m *mockRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	m.calls++
+	if m.index >= len(m.responses) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	}
+	resp := m.responses[m.index]
+	m.index++
+	return resp, nil
+}
+
+func makeResp(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func fastConfig() RetryTransportConfig {
+	return RetryTransportConfig{
+		MaxRetries:      3,
+		InitialInterval: time.Millisecond,
+		MaxInterval:     10 * time.Millisecond,
+	}
+}
+
+func TestRetryTransport_NoRetryOnSuccess(t *testing.T) {
+	mock := &mockRoundTripper{
+		responses: []*http.Response{makeResp(200, "ok")},
+	}
+	rt := NewRetryTransport(mock, fastConfig())
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	resp, err := rt.RoundTrip(req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if mock.calls != 1 {
+		t.Fatalf("expected 1 call, got %d", mock.calls)
+	}
+}
+
+func TestRetryTransport_NoRetryOnClientError(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{"400", 400},
+		{"401", 401},
+		{"403", 403},
+		{"404", 404},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &mockRoundTripper{
+				responses: []*http.Response{makeResp(tc.status, "")},
+			}
+			rt := NewRetryTransport(mock, fastConfig())
+
+			req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+			resp, err := rt.RoundTrip(req)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp.StatusCode != tc.status {
+				t.Fatalf("expected %d, got %d", tc.status, resp.StatusCode)
+			}
+			if mock.calls != 1 {
+				t.Fatalf("expected 1 call, got %d", mock.calls)
+			}
+		})
+	}
+}
+
+func TestRetryTransport_RetriesOn500(t *testing.T) {
+	mock := &mockRoundTripper{
+		responses: []*http.Response{
+			makeResp(500, "err"),
+			makeResp(500, "err"),
+			makeResp(200, "ok"),
+		},
+	}
+	rt := NewRetryTransport(mock, fastConfig())
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	resp, err := rt.RoundTrip(req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if mock.calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", mock.calls)
+	}
+}
+
+func TestRetryTransport_ExhaustsRetriesOn500(t *testing.T) {
+	cfg := fastConfig()
+	// maxRetries=3 means 3 retries after the first attempt = 4 total
+	responses := make([]*http.Response, int(cfg.MaxRetries)+2)
+	for i := range responses {
+		responses[i] = makeResp(503, "err")
+	}
+	mock := &mockRoundTripper{responses: responses}
+	rt := NewRetryTransport(mock, cfg)
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	resp, err := rt.RoundTrip(req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 503 {
+		t.Fatalf("expected 503, got %d", resp.StatusCode)
+	}
+	expectedCalls := int(cfg.MaxRetries) + 1
+	if mock.calls != expectedCalls {
+		t.Fatalf("expected %d calls, got %d", expectedCalls, mock.calls)
+	}
+}
+
+func TestRetryTransport_RetriesOn429(t *testing.T) {
+	mock := &mockRoundTripper{
+		responses: []*http.Response{
+			makeResp(429, "rate limited"),
+			makeResp(200, "ok"),
+		},
+	}
+	rt := NewRetryTransport(mock, fastConfig())
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	resp, err := rt.RoundTrip(req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if mock.calls != 2 {
+		t.Fatalf("expected 2 calls, got %d", mock.calls)
+	}
+}
+
+func TestRetryTransport_RespectsRetryAfterHeader(t *testing.T) {
+	r429 := makeResp(429, "")
+	r429.Header.Set("Retry-After", "0")
+	mock := &mockRoundTripper{
+		responses: []*http.Response{
+			r429,
+			makeResp(200, "ok"),
+		},
+	}
+	rt := NewRetryTransport(mock, fastConfig())
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	resp, err := rt.RoundTrip(req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestRetryTransport_ResendsBodyOnRetry(t *testing.T) {
+	var bodies []string
+	mock := &mockRoundTripper{}
+	mock.responses = []*http.Response{
+		makeResp(500, ""),
+		makeResp(200, "ok"),
+	}
+
+	captureTransport := &capturingTransport{
+		wrapped: mock,
+		capture: &bodies,
+	}
+	rt := NewRetryTransport(captureTransport, fastConfig())
+
+	// Use http.NewRequest which sets GetBody for retryable requests
+	req, _ := http.NewRequest(http.MethodPost, "http://example.com", strings.NewReader("hello"))
+	resp, err := rt.RoundTrip(req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 captured bodies, got %d", len(bodies))
+	}
+	for i, b := range bodies {
+		if b != "hello" {
+			t.Fatalf("attempt %d: expected body 'hello', got %q", i, b)
+		}
+	}
+}
+
+func TestRetryTransport_ResendsBodyOnRetryWithoutGetBody(t *testing.T) {
+	var bodies []string
+	mock := &mockRoundTripper{}
+	mock.responses = []*http.Response{
+		makeResp(500, ""),
+		makeResp(200, "ok"),
+	}
+
+	captureTransport := &capturingTransport{
+		wrapped: mock,
+		capture: &bodies,
+	}
+	rt := NewRetryTransport(captureTransport, fastConfig())
+
+	// Manually create request without GetBody set (simulates some custom request builders)
+	req, _ := http.NewRequest(http.MethodPost, "http://example.com", nil)
+	req.Body = io.NopCloser(strings.NewReader("hello"))
+	req.GetBody = nil // Ensure GetBody is not set
+
+	resp, err := rt.RoundTrip(req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 captured bodies, got %d", len(bodies))
+	}
+	for i, b := range bodies {
+		if b != "hello" {
+			t.Fatalf("attempt %d: expected body 'hello', got %q", i, b)
+		}
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected time.Duration
+	}{
+		{"", 0},
+		{"0", 0},
+		{"5", 5 * time.Second},
+		{"120", 120 * time.Second},
+		{"invalid", 0},
+	}
+	for _, tc := range tests {
+		got := parseRetryAfter(tc.input)
+		if got != tc.expected {
+			t.Errorf("parseRetryAfter(%q) = %v, want %v", tc.input, got, tc.expected)
+		}
+	}
+}
+
+type capturingTransport struct {
+	wrapped http.RoundTripper
+	capture *[]string
+}
+
+func (c *capturingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Body != nil {
+		b, _ := io.ReadAll(req.Body)
+		req.Body.Close()
+		*c.capture = append(*c.capture, string(b))
+		req.Body = io.NopCloser(strings.NewReader(string(b)))
+	}
+	return c.wrapped.RoundTrip(req)
+}

--- a/castai/sdk/client/retry_transport_test.go
+++ b/castai/sdk/client/retry_transport_test.go
@@ -1,9 +1,13 @@
 package client
 
 import (
+	"context"
+	"errors"
 	"io"
+	"net"
 	"net/http"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -26,6 +30,33 @@ func (m *mockRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
 	m.index++
 	return resp, nil
 }
+
+type mockErrRoundTripper struct {
+	errors []error
+	index  int
+	calls  int
+}
+
+func (m *mockErrRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	m.calls++
+	if m.index >= len(m.errors) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	}
+	err := m.errors[m.index]
+	m.index++
+	return nil, err
+}
+
+type timeoutError struct {
+	msg string
+}
+
+func (e *timeoutError) Error() string   { return e.msg }
+func (e *timeoutError) Temporary() bool { return false }
+func (e *timeoutError) Timeout() bool   { return true }
 
 func makeResp(status int, body string) *http.Response {
 	return &http.Response{
@@ -261,6 +292,144 @@ func TestRetryTransport_ResendsBodyOnRetryWithoutGetBody(t *testing.T) {
 	}
 }
 
+func TestRetryTransport_RetriesOnNetworkError(t *testing.T) {
+	mock := &mockErrRoundTripper{
+		errors: []error{
+			&timeoutError{msg: "connection refused"},
+			&timeoutError{msg: "connection refused"},
+		},
+	}
+	rt := NewRetryTransport(mock, fastConfig())
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	resp, err := rt.RoundTrip(req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if mock.calls != 3 {
+		t.Fatalf("expected 3 calls (2 errors + 1 success), got %d", mock.calls)
+	}
+}
+
+func TestRetryTransport_ExhaustsRetriesOnNetworkError(t *testing.T) {
+	cfg := fastConfig()
+	// maxRetries=3 means 3 retries after the first attempt = 4 total
+	errs := make([]error, int(cfg.MaxRetries)+2)
+	for i := range errs {
+		errs[i] = &timeoutError{msg: "connection refused"}
+	}
+	mock := &mockErrRoundTripper{errors: errs}
+	rt := NewRetryTransport(mock, cfg)
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	_, err := rt.RoundTrip(req)
+
+	if err == nil {
+		t.Fatal("expected error got nil")
+	}
+	expectedCalls := int(cfg.MaxRetries) + 1
+	if mock.calls != expectedCalls {
+		t.Fatalf("expected %d calls, got %d", expectedCalls, mock.calls)
+	}
+}
+
+func TestRetryTransport_NoRetryOnNonTransientError(t *testing.T) {
+	mock := &mockErrRoundTripper{
+		errors: []error{errors.New("permanent failure")},
+	}
+	rt := NewRetryTransport(mock, fastConfig())
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	_, err := rt.RoundTrip(req)
+
+	if err == nil {
+		t.Fatal("expected error got nil")
+	}
+	if mock.calls != 1 {
+		t.Fatalf("expected 1 call (no retries for non-transient error), got %d", mock.calls)
+	}
+}
+
+func TestRetryTransport_ContextCancellationNotRetried(t *testing.T) {
+	mock := &mockErrRoundTripper{
+		errors: []error{context.Canceled},
+	}
+	rt := NewRetryTransport(mock, fastConfig())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+	_, err := rt.RoundTrip(req)
+
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled got %v", err)
+	}
+	if mock.calls != 1 {
+		t.Fatalf("expected 1 call, got %d", mock.calls)
+	}
+}
+
+func TestRetryTransport_NoRetryOnTLSError(t *testing.T) {
+	// TLS errors are not retryable (not temporary)
+	mock := &mockErrRoundTripper{
+		errors: []error{&net.OpError{Op: "remote error", Err: errors.New("tls: bad certificate")}},
+	}
+	rt := NewRetryTransport(mock, fastConfig())
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	_, err := rt.RoundTrip(req)
+
+	if err == nil {
+		t.Fatal("expected error got nil")
+	}
+	if mock.calls != 1 {
+		t.Fatalf("expected 1 call (no retries for TLS error), got %d", mock.calls)
+	}
+}
+
+func TestRetryTransport_SyscallErrorRetry(t *testing.T) {
+	mock := &mockErrRoundTripper{
+		errors: []error{
+			syscall.Errno(syscall.ECONNREFUSED),
+			syscall.Errno(syscall.ECONNRESET),
+		},
+	}
+	rt := NewRetryTransport(mock, fastConfig())
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	resp, err := rt.RoundTrip(req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if mock.calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", mock.calls)
+	}
+}
+
+func TestRetryTransport_CloseIdleConnectionsDelegates(t *testing.T) {
+	mock := &mockClosableTransport{}
+	rt := NewRetryTransport(mock, fastConfig())
+
+	type closeIdler interface{ CloseIdleConnections() }
+	if tr, ok := rt.(closeIdler); ok {
+		tr.CloseIdleConnections()
+	} else {
+		t.Fatal("retryTransport does not implement CloseIdleConnections")
+	}
+
+	if !mock.closeCalled {
+		t.Fatal("expected CloseIdleConnections to be called on wrapped transport")
+	}
+}
+
 func TestParseRetryAfter(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -280,6 +449,23 @@ func TestParseRetryAfter(t *testing.T) {
 	}
 }
 
+func TestParseRetryAfter_HTTPDate(t *testing.T) {
+	// Use a date in the future
+	future := time.Now().UTC().Add(5 * time.Second)
+	got := parseRetryAfter(future.Format(http.TimeFormat))
+	// Allow 1 second tolerance due to parsing overhead
+	if got < 4*time.Second || got > 6*time.Second {
+		t.Errorf("parseRetryAfter(date) = %v, want ~5s", got)
+	}
+
+	// Past date should return 0
+	past := time.Now().UTC().Add(-5 * time.Second)
+	got = parseRetryAfter(past.Format(http.TimeFormat))
+	if got != 0 {
+		t.Errorf("parseRetryAfter(past date) = %v, want 0", got)
+	}
+}
+
 type capturingTransport struct {
 	wrapped http.RoundTripper
 	capture *[]string
@@ -288,9 +474,18 @@ type capturingTransport struct {
 func (c *capturingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req.Body != nil {
 		b, _ := io.ReadAll(req.Body)
-		req.Body.Close()
+		_ = req.Body.Close()
 		*c.capture = append(*c.capture, string(b))
 		req.Body = io.NopCloser(strings.NewReader(string(b)))
 	}
 	return c.wrapped.RoundTrip(req)
+}
+
+type mockClosableTransport struct {
+	mockRoundTripper
+	closeCalled bool
+}
+
+func (m *mockClosableTransport) CloseIdleConnections() {
+	m.closeCalled = true
 }


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds automatic retries with exponential backoff to the provider's HTTP client. The client now retries transient network errors, HTTP 5xx responses, and `429 Too Many Requests` responses, improving resilience against temporary API unavailability and rate limiting.

### Why
Transient network failures or brief API rate limiting can cause Terraform plans and applies to fail unexpectedly. Retrying these requests reduces spurious failures and improves the reliability of long-running Terraform operations.

### Key changes
- `castai/sdk/client/client.go`: Wrapped the logging HTTP transport in `NewRetryTransport` inside `GetHttpClient`.
- `castai/sdk/client/retry_transport.go` (new): Added `retryTransport`, an `http.RoundTripper` implementation that:
  - Retries on HTTP 500+ and `429` responses, draining response bodies to reuse connections.
  - Respects the `Retry-After` header when handling `429` responses.
  - Retries transient network errors including `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, and other timeout errors.
  - Preserves and resends request bodies on retry, including for requests without `GetBody` set.
  - Uses exponential backoff with configurable `MaxRetries`, `InitialInterval`, and `MaxInterval`.
  - Delegates `CloseIdleConnections()` to the wrapped transport.
- `castai/sdk/client/retry_transport_test.go` (new): Added unit tests for retry logic, `Retry-After` header parsing, request body preservation, and connection closing delegation.

### Impact
- **Retry defaults:** Up to 3 retries with a 100 ms initial backoff and a 30 s maximum backoff interval.
- **Non-retryable errors:** Client errors (4xx), context cancellation, deadline exceeded, and TLS errors are not retried.
- **Dependency:** Introduces `github.com/cenkalti/backoff/v4` as a new dependency.
- **Behavior change:** Previously failing requests that failed due to transient issues may now succeed after a short delay.