### PR TITLE
feat: add support for edge location networking

### DIFF
--- a/castai/resource_edge_location.go
+++ b/castai/resource_edge_location.go
@@ -13,13 +13,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/samber/lo"
 
 	"github.com/castai/terraform-provider-castai/castai/sdk/omni"
@@ -47,6 +47,7 @@ type edgeLocationModel struct {
 	Region           types.String       `tfsdk:"region"`
 	ControlPlaneMode types.String       `tfsdk:"control_plane_mode"`
 	ControlPlane     *controlPlaneModel `tfsdk:"control_plane"`
+	Networking       *networkingModel   `tfsdk:"networking"`
 	Zones            []zoneModel        `tfsdk:"zones"`
 	AWS              *awsModel          `tfsdk:"aws"`
 	GCP              *gcpModel          `tfsdk:"gcp"`
@@ -57,6 +58,10 @@ type edgeLocationModel struct {
 
 type controlPlaneModel struct {
 	Ha types.Bool `tfsdk:"ha"`
+}
+
+type networkingModel struct {
+	TunneledCIDRs types.List `tfsdk:"tunneled_cidrs"`
 }
 
 type zoneModel struct {
@@ -243,9 +248,17 @@ func (r *edgeLocationResource) Schema(_ context.Context, _ resource.SchemaReques
 					"ha": schema.BoolAttribute{
 						Required:    true,
 						Description: "Whether to use HA mode for control plane. If not set, default is HA.",
-						PlanModifiers: []planmodifier.Bool{
-							boolplanmodifier.RequiresReplace(),
-						},
+					},
+				},
+			},
+			"networking": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Edge cluster networking configuration.",
+				Attributes: map[string]schema.Attribute{
+					"tunneled_cidrs": schema.ListAttribute{
+						Optional:    true,
+						ElementType: types.StringType,
+						Description: "List of destination CIDR blocks whose traffic should be routed through the main cluster instead of directly from the edge cluster.",
 					},
 				},
 			},
@@ -469,12 +482,10 @@ func (r *edgeLocationResource) Create(ctx context.Context, req resource.CreateRe
 		createReq.Description = lo.ToPtr(plan.Description.ValueString())
 	}
 
-	if plan.ControlPlane != nil {
-		createReq.EdgeClusterSpec = &omni.EdgeClusterSpec{
-			ControlPlane: &omni.EdgeClusterControlPlane{
-				Ha: plan.ControlPlane.Ha.ValueBoolPointer(),
-			},
-		}
+	createReq.EdgeClusterSpec, diags = r.toEdgeClusterSpec(ctx, plan.ControlPlane, plan.Networking)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Map cloud provider specific configurations.
@@ -562,9 +573,16 @@ func (r *edgeLocationResource) Read(ctx context.Context, req resource.ReadReques
 	if edgeLocation.ControlPlaneMode != nil {
 		state.ControlPlaneMode = types.StringValue(string(*edgeLocation.ControlPlaneMode))
 	}
-	if edgeLocation.EdgeClusterSpec != nil && edgeLocation.EdgeClusterSpec.ControlPlane != nil {
-		state.ControlPlane = &controlPlaneModel{
-			Ha: types.BoolPointerValue(edgeLocation.EdgeClusterSpec.ControlPlane.Ha),
+	if edgeLocation.EdgeClusterSpec != nil {
+		if edgeLocation.EdgeClusterSpec.ControlPlane != nil {
+			state.ControlPlane = &controlPlaneModel{
+				Ha: types.BoolPointerValue(edgeLocation.EdgeClusterSpec.ControlPlane.Ha),
+			}
+		}
+		if edgeLocation.EdgeClusterSpec.Networking != nil && edgeLocation.EdgeClusterSpec.Networking.TunneledCidrs != nil {
+			cidrs, d := types.ListValueFrom(ctx, types.StringType, *edgeLocation.EdgeClusterSpec.Networking.TunneledCidrs)
+			resp.Diagnostics.Append(d...)
+			state.Networking = &networkingModel{TunneledCIDRs: cidrs}
 		}
 	}
 
@@ -627,6 +645,14 @@ func (r *edgeLocationResource) Update(ctx context.Context, req resource.UpdateRe
 		diags diag.Diagnostics
 		mc    ModelWithCredentials
 	)
+
+	updateReq.EdgeClusterSpec, diags = r.toEdgeClusterSpec(ctx, plan.ControlPlane, plan.Networking)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Include cloud provider config if it or credentials has changed.
 	switch {
 	case plan.AWS != nil && (!plan.AWS.Equal(state.AWS) || credentialsChanged):
 		updateReq.Aws, diags = r.toAWS(ctx, plan.AWS, config.AWS)
@@ -776,6 +802,33 @@ func (r *edgeLocationResource) ImportState(ctx context.Context, req resource.Imp
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("organization_id"), ids[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("cluster_id"), ids[1])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), ids[2])...)
+}
+
+func (r *edgeLocationResource) toEdgeClusterSpec(ctx context.Context, cp *controlPlaneModel, net *networkingModel) (*omni.EdgeClusterSpec, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if cp == nil && net == nil {
+		return nil, diags
+	}
+
+	spec := &omni.EdgeClusterSpec{}
+	if cp != nil {
+		spec.ControlPlane = &omni.EdgeClusterControlPlane{
+			Ha: cp.Ha.ValueBoolPointer(),
+		}
+	}
+	
+	opts := basetypes.CollectionLengthOptions{UnhandledNullAsZero: true, UnhandledUnknownAsZero: true}
+	if net != nil && net.TunneledCIDRs.Length(opts) > 0 {
+		var items []string
+		diags.Append(net.TunneledCIDRs.ElementsAs(ctx, &items, false)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		spec.Networking = &omni.EdgeClusterNetworking{
+			TunneledCidrs: &items,
+		}
+	}
+	return spec, diags
 }
 
 func (r *edgeLocationResource) toZones(zones []zoneModel) []omni.Zone {

--- a/castai/resource_edge_location.go
+++ b/castai/resource_edge_location.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/samber/lo"
 
 	"github.com/castai/terraform-provider-castai/castai/sdk/omni"
@@ -816,11 +815,10 @@ func (r *edgeLocationResource) toEdgeClusterSpec(ctx context.Context, cp *contro
 			Ha: cp.Ha.ValueBoolPointer(),
 		}
 	}
-	
-	opts := basetypes.CollectionLengthOptions{UnhandledNullAsZero: true, UnhandledUnknownAsZero: true}
-	if net != nil && net.TunneledCIDRs.Length(opts) > 0 {
+
+	if net != nil {
 		var items []string
-		diags.Append(net.TunneledCIDRs.ElementsAs(ctx, &items, false)...)
+		diags.Append(net.TunneledCIDRs.ElementsAs(ctx, &items, true)...)
 		if diags.HasError() {
 			return nil, diags
 		}

--- a/castai/resource_edge_location.go
+++ b/castai/resource_edge_location.go
@@ -13,7 +13,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -59,8 +61,22 @@ type controlPlaneModel struct {
 	Ha types.Bool `tfsdk:"ha"`
 }
 
+func (m *controlPlaneModel) Equal(other *controlPlaneModel) bool {
+	if m == nil || other == nil {
+		return m == other
+	}
+	return m.Ha.Equal(other.Ha)
+}
+
 type networkingModel struct {
 	TunneledCIDRs types.List `tfsdk:"tunneled_cidrs"`
+}
+
+func (m *networkingModel) Equal(other *networkingModel) bool {
+	if m == nil || other == nil {
+		return m == other
+	}
+	return m.TunneledCIDRs.Equal(other.TunneledCIDRs)
 }
 
 type zoneModel struct {
@@ -242,11 +258,19 @@ func (r *edgeLocationResource) Schema(_ context.Context, _ resource.SchemaReques
 			},
 			"control_plane": schema.SingleNestedAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Control plane configuration. Only valid when control_plane_mode is SHARED.",
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
 				Attributes: map[string]schema.Attribute{
 					"ha": schema.BoolAttribute{
-						Required:    true,
+						Optional:    true,
+						Computed:    true,
 						Description: "Whether to use HA mode for control plane. If not set, default is HA.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},
@@ -645,7 +669,7 @@ func (r *edgeLocationResource) Update(ctx context.Context, req resource.UpdateRe
 		mc    ModelWithCredentials
 	)
 
-	updateReq.EdgeClusterSpec, diags = r.toEdgeClusterSpec(ctx, plan.ControlPlane, plan.Networking)
+	updateReq.EdgeClusterSpec, diags = r.edgeClusterSpecUpdate(ctx, plan, state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -801,6 +825,41 @@ func (r *edgeLocationResource) ImportState(ctx context.Context, req resource.Imp
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("organization_id"), ids[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("cluster_id"), ids[1])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), ids[2])...)
+}
+
+// edgeClusterSpecUpdate builds an EdgeClusterSpec containing only the sub-blocks that
+// changed between plan and state. Removed blocks are reset to API defaults.
+// Returns nil when nothing changed so the field is omitted from the PATCH request.
+func (r *edgeLocationResource) edgeClusterSpecUpdate(ctx context.Context, plan, state edgeLocationModel) (*omni.EdgeClusterSpec, diag.Diagnostics) {
+	var (
+		diags      diag.Diagnostics
+		cpChanged  = !plan.ControlPlane.Equal(state.ControlPlane)
+		netChanged = !plan.Networking.Equal(state.Networking)
+	)
+
+	if !cpChanged && !netChanged {
+		return nil, diags
+	}
+
+	spec := &omni.EdgeClusterSpec{}
+	if cpChanged {
+		spec.ControlPlane = &omni.EdgeClusterControlPlane{Ha: lo.ToPtr(true)}
+		if plan.ControlPlane != nil {
+			spec.ControlPlane.Ha = plan.ControlPlane.Ha.ValueBoolPointer()
+		}
+	}
+	if netChanged {
+		spec.Networking = &omni.EdgeClusterNetworking{TunneledCidrs: &[]string{}}
+		if plan.Networking != nil {
+			var items []string
+			diags.Append(plan.Networking.TunneledCIDRs.ElementsAs(ctx, &items, true)...)
+			if diags.HasError() {
+				return nil, diags
+			}
+			spec.Networking.TunneledCidrs = &items
+		}
+	}
+	return spec, diags
 }
 
 func (r *edgeLocationResource) toEdgeClusterSpec(ctx context.Context, cp *controlPlaneModel, net *networkingModel) (*omni.EdgeClusterSpec, diag.Diagnostics) {

--- a/castai/resource_edge_location.go
+++ b/castai/resource_edge_location.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -258,11 +257,7 @@ func (r *edgeLocationResource) Schema(_ context.Context, _ resource.SchemaReques
 			},
 			"control_plane": schema.SingleNestedAttribute{
 				Optional:    true,
-				Computed:    true,
 				Description: "Control plane configuration. Only valid when control_plane_mode is SHARED.",
-				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.UseStateForUnknown(),
-				},
 				Attributes: map[string]schema.Attribute{
 					"ha": schema.BoolAttribute{
 						Optional:    true,
@@ -597,7 +592,9 @@ func (r *edgeLocationResource) Read(ctx context.Context, req resource.ReadReques
 		state.ControlPlaneMode = types.StringValue(string(*edgeLocation.ControlPlaneMode))
 	}
 	if edgeLocation.EdgeClusterSpec != nil {
-		if edgeLocation.EdgeClusterSpec.ControlPlane != nil {
+		// Only sync control_plane from API if it was already managed in state.
+		// Otherwise, we'd cause perpetual drift for users who never set the block.
+		if state.ControlPlane != nil && edgeLocation.EdgeClusterSpec.ControlPlane != nil {
 			state.ControlPlane = &controlPlaneModel{
 				Ha: types.BoolPointerValue(edgeLocation.EdgeClusterSpec.ControlPlane.Ha),
 			}

--- a/castai/resource_edge_location_test.go
+++ b/castai/resource_edge_location_test.go
@@ -134,7 +134,7 @@ func TestAccCloudAgnostic_ResourceEdgeLocationAWSImpersonation(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "aws.security_group_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "credentials_revision", "1"),
-					resource.TestCheckResourceAttr(resourceName, "networking.tunneled_cidrs.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "networking"),
 				),
 			},
 			{
@@ -168,7 +168,7 @@ func TestAccCloudAgnostic_ResourceEdgeLocationAWSImpersonation(t *testing.T) {
 			{
 				Config: testAccEdgeLocationAWSImpersonationConfig(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "networking.tunneled_cidrs.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "networking"),
 				),
 			},
 		},
@@ -259,11 +259,17 @@ func testAccEdgeLocationAWSImpersonationConfigWithParams(rName, clusterName, des
 
 	zonesConfig, subnetConfig := formatAWSZonesAndSubnets(zones)
 
-	quoted := make([]string, 0, len(tunneledCIDRs))
-	for _, c := range tunneledCIDRs {
-		quoted = append(quoted, fmt.Sprintf("%q", c))
+	networkingBlock := ""
+	if tunneledCIDRs != nil {
+		quoted := make([]string, 0, len(tunneledCIDRs))
+		for _, c := range tunneledCIDRs {
+			quoted = append(quoted, fmt.Sprintf("%q", c))
+		}
+		networkingBlock = fmt.Sprintf(`
+  networking = {
+    tunneled_cidrs = [%s]
+  }`, strings.Join(quoted, ", "))
 	}
-	tunneledCIDRsConfig := strings.Join(quoted, ", ")
 
 	return ConfigCompose(testOmniClusterConfig(clusterName), fmt.Sprintf(`
 resource "castai_edge_location" "test" {
@@ -274,10 +280,7 @@ resource "castai_edge_location" "test" {
   region          	 = "us-east-1"
   control_plane_mode = "SHARED"
 %[3]s
-
-  networking = {
-    tunneled_cidrs = [%[7]s]
-  }
+%[7]s
 
   aws = {
     account_id               = "123456789012"
@@ -291,7 +294,7 @@ resource "castai_edge_location" "test" {
     }
   }
 }
-`, rName, description, zonesConfig, subnetConfig, organizationID, roleArn, tunneledCIDRsConfig))
+`, rName, description, zonesConfig, subnetConfig, organizationID, roleArn, networkingBlock))
 }
 
 func testAccEdgeLocationGCPImpersonationConfig(rName, clusterName string) string {

--- a/castai/resource_edge_location_test.go
+++ b/castai/resource_edge_location_test.go
@@ -135,6 +135,7 @@ func TestAccCloudAgnostic_ResourceEdgeLocationAWSImpersonation(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "credentials_revision", "1"),
 					resource.TestCheckNoResourceAttr(resourceName, "networking"),
+					resource.TestCheckNoResourceAttr(resourceName, "control_plane"),
 				),
 			},
 			{
@@ -163,12 +164,14 @@ func TestAccCloudAgnostic_ResourceEdgeLocationAWSImpersonation(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "networking.tunneled_cidrs.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "networking.tunneled_cidrs.0", "10.10.0.0/16"),
 					resource.TestCheckResourceAttr(resourceName, "networking.tunneled_cidrs.1", "192.168.0.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "control_plane.ha", "false"),
 				),
 			},
 			{
 				Config: testAccEdgeLocationAWSImpersonationConfig(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr(resourceName, "networking"),
+					resource.TestCheckNoResourceAttr(resourceName, "control_plane"),
 				),
 			},
 		},
@@ -245,16 +248,17 @@ func formatAWSZonesAndSubnets(zones []string) (zonesConfig string, subnetConfig 
 
 func testAccEdgeLocationAWSImpersonationConfig(rName, clusterName string) string {
 	return testAccEdgeLocationAWSImpersonationConfigWithParams(rName, clusterName, "Test edge location impersonation",
-		[]string{"us-east-1a", "us-east-1b"}, "arn:aws:iam::123456789012:role/castai-omni-edge", nil)
+		[]string{"us-east-1a", "us-east-1b"}, "arn:aws:iam::123456789012:role/castai-omni-edge", nil, nil)
 }
 
 func testAccEdgeLocationAWSImpersonationUpdated(rName, clusterName string) string {
+	ha := false
 	return testAccEdgeLocationAWSImpersonationConfigWithParams(rName, clusterName, "Updated edge location impersonation",
 		[]string{"us-east-1a", "us-east-1b", "us-east-1c"}, "arn:aws:iam::123456789012:role/castai-omni-edge-updated",
-		[]string{"10.10.0.0/16", "192.168.0.0/24"})
+		[]string{"10.10.0.0/16", "192.168.0.0/24"}, &ha)
 }
 
-func testAccEdgeLocationAWSImpersonationConfigWithParams(rName, clusterName, description string, zones []string, roleArn string, tunneledCIDRs []string) string {
+func testAccEdgeLocationAWSImpersonationConfigWithParams(rName, clusterName, description string, zones []string, roleArn string, tunneledCIDRs []string, ha *bool) string {
 	organizationID := testAccGetOrganizationID()
 
 	zonesConfig, subnetConfig := formatAWSZonesAndSubnets(zones)
@@ -271,6 +275,14 @@ func testAccEdgeLocationAWSImpersonationConfigWithParams(rName, clusterName, des
   }`, strings.Join(quoted, ", "))
 	}
 
+	controlPlaneBlock := ""
+	if ha != nil {
+		controlPlaneBlock = fmt.Sprintf(`
+  control_plane = {
+    ha = %t
+  }`, *ha)
+	}
+
 	return ConfigCompose(testOmniClusterConfig(clusterName), fmt.Sprintf(`
 resource "castai_edge_location" "test" {
   organization_id 	 = %[5]q
@@ -281,6 +293,7 @@ resource "castai_edge_location" "test" {
   control_plane_mode = "SHARED"
 %[3]s
 %[7]s
+%[8]s
 
   aws = {
     account_id               = "123456789012"
@@ -294,7 +307,7 @@ resource "castai_edge_location" "test" {
     }
   }
 }
-`, rName, description, zonesConfig, subnetConfig, organizationID, roleArn, networkingBlock))
+`, rName, description, zonesConfig, subnetConfig, organizationID, roleArn, networkingBlock, controlPlaneBlock))
 }
 
 func testAccEdgeLocationGCPImpersonationConfig(rName, clusterName string) string {

--- a/castai/resource_edge_location_test.go
+++ b/castai/resource_edge_location_test.go
@@ -134,6 +134,7 @@ func TestAccCloudAgnostic_ResourceEdgeLocationAWSImpersonation(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "aws.security_group_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "credentials_revision", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.tunneled_cidrs.#", "0"),
 				),
 			},
 			{
@@ -159,6 +160,9 @@ func TestAccCloudAgnostic_ResourceEdgeLocationAWSImpersonation(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "zones.2.id", "us-east-1c"),
 					resource.TestCheckResourceAttr(resourceName, "zones.2.name", "us-east-1c"),
 					resource.TestCheckResourceAttr(resourceName, "aws.role_arn", "arn:aws:iam::123456789012:role/castai-omni-edge-updated"),
+					resource.TestCheckResourceAttr(resourceName, "networking.tunneled_cidrs.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "networking.tunneled_cidrs.0", "10.10.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "networking.tunneled_cidrs.1", "192.168.0.0/24"),
 				),
 			},
 		},
@@ -235,18 +239,25 @@ func formatAWSZonesAndSubnets(zones []string) (zonesConfig string, subnetConfig 
 
 func testAccEdgeLocationAWSImpersonationConfig(rName, clusterName string) string {
 	return testAccEdgeLocationAWSImpersonationConfigWithParams(rName, clusterName, "Test edge location impersonation",
-		[]string{"us-east-1a", "us-east-1b"}, "arn:aws:iam::123456789012:role/castai-omni-edge")
+		[]string{"us-east-1a", "us-east-1b"}, "arn:aws:iam::123456789012:role/castai-omni-edge", nil)
 }
 
 func testAccEdgeLocationAWSImpersonationUpdated(rName, clusterName string) string {
 	return testAccEdgeLocationAWSImpersonationConfigWithParams(rName, clusterName, "Updated edge location impersonation",
-		[]string{"us-east-1a", "us-east-1b", "us-east-1c"}, "arn:aws:iam::123456789012:role/castai-omni-edge-updated")
+		[]string{"us-east-1a", "us-east-1b", "us-east-1c"}, "arn:aws:iam::123456789012:role/castai-omni-edge-updated",
+		[]string{"10.10.0.0/16", "192.168.0.0/24"})
 }
 
-func testAccEdgeLocationAWSImpersonationConfigWithParams(rName, clusterName, description string, zones []string, roleArn string) string {
+func testAccEdgeLocationAWSImpersonationConfigWithParams(rName, clusterName, description string, zones []string, roleArn string, tunneledCIDRs []string) string {
 	organizationID := testAccGetOrganizationID()
 
 	zonesConfig, subnetConfig := formatAWSZonesAndSubnets(zones)
+
+	quoted := make([]string, 0, len(tunneledCIDRs))
+	for _, c := range tunneledCIDRs {
+		quoted = append(quoted, fmt.Sprintf("%q", c))
+	}
+	tunneledCIDRsConfig := strings.Join(quoted, ", ")
 
 	return ConfigCompose(testOmniClusterConfig(clusterName), fmt.Sprintf(`
 resource "castai_edge_location" "test" {
@@ -257,6 +268,10 @@ resource "castai_edge_location" "test" {
   region          	 = "us-east-1"
   control_plane_mode = "SHARED"
 %[3]s
+
+  networking = {
+    tunneled_cidrs = [%[7]s]
+  }
 
   aws = {
     account_id               = "123456789012"
@@ -270,7 +285,7 @@ resource "castai_edge_location" "test" {
     }
   }
 }
-`, rName, description, zonesConfig, subnetConfig, organizationID, roleArn))
+`, rName, description, zonesConfig, subnetConfig, organizationID, roleArn, tunneledCIDRsConfig))
 }
 
 func testAccEdgeLocationGCPImpersonationConfig(rName, clusterName string) string {

--- a/castai/resource_edge_location_test.go
+++ b/castai/resource_edge_location_test.go
@@ -165,6 +165,12 @@ func TestAccCloudAgnostic_ResourceEdgeLocationAWSImpersonation(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "networking.tunneled_cidrs.1", "192.168.0.0/24"),
 				),
 			},
+			{
+				Config: testAccEdgeLocationAWSImpersonationConfig(rName, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "networking.tunneled_cidrs.#", "0"),
+				),
+			},
 		},
 	})
 }

--- a/castai/resource_workload_custom_metrics_data_source.go
+++ b/castai/resource_workload_custom_metrics_data_source.go
@@ -290,7 +290,7 @@ func expandWorkloadCustomMetricsDataSourceCreate(d *schema.ResourceData) (sdk.Wo
 
 	return sdk.WorkloadOptimizationAPICreateCustomMetricsDataSourceJSONRequestBody{
 		Name: name,
-		Type: sdk.PROMETHEUS,
+		Type: sdk.WorkloadoptimizationV1CustomMetricsDataSourceTypePROMETHEUS,
 		Data: sdk.WorkloadoptimizationV1CustomMetricsDataSourceInput{
 			Prometheus: prometheusInput,
 		},

--- a/castai/resource_workload_custom_metrics_data_source_test.go
+++ b/castai/resource_workload_custom_metrics_data_source_test.go
@@ -58,7 +58,7 @@ func TestWorkloadCustomMetricsDataSource_CreateWithPresets(t *testing.T) {
 		Id:               dsID,
 		ClusterId:        clusterID,
 		Name:             "my-prometheus",
-		Type:             sdk.PROMETHEUS,
+		Type:             sdk.WorkloadoptimizationV1CustomMetricsDataSourceTypePROMETHEUS,
 		Status:           sdk.WorkloadoptimizationV1CustomMetricsDataSourceStatusCONNECTING,
 		KubeResourceName: "my-prometheus",
 		ManagedByCast:    true,
@@ -157,7 +157,7 @@ func TestWorkloadCustomMetricsDataSource_CreateWithManualMetrics(t *testing.T) {
 		Id:               dsID,
 		ClusterId:        clusterID,
 		Name:             "custom-prom",
-		Type:             sdk.PROMETHEUS,
+		Type:             sdk.WorkloadoptimizationV1CustomMetricsDataSourceTypePROMETHEUS,
 		Status:           sdk.WorkloadoptimizationV1CustomMetricsDataSourceStatusCONNECTING,
 		KubeResourceName: "custom-prom",
 		ManagedByCast:    true,
@@ -324,7 +324,7 @@ func TestWorkloadCustomMetricsDataSource_Update(t *testing.T) {
 		Id:               dsID,
 		ClusterId:        clusterID,
 		Name:             "updated-name",
-		Type:             sdk.PROMETHEUS,
+		Type:             sdk.WorkloadoptimizationV1CustomMetricsDataSourceTypePROMETHEUS,
 		Status:           sdk.WorkloadoptimizationV1CustomMetricsDataSourceStatusCONNECTED,
 		KubeResourceName: "my-prometheus",
 		ManagedByCast:    true,
@@ -715,7 +715,7 @@ func TestWorkloadCustomMetricsDataSource_ImportReadWithManualMetrics(t *testing.
 				Id:               dsID,
 				ClusterId:        clusterID,
 				Name:             "custom-prom",
-				Type:             sdk.PROMETHEUS,
+				Type:             sdk.WorkloadoptimizationV1CustomMetricsDataSourceTypePROMETHEUS,
 				Status:           sdk.WorkloadoptimizationV1CustomMetricsDataSourceStatusCONNECTED,
 				KubeResourceName: "custom-prom",
 				ManagedByCast:    true,
@@ -771,4 +771,3 @@ func TestWorkloadCustomMetricsDataSource_ImportReadWithManualMetrics(t *testing.
 	r.Equal("sum(rate(http_requests_total[5m])) by (pod)", metricsByName["http_requests_total"])
 	r.Equal("avg(queue_depth) by (pod)", metricsByName["queue_depth"])
 }
-

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -706,6 +706,17 @@ const (
 	WorkloadoptimizationV1ApplyTypeUNKNOWN   WorkloadoptimizationV1ApplyType = "UNKNOWN"
 )
 
+// Defines values for WorkloadoptimizationV1ConversionResultStatus.
+const (
+	ALREADYAVERAGE              WorkloadoptimizationV1ConversionResultStatus = "ALREADY_AVERAGE"
+	CONVERSIONSTATUSUNSPECIFIED WorkloadoptimizationV1ConversionResultStatus = "CONVERSION_STATUS_UNSPECIFIED"
+	CONVERTED                   WorkloadoptimizationV1ConversionResultStatus = "CONVERTED"
+	MISSINGREQUESTS             WorkloadoptimizationV1ConversionResultStatus = "MISSING_REQUESTS"
+	NOMETRICS                   WorkloadoptimizationV1ConversionResultStatus = "NO_METRICS"
+	NONCONVERTIBLE              WorkloadoptimizationV1ConversionResultStatus = "NON_CONVERTIBLE"
+	REQUESTSTOOSMALL            WorkloadoptimizationV1ConversionResultStatus = "REQUESTS_TOO_SMALL"
+)
+
 // Defines values for WorkloadoptimizationV1CustomMetricUnit.
 const (
 	WorkloadoptimizationV1CustomMetricUnitBYTES                       WorkloadoptimizationV1CustomMetricUnit = "BYTES"
@@ -750,9 +761,9 @@ const (
 
 // Defines values for WorkloadoptimizationV1CustomMetricsDataSourceType.
 const (
-	NODEWORKLOAD    WorkloadoptimizationV1CustomMetricsDataSourceType = "NODE_WORKLOAD"
-	PROMETHEUS      WorkloadoptimizationV1CustomMetricsDataSourceType = "PROMETHEUS"
-	TYPEUNSPECIFIED WorkloadoptimizationV1CustomMetricsDataSourceType = "TYPE_UNSPECIFIED"
+	WorkloadoptimizationV1CustomMetricsDataSourceTypeNODEWORKLOAD    WorkloadoptimizationV1CustomMetricsDataSourceType = "NODE_WORKLOAD"
+	WorkloadoptimizationV1CustomMetricsDataSourceTypePROMETHEUS      WorkloadoptimizationV1CustomMetricsDataSourceType = "PROMETHEUS"
+	WorkloadoptimizationV1CustomMetricsDataSourceTypeTYPEUNSPECIFIED WorkloadoptimizationV1CustomMetricsDataSourceType = "TYPE_UNSPECIFIED"
 )
 
 // Defines values for WorkloadoptimizationV1EventType.
@@ -799,8 +810,8 @@ const (
 
 // Defines values for WorkloadoptimizationV1HPAConverterType.
 const (
-	AVERAGEVALUEFROMORIGINALREQUESTS WorkloadoptimizationV1HPAConverterType = "AVERAGE_VALUE_FROM_ORIGINAL_REQUESTS"
-	HPACONVERTERTYPEUNSPECIFIED      WorkloadoptimizationV1HPAConverterType = "HPA_CONVERTER_TYPE_UNSPECIFIED"
+	WorkloadoptimizationV1HPAConverterTypeAVERAGEVALUEFROMORIGINALREQUESTS WorkloadoptimizationV1HPAConverterType = "AVERAGE_VALUE_FROM_ORIGINAL_REQUESTS"
+	WorkloadoptimizationV1HPAConverterTypeHPACONVERTERTYPEUNSPECIFIED      WorkloadoptimizationV1HPAConverterType = "HPA_CONVERTER_TYPE_UNSPECIFIED"
 )
 
 // Defines values for WorkloadoptimizationV1HPALegacyUnsupportedReasonType.
@@ -812,6 +823,20 @@ const (
 	HPALEGACYUNSUPPORTEDREASONWORKLOADTYPE        WorkloadoptimizationV1HPALegacyUnsupportedReasonType = "HPA_LEGACY_UNSUPPORTED_REASON_WORKLOAD_TYPE"
 )
 
+// Defines values for WorkloadoptimizationV1HPAManagementMode.
+const (
+	MODEMANAGED     WorkloadoptimizationV1HPAManagementMode = "MODE_MANAGED"
+	MODEUNMANAGED   WorkloadoptimizationV1HPAManagementMode = "MODE_UNMANAGED"
+	MODEUNSPECIFIED WorkloadoptimizationV1HPAManagementMode = "MODE_UNSPECIFIED"
+)
+
+// Defines values for WorkloadoptimizationV1HPAManagementSource.
+const (
+	SOURCESCALINGPOLICY WorkloadoptimizationV1HPAManagementSource = "SOURCE_SCALING_POLICY"
+	SOURCEUNSPECIFIED   WorkloadoptimizationV1HPAManagementSource = "SOURCE_UNSPECIFIED"
+	SOURCEVPACONVERTER  WorkloadoptimizationV1HPAManagementSource = "SOURCE_VPA_CONVERTER"
+)
+
 // Defines values for WorkloadoptimizationV1HPAMode.
 const (
 	HPAMODELEGACY      WorkloadoptimizationV1HPAMode = "HPA_MODE_LEGACY"
@@ -820,6 +845,15 @@ const (
 	HPAMODETAKEOVER    WorkloadoptimizationV1HPAMode = "HPA_MODE_TAKEOVER"
 	HPAMODEUNSPECIFIED WorkloadoptimizationV1HPAMode = "HPA_MODE_UNSPECIFIED"
 	HPAMODEV2          WorkloadoptimizationV1HPAMode = "HPA_MODE_V2"
+)
+
+// Defines values for WorkloadoptimizationV1HPAOwnerType.
+const (
+	WorkloadoptimizationV1HPAOwnerTypeTYPECASTAI      WorkloadoptimizationV1HPAOwnerType = "TYPE_CASTAI"
+	WorkloadoptimizationV1HPAOwnerTypeTYPEKEDA        WorkloadoptimizationV1HPAOwnerType = "TYPE_KEDA"
+	WorkloadoptimizationV1HPAOwnerTypeTYPEOTHER       WorkloadoptimizationV1HPAOwnerType = "TYPE_OTHER"
+	WorkloadoptimizationV1HPAOwnerTypeTYPESTANDALONE  WorkloadoptimizationV1HPAOwnerType = "TYPE_STANDALONE"
+	WorkloadoptimizationV1HPAOwnerTypeTYPEUNSPECIFIED WorkloadoptimizationV1HPAOwnerType = "TYPE_UNSPECIFIED"
 )
 
 // Defines values for WorkloadoptimizationV1HPAScalingPolicyType.
@@ -1364,9 +1398,9 @@ const (
 
 // Defines values for WorkloadOptimizationAPIGetWorkloadFiltersParamsManagementOptions.
 const (
-	MANAGED   WorkloadOptimizationAPIGetWorkloadFiltersParamsManagementOptions = "MANAGED"
-	READONLY  WorkloadOptimizationAPIGetWorkloadFiltersParamsManagementOptions = "READ_ONLY"
-	UNDEFINED WorkloadOptimizationAPIGetWorkloadFiltersParamsManagementOptions = "UNDEFINED"
+	WorkloadOptimizationAPIGetWorkloadFiltersParamsManagementOptionsMANAGED   WorkloadOptimizationAPIGetWorkloadFiltersParamsManagementOptions = "MANAGED"
+	WorkloadOptimizationAPIGetWorkloadFiltersParamsManagementOptionsREADONLY  WorkloadOptimizationAPIGetWorkloadFiltersParamsManagementOptions = "READ_ONLY"
+	WorkloadOptimizationAPIGetWorkloadFiltersParamsManagementOptionsUNDEFINED WorkloadOptimizationAPIGetWorkloadFiltersParamsManagementOptions = "UNDEFINED"
 )
 
 // Defines values for WorkloadOptimizationAPIGetInstallCmdParamsCmePresets.
@@ -1387,6 +1421,19 @@ const (
 	WorkloadOptimizationAPIGetInstallScriptParamsCmePresetsMICROMETER    WorkloadOptimizationAPIGetInstallScriptParamsCmePresets = "MICROMETER"
 	WorkloadOptimizationAPIGetInstallScriptParamsCmePresetsOTELJAVAAGENT WorkloadOptimizationAPIGetInstallScriptParamsCmePresets = "OTEL_JAVA_AGENT"
 	WorkloadOptimizationAPIGetInstallScriptParamsCmePresetsSDKPROMETHEUS WorkloadOptimizationAPIGetInstallScriptParamsCmePresets = "SDK_PROMETHEUS"
+)
+
+// Defines values for WorkloadOptimizationAPIListClusterHPAsParamsManagementOptions.
+const (
+	WorkloadOptimizationAPIListClusterHPAsParamsManagementOptionsMANAGED   WorkloadOptimizationAPIListClusterHPAsParamsManagementOptions = "MANAGED"
+	WorkloadOptimizationAPIListClusterHPAsParamsManagementOptionsREADONLY  WorkloadOptimizationAPIListClusterHPAsParamsManagementOptions = "READ_ONLY"
+	WorkloadOptimizationAPIListClusterHPAsParamsManagementOptionsUNDEFINED WorkloadOptimizationAPIListClusterHPAsParamsManagementOptions = "UNDEFINED"
+)
+
+// Defines values for WorkloadOptimizationAPIListClusterHPAsParamsIncludeConversion.
+const (
+	WorkloadOptimizationAPIListClusterHPAsParamsIncludeConversionAVERAGEVALUEFROMORIGINALREQUESTS WorkloadOptimizationAPIListClusterHPAsParamsIncludeConversion = "AVERAGE_VALUE_FROM_ORIGINAL_REQUESTS"
+	WorkloadOptimizationAPIListClusterHPAsParamsIncludeConversionHPACONVERTERTYPEUNSPECIFIED      WorkloadOptimizationAPIListClusterHPAsParamsIncludeConversion = "HPA_CONVERTER_TYPE_UNSPECIFIED"
 )
 
 // Defines values for WorkloadOptimizationAPIGetAggregatedWorkloadCustomMetricsV1BetaParamsAggregationType.
@@ -8554,6 +8601,25 @@ type WorkloadoptimizationV1CPUPressureSettings struct {
 	MinPressuredPodPercentage float64 `json:"minPressuredPodPercentage"`
 }
 
+// WorkloadoptimizationV1ClusterHPA defines model for workloadoptimization.v1.ClusterHPA.
+type WorkloadoptimizationV1ClusterHPA struct {
+	// Conversion ConversionResult captures the outcome of running an HPA converter.
+	Conversion *WorkloadoptimizationV1ConversionResult `json:"conversion,omitempty"`
+	InCluster  WorkloadoptimizationV1HPASpec           `json:"inCluster"`
+
+	// Management HPAManagement describes the CAST control-plane relationship to this HPA.
+	// source is meaningful only when mode == MODE_MANAGED.
+	Management WorkloadoptimizationV1HPAManagement `json:"management"`
+	Name       string                              `json:"name"`
+	Namespace  string                              `json:"namespace"`
+	Original   WorkloadoptimizationV1HPASpec       `json:"original"`
+
+	// Owner HPAOwner describes who owns the HPA Kubernetes object (from OwnerReferences).
+	// Independent of CAST management.
+	Owner    WorkloadoptimizationV1HPAOwner          `json:"owner"`
+	Workload WorkloadoptimizationV1HPAWorkloadTarget `json:"workload"`
+}
+
 // WorkloadoptimizationV1ConfidenceSettings defines model for workloadoptimization.v1.ConfidenceSettings.
 type WorkloadoptimizationV1ConfidenceSettings struct {
 	// Threshold Defines the confidence threshold that's enough to automatically optimize a given workload vertically. Value must be [0:1].
@@ -8697,6 +8763,39 @@ type WorkloadoptimizationV1ContainerThresholds struct {
 	Cpu    *WorkloadoptimizationV1ResourceThreshold `json:"cpu,omitempty"`
 	Memory *WorkloadoptimizationV1ResourceThreshold `json:"memory,omitempty"`
 }
+
+// WorkloadoptimizationV1ConversionResult ConversionResult captures the outcome of running an HPA converter.
+type WorkloadoptimizationV1ConversionResult struct {
+	Converted *WorkloadoptimizationV1HPASpec `json:"converted,omitempty"`
+
+	// ConverterType HPAConverterType defines the strategy for converting HPA.
+	//
+	//  - AVERAGE_VALUE_FROM_ORIGINAL_REQUESTS: Converts HPA utilization (%) targets to AverageValue using workload container requests.
+	ConverterType WorkloadoptimizationV1HPAConverterType `json:"converterType"`
+
+	// ErrorMessage Human-readable detail when status is not CONVERTED.
+	ErrorMessage *string `json:"errorMessage"`
+
+	// Status Status reports the outcome of running an HPA converter on a single HPA.
+	//
+	//  - CONVERTED: Converter succeeded; `converted` is populated.
+	//  - NON_CONVERTIBLE: HPA uses metrics not handled by this converter (external/object/pods).
+	//  - MISSING_REQUESTS: Workload has no CPU/memory requests required for the conversion.
+	//  - REQUESTS_TOO_SMALL: Conversion would round to zero.
+	//  - ALREADY_AVERAGE: HPA already targets AverageValue.
+	//  - NO_METRICS: HPA has no metrics to convert.
+	Status WorkloadoptimizationV1ConversionResultStatus `json:"status"`
+}
+
+// WorkloadoptimizationV1ConversionResultStatus Status reports the outcome of running an HPA converter on a single HPA.
+//
+//   - CONVERTED: Converter succeeded; `converted` is populated.
+//   - NON_CONVERTIBLE: HPA uses metrics not handled by this converter (external/object/pods).
+//   - MISSING_REQUESTS: Workload has no CPU/memory requests required for the conversion.
+//   - REQUESTS_TOO_SMALL: Conversion would round to zero.
+//   - ALREADY_AVERAGE: HPA already targets AverageValue.
+//   - NO_METRICS: HPA has no metrics to convert.
+type WorkloadoptimizationV1ConversionResultStatus string
 
 // WorkloadoptimizationV1Costs defines model for workloadoptimization.v1.Costs.
 type WorkloadoptimizationV1Costs struct {
@@ -9269,6 +9368,34 @@ type WorkloadoptimizationV1HPALegacyUnsupportedReason struct {
 //   - HPA_LEGACY_UNSUPPORTED_REASON_ROLLOUT_WORKLOAD_REF: Rollout workload is configured using workloadRef.
 type WorkloadoptimizationV1HPALegacyUnsupportedReasonType string
 
+// WorkloadoptimizationV1HPAManagement HPAManagement describes the CAST control-plane relationship to this HPA.
+// source is meaningful only when mode == MODE_MANAGED.
+type WorkloadoptimizationV1HPAManagement struct {
+	// Mode Mode describes whether CAST actively manages this HPA.
+	//
+	//  - MODE_UNMANAGED: CAST does not manage this HPA.
+	//  - MODE_MANAGED: CAST mutates / owns this HPA.
+	Mode WorkloadoptimizationV1HPAManagementMode `json:"mode"`
+
+	// Source Source identifies which CAST feature created or manages this HPA.
+	//
+	//  - SOURCE_VPA_CONVERTER: Managed via the VPA converter path (vertical-only policy with AverageValueFromOriginalRequests).
+	//  - SOURCE_SCALING_POLICY: Managed via horizontal autoscaling policy.
+	Source WorkloadoptimizationV1HPAManagementSource `json:"source"`
+}
+
+// WorkloadoptimizationV1HPAManagementMode Mode describes whether CAST actively manages this HPA.
+//
+//   - MODE_UNMANAGED: CAST does not manage this HPA.
+//   - MODE_MANAGED: CAST mutates / owns this HPA.
+type WorkloadoptimizationV1HPAManagementMode string
+
+// WorkloadoptimizationV1HPAManagementSource Source identifies which CAST feature created or manages this HPA.
+//
+//   - SOURCE_VPA_CONVERTER: Managed via the VPA converter path (vertical-only policy with AverageValueFromOriginalRequests).
+//   - SOURCE_SCALING_POLICY: Managed via horizontal autoscaling policy.
+type WorkloadoptimizationV1HPAManagementSource string
+
 // WorkloadoptimizationV1HPAMaxedOutEvent defines model for workloadoptimization.v1.HPAMaxedOutEvent.
 type WorkloadoptimizationV1HPAMaxedOutEvent struct {
 	DesiredReplicas int32 `json:"desiredReplicas"`
@@ -9283,6 +9410,30 @@ type WorkloadoptimizationV1HPAMaxedOutEvent struct {
 //   - HPA_MODE_TAKEOVER: HPA v2 is configured with ownership takeover.
 //   - HPA_MODE_NATIVE: Workload has an existing native HPA that is not managed by CAST AI.
 type WorkloadoptimizationV1HPAMode string
+
+// WorkloadoptimizationV1HPAOwner HPAOwner describes who owns the HPA Kubernetes object (from OwnerReferences).
+// Independent of CAST management.
+type WorkloadoptimizationV1HPAOwner struct {
+	ApiVersion *string `json:"apiVersion,omitempty"`
+	Kind       *string `json:"kind,omitempty"`
+	Name       *string `json:"name,omitempty"`
+
+	// Type Type classifies the controller that owns the HPA object.
+	//
+	//  - TYPE_STANDALONE: No owner reference present - plain Kubernetes HPA.
+	//  - TYPE_KEDA: Owned by a KEDA ScaledObject.
+	//  - TYPE_CASTAI: Owned by CAST AI (Recommendation CRD).
+	//  - TYPE_OTHER: Owned by some other third-party controller.
+	Type WorkloadoptimizationV1HPAOwnerType `json:"type"`
+}
+
+// WorkloadoptimizationV1HPAOwnerType Type classifies the controller that owns the HPA object.
+//
+//   - TYPE_STANDALONE: No owner reference present - plain Kubernetes HPA.
+//   - TYPE_KEDA: Owned by a KEDA ScaledObject.
+//   - TYPE_CASTAI: Owned by CAST AI (Recommendation CRD).
+//   - TYPE_OTHER: Owned by some other third-party controller.
+type WorkloadoptimizationV1HPAOwnerType string
 
 // WorkloadoptimizationV1HPAScalingPolicy HPAScalingPolicy is a single policy which must hold true for a specified past interval.
 type WorkloadoptimizationV1HPAScalingPolicy struct {
@@ -9374,6 +9525,17 @@ type WorkloadoptimizationV1HPAState struct {
 	V2UnsupportedReason *WorkloadoptimizationV1HPAUnsupportedReason `json:"v2UnsupportedReason,omitempty"`
 }
 
+// WorkloadoptimizationV1HPATargetWorkloadContainer HPATargetWorkloadContainer mirrors Container.
+type WorkloadoptimizationV1HPATargetWorkloadContainer struct {
+	Name              string                           `json:"name"`
+	OriginalResources *WorkloadoptimizationV1Resources `json:"originalResources,omitempty"`
+	Recommendation    *WorkloadoptimizationV1Resources `json:"recommendation,omitempty"`
+	Resources         *WorkloadoptimizationV1Resources `json:"resources,omitempty"`
+
+	// Runtime Defines the application runtime.
+	Runtime *WorkloadoptimizationV1Runtime `json:"runtime,omitempty"`
+}
+
 // WorkloadoptimizationV1HPAUnsupportedReason HPAUnsupportedReason contains categorized type and description for why HPA V2 is unsupported.
 type WorkloadoptimizationV1HPAUnsupportedReason struct {
 	// Description Description of why HPA V2 is unsupported.
@@ -9414,6 +9576,23 @@ type WorkloadoptimizationV1HPAV2Config struct {
 
 	// TakeOwnership Whether CAST AI takes ownership of the existing native HPA.
 	TakeOwnership bool `json:"takeOwnership"`
+}
+
+// WorkloadoptimizationV1HPAWorkloadTarget defines model for workloadoptimization.v1.HPAWorkloadTarget.
+type WorkloadoptimizationV1HPAWorkloadTarget struct {
+	Containers        []WorkloadoptimizationV1HPATargetWorkloadContainer `json:"containers"`
+	CreatedAt         time.Time                                          `json:"createdAt"`
+	Group             string                                             `json:"group"`
+	Id                string                                             `json:"id"`
+	IsCustom          bool                                               `json:"isCustom"`
+	Kind              string                                             `json:"kind"`
+	Name              string                                             `json:"name"`
+	Namespace         string                                             `json:"namespace"`
+	RunningPods       int32                                              `json:"runningPods"`
+	ScalingPolicyId   string                                             `json:"scalingPolicyId"`
+	ScalingPolicyName string                                             `json:"scalingPolicyName"`
+	UpdatedAt         time.Time                                          `json:"updatedAt"`
+	Version           string                                             `json:"version"`
 }
 
 // WorkloadoptimizationV1HeapCommited defines model for workloadoptimization.v1.HeapCommited.
@@ -9635,6 +9814,11 @@ type WorkloadoptimizationV1LimitRangeResource struct {
 
 	// Min The min amount of a resource. For memory - this is in MiB, for CPU - this is in cores.
 	Min *float64 `json:"min"`
+}
+
+// WorkloadoptimizationV1ListClusterHPAsResponse defines model for workloadoptimization.v1.ListClusterHPAsResponse.
+type WorkloadoptimizationV1ListClusterHPAsResponse struct {
+	Items []WorkloadoptimizationV1ClusterHPA `json:"items"`
 }
 
 // WorkloadoptimizationV1ListCustomMetricsDataSourcesResponse defines model for workloadoptimization.v1.ListCustomMetricsDataSourcesResponse.
@@ -12233,6 +12417,27 @@ type InventoryAPIListZonesParams struct {
 	PageSize  *int32  `form:"pageSize,omitempty" json:"pageSize,omitempty"`
 	PageToken *string `form:"pageToken,omitempty" json:"pageToken,omitempty"`
 }
+
+// WorkloadOptimizationAPIListClusterHPAsParams defines parameters for WorkloadOptimizationAPIListClusterHPAs.
+type WorkloadOptimizationAPIListClusterHPAsParams struct {
+	WorkloadNames      *[]string                                                        `form:"workloadNames,omitempty" json:"workloadNames,omitempty"`
+	Namespaces         *[]string                                                        `form:"namespaces,omitempty" json:"namespaces,omitempty"`
+	ScalingPolicyNames *[]string                                                        `form:"scalingPolicyNames,omitempty" json:"scalingPolicyNames,omitempty"`
+	Kinds              *[]string                                                        `form:"kinds,omitempty" json:"kinds,omitempty"`
+	ManagementOptions  *[]WorkloadOptimizationAPIListClusterHPAsParamsManagementOptions `form:"managementOptions,omitempty" json:"managementOptions,omitempty"`
+
+	// IncludeConversion Identifier of the HPA converter to apply to each returned HPA. When empty,
+	// no conversion is executed and the `conversion` field on each item is unset.
+	//
+	//  - AVERAGE_VALUE_FROM_ORIGINAL_REQUESTS: Converts HPA utilization (%) targets to AverageValue using workload container requests.
+	IncludeConversion *WorkloadOptimizationAPIListClusterHPAsParamsIncludeConversion `form:"includeConversion,omitempty" json:"includeConversion,omitempty"`
+}
+
+// WorkloadOptimizationAPIListClusterHPAsParamsManagementOptions defines parameters for WorkloadOptimizationAPIListClusterHPAs.
+type WorkloadOptimizationAPIListClusterHPAsParamsManagementOptions string
+
+// WorkloadOptimizationAPIListClusterHPAsParamsIncludeConversion defines parameters for WorkloadOptimizationAPIListClusterHPAs.
+type WorkloadOptimizationAPIListClusterHPAsParamsIncludeConversion string
 
 // WorkloadOptimizationAPIGetWorkloadCustomMetricsV1BetaParams defines parameters for WorkloadOptimizationAPIGetWorkloadCustomMetricsV1Beta.
 type WorkloadOptimizationAPIGetWorkloadCustomMetricsV1BetaParams struct {

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -8977,16 +8977,17 @@ type WorkloadoptimizationV1FailedHookEvent struct {
 
 // WorkloadoptimizationV1GetAgentStatusResponse defines model for workloadoptimization.v1.GetAgentStatusResponse.
 type WorkloadoptimizationV1GetAgentStatusResponse struct {
-	CastAgentCurrentVersion          *string    `json:"castAgentCurrentVersion"`
-	ClusterId                        string     `json:"clusterId"`
-	CurrentVersion                   *string    `json:"currentVersion"`
-	HpaSupportedFromCastAgentVersion *string    `json:"hpaSupportedFromCastAgentVersion"`
-	InPlaceResizeEnabled             bool       `json:"inPlaceResizeEnabled"`
-	InstalledAt                      *time.Time `json:"installedAt"`
-	LatestVersion                    *string    `json:"latestVersion"`
-	MetricsExporterVersion           *string    `json:"metricsExporterVersion"`
-	NativeHpaSupportedFromVersion    *string    `json:"nativeHpaSupportedFromVersion"`
-	PsiMetricsSupported              bool       `json:"psiMetricsSupported"`
+	CastAgentCurrentVersion           *string    `json:"castAgentCurrentVersion"`
+	ClusterId                         string     `json:"clusterId"`
+	CurrentVersion                    *string    `json:"currentVersion"`
+	HpaConvertersSupportedFromVersion string     `json:"hpaConvertersSupportedFromVersion"`
+	HpaSupportedFromCastAgentVersion  *string    `json:"hpaSupportedFromCastAgentVersion"`
+	InPlaceResizeEnabled              bool       `json:"inPlaceResizeEnabled"`
+	InstalledAt                       *time.Time `json:"installedAt"`
+	LatestVersion                     *string    `json:"latestVersion"`
+	MetricsExporterVersion            *string    `json:"metricsExporterVersion"`
+	NativeHpaSupportedFromVersion     *string    `json:"nativeHpaSupportedFromVersion"`
+	PsiMetricsSupported               bool       `json:"psiMetricsSupported"`
 
 	// ResourceQuotasAffectingOptimization True if we detected at least one ResourceQuota with a hard CPU or memory limit,
 	// regardless of whether VPA is enabled or the quota is currently affecting workload optimization.

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -1037,6 +1037,9 @@ type ClientInterface interface {
 	// InventoryAPIListZones request
 	InventoryAPIListZones(ctx context.Context, params *InventoryAPIListZonesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// WorkloadOptimizationAPIListClusterHPAs request
+	WorkloadOptimizationAPIListClusterHPAs(ctx context.Context, clusterId string, params *WorkloadOptimizationAPIListClusterHPAsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// WorkloadOptimizationAPIGetWorkloadCustomMetricsV1Beta request
 	WorkloadOptimizationAPIGetWorkloadCustomMetricsV1Beta(ctx context.Context, clusterId string, workloadId string, params *WorkloadOptimizationAPIGetWorkloadCustomMetricsV1BetaParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -5172,6 +5175,18 @@ func (c *Client) WorkloadOptimizationAPIGetInstallScript(ctx context.Context, pa
 
 func (c *Client) InventoryAPIListZones(ctx context.Context, params *InventoryAPIListZonesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewInventoryAPIListZonesRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) WorkloadOptimizationAPIListClusterHPAs(ctx context.Context, clusterId string, params *WorkloadOptimizationAPIListClusterHPAsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewWorkloadOptimizationAPIListClusterHPAsRequest(c.Server, clusterId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -21191,6 +21206,142 @@ func NewInventoryAPIListZonesRequest(server string, params *InventoryAPIListZone
 	return req, nil
 }
 
+// NewWorkloadOptimizationAPIListClusterHPAsRequest generates requests for WorkloadOptimizationAPIListClusterHPAs
+func NewWorkloadOptimizationAPIListClusterHPAsRequest(server string, clusterId string, params *WorkloadOptimizationAPIListClusterHPAsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "clusterId", runtime.ParamLocationPath, clusterId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1beta/workload-autoscaling/clusters/%s/hpas:analyze", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.WorkloadNames != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "workloadNames", runtime.ParamLocationQuery, *params.WorkloadNames); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Namespaces != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "namespaces", runtime.ParamLocationQuery, *params.Namespaces); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ScalingPolicyNames != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "scalingPolicyNames", runtime.ParamLocationQuery, *params.ScalingPolicyNames); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Kinds != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "kinds", runtime.ParamLocationQuery, *params.Kinds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ManagementOptions != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "managementOptions", runtime.ParamLocationQuery, *params.ManagementOptions); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IncludeConversion != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "includeConversion", runtime.ParamLocationQuery, *params.IncludeConversion); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewWorkloadOptimizationAPIGetWorkloadCustomMetricsV1BetaRequest generates requests for WorkloadOptimizationAPIGetWorkloadCustomMetricsV1Beta
 func NewWorkloadOptimizationAPIGetWorkloadCustomMetricsV1BetaRequest(server string, clusterId string, workloadId string, params *WorkloadOptimizationAPIGetWorkloadCustomMetricsV1BetaParams) (*http.Request, error) {
 	var err error
@@ -22559,6 +22710,9 @@ type ClientWithResponsesInterface interface {
 
 	// InventoryAPIListZones request
 	InventoryAPIListZonesWithResponse(ctx context.Context, params *InventoryAPIListZonesParams) (*InventoryAPIListZonesResponse, error)
+
+	// WorkloadOptimizationAPIListClusterHPAs request
+	WorkloadOptimizationAPIListClusterHPAsWithResponse(ctx context.Context, clusterId string, params *WorkloadOptimizationAPIListClusterHPAsParams) (*WorkloadOptimizationAPIListClusterHPAsResponse, error)
 
 	// WorkloadOptimizationAPIGetWorkloadCustomMetricsV1Beta request
 	WorkloadOptimizationAPIGetWorkloadCustomMetricsV1BetaWithResponse(ctx context.Context, clusterId string, workloadId string, params *WorkloadOptimizationAPIGetWorkloadCustomMetricsV1BetaParams) (*WorkloadOptimizationAPIGetWorkloadCustomMetricsV1BetaResponse, error)
@@ -30353,6 +30507,36 @@ func (r InventoryAPIListZonesResponse) GetBody() []byte {
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
+type WorkloadOptimizationAPIListClusterHPAsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *WorkloadoptimizationV1ListClusterHPAsResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r WorkloadOptimizationAPIListClusterHPAsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r WorkloadOptimizationAPIListClusterHPAsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r WorkloadOptimizationAPIListClusterHPAsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
 type WorkloadOptimizationAPIGetWorkloadCustomMetricsV1BetaResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -33482,6 +33666,15 @@ func (c *ClientWithResponses) InventoryAPIListZonesWithResponse(ctx context.Cont
 		return nil, err
 	}
 	return ParseInventoryAPIListZonesResponse(rsp)
+}
+
+// WorkloadOptimizationAPIListClusterHPAsWithResponse request returning *WorkloadOptimizationAPIListClusterHPAsResponse
+func (c *ClientWithResponses) WorkloadOptimizationAPIListClusterHPAsWithResponse(ctx context.Context, clusterId string, params *WorkloadOptimizationAPIListClusterHPAsParams) (*WorkloadOptimizationAPIListClusterHPAsResponse, error) {
+	rsp, err := c.WorkloadOptimizationAPIListClusterHPAs(ctx, clusterId, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseWorkloadOptimizationAPIListClusterHPAsResponse(rsp)
 }
 
 // WorkloadOptimizationAPIGetWorkloadCustomMetricsV1BetaWithResponse request returning *WorkloadOptimizationAPIGetWorkloadCustomMetricsV1BetaResponse
@@ -40221,6 +40414,32 @@ func ParseInventoryAPIListZonesResponse(rsp *http.Response) (*InventoryAPIListZo
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest CastaiInventoryV1beta1ListZonesResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseWorkloadOptimizationAPIListClusterHPAsResponse parses an HTTP response from a WorkloadOptimizationAPIListClusterHPAsWithResponse call
+func ParseWorkloadOptimizationAPIListClusterHPAsResponse(rsp *http.Response) (*WorkloadOptimizationAPIListClusterHPAsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &WorkloadOptimizationAPIListClusterHPAsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest WorkloadoptimizationV1ListClusterHPAsResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -6695,6 +6695,26 @@ func (mr *MockClientInterfaceMockRecorder) WorkloadOptimizationAPIGetWorkloadsSu
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetWorkloadsSummaryMetrics", reflect.TypeOf((*MockClientInterface)(nil).WorkloadOptimizationAPIGetWorkloadsSummaryMetrics), varargs...)
 }
 
+// WorkloadOptimizationAPIListClusterHPAs mocks base method.
+func (m *MockClientInterface) WorkloadOptimizationAPIListClusterHPAs(ctx context.Context, clusterId string, params *sdk.WorkloadOptimizationAPIListClusterHPAsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, clusterId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIListClusterHPAs", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadOptimizationAPIListClusterHPAs indicates an expected call of WorkloadOptimizationAPIListClusterHPAs.
+func (mr *MockClientInterfaceMockRecorder) WorkloadOptimizationAPIListClusterHPAs(ctx, clusterId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, clusterId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIListClusterHPAs", reflect.TypeOf((*MockClientInterface)(nil).WorkloadOptimizationAPIListClusterHPAs), varargs...)
+}
+
 // WorkloadOptimizationAPIListCustomMetricsDataSources mocks base method.
 func (m *MockClientInterface) WorkloadOptimizationAPIListCustomMetricsDataSources(ctx context.Context, clusterId string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -18681,6 +18701,41 @@ func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIGetWorkloadsSu
 func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIGetWorkloadsSummaryWithResponse(ctx, clusterId, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetWorkloadsSummaryWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIGetWorkloadsSummaryWithResponse), ctx, clusterId, params)
+}
+
+// WorkloadOptimizationAPIListClusterHPAs mocks base method.
+func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIListClusterHPAs(ctx context.Context, clusterId string, params *sdk.WorkloadOptimizationAPIListClusterHPAsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, clusterId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIListClusterHPAs", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadOptimizationAPIListClusterHPAs indicates an expected call of WorkloadOptimizationAPIListClusterHPAs.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIListClusterHPAs(ctx, clusterId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, clusterId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIListClusterHPAs", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIListClusterHPAs), varargs...)
+}
+
+// WorkloadOptimizationAPIListClusterHPAsWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIListClusterHPAsWithResponse(ctx context.Context, clusterId string, params *sdk.WorkloadOptimizationAPIListClusterHPAsParams) (*sdk.WorkloadOptimizationAPIListClusterHPAsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIListClusterHPAsWithResponse", ctx, clusterId, params)
+	ret0, _ := ret[0].(*sdk.WorkloadOptimizationAPIListClusterHPAsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadOptimizationAPIListClusterHPAsWithResponse indicates an expected call of WorkloadOptimizationAPIListClusterHPAsWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIListClusterHPAsWithResponse(ctx, clusterId, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIListClusterHPAsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIListClusterHPAsWithResponse), ctx, clusterId, params)
 }
 
 // WorkloadOptimizationAPIListCustomMetricsDataSources mocks base method.

--- a/castai/sdk/omni/api.gen.go
+++ b/castai/sdk/omni/api.gen.go
@@ -194,12 +194,23 @@ type EdgeClusterControlPlane struct {
 	Ha *bool `json:"ha,omitempty"`
 }
 
+// EdgeClusterNetworking EdgeClusterNetworking contains networking configuration options for the edge cluster.
+type EdgeClusterNetworking struct {
+	// TunneledCidrs A list of destination CIDR blocks whose traffic should be routed through the main cluster instead of directly from the
+	//  edge cluster. When specified, the edge cluster will forward packets destined to these CIDRs over the peering tunnel
+	//  to the main cluster, which then routes them on to their final destination.
+	TunneledCidrs *[]string `json:"tunneledCidrs,omitempty"`
+}
+
 // EdgeClusterSpec EdgeClusterSpec contains configuration overrides for the edge cluster.
 //
 //	Fields left unset will use system defaults.
 type EdgeClusterSpec struct {
 	// ControlPlane Control plane configuration overrides.
 	ControlPlane *EdgeClusterControlPlane `json:"controlPlane,omitempty"`
+
+	// Networking Networking configuration.
+	Networking *EdgeClusterNetworking `json:"networking,omitempty"`
 }
 
 // EdgeLocation Message to represent edge location.
@@ -225,7 +236,7 @@ type EdgeLocation struct {
 	// Description The description of the edge location.
 	Description *string `json:"description,omitempty"`
 
-	// EdgeClusterSpec Optional edge cluster spec overrides. Ignored during edge location update.
+	// EdgeClusterSpec Optional edge cluster spec overrides.
 	EdgeClusterSpec *EdgeClusterSpec `json:"edgeClusterSpec,omitempty"`
 
 	// Error If state if failed, this field will contain the error message.
@@ -277,6 +288,9 @@ type EdgeLocationUpdate struct {
 
 	// Description The description of the edge location.
 	Description *string `json:"description,omitempty"`
+
+	// EdgeClusterSpec Edge cluster spec configuration.
+	EdgeClusterSpec *EdgeClusterSpec `json:"edgeClusterSpec,omitempty"`
 
 	// Gcp Google Cloud specific parameters.
 	Gcp *GCPParam `json:"gcp,omitempty"`

--- a/docs/resources/edge_location.md
+++ b/docs/resources/edge_location.md
@@ -97,7 +97,7 @@ Optional:
 <a id="nestedatt--control_plane"></a>
 ### Nested Schema for `control_plane`
 
-Required:
+Optional:
 
 - `ha` (Boolean) Whether to use HA mode for control plane. If not set, default is HA.
 

--- a/docs/resources/edge_location.md
+++ b/docs/resources/edge_location.md
@@ -64,6 +64,7 @@ resource "castai_edge_location" "aws_example" {
 - `control_plane_mode` (String) The mode of control plane inside edge location. Valid values: DEDICATED, SHARED.
 - `description` (String) Description of the edge location
 - `gcp` (Attributes) GCP configuration for the edge location (see [below for nested schema](#nestedatt--gcp))
+- `networking` (Attributes) Edge cluster networking configuration. (see [below for nested schema](#nestedatt--networking))
 - `oci` (Attributes) OCI configuration for the edge location (see [below for nested schema](#nestedatt--oci))
 - `zones` (Attributes List) List of availability zones for the edge location (see [below for nested schema](#nestedatt--zones))
 
@@ -117,6 +118,14 @@ Optional:
 - `instance_service_account` (String) GCP service account email to be attached to edge instances. It can be used to grant permissions to access other GCP resources.
 - `subnet_cidr` (String) VPC Subnet IPv4 CIDR block
 - `target_service_account_email` (String) Target service account email to be used for impersonation
+
+
+<a id="nestedatt--networking"></a>
+### Nested Schema for `networking`
+
+Optional:
+
+- `tunneled_cidrs` (List of String) List of destination CIDR blocks whose traffic should be routed through the main cluster instead of directly from the edge cluster.
 
 
 <a id="nestedatt--oci"></a>


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds an optional `networking` block to the `castai_edge_location` resource to configure edge cluster traffic tunneling via CIDR lists. Also fixes perpetual state drift for the `control_plane` block and regenerates the internal SDK from the latest OpenAPI spec.

### Why
Users need to route specific destination networks through the main cluster instead of directly from the edge. The `control_plane` block previously caused unnecessary plan diffs for users who never configured it.

### Key changes
- `castai/resource_edge_location.go`:
  - Adds `networking` single nested block with `tunneled_cidrs` list attribute
  - Changes `control_plane.ha` from required to `Optional` + `Computed`; replaces `RequiresReplace` with `UseStateForUnknown`
  - Introduces `toEdgeClusterSpec` and `edgeClusterSpecUpdate` helpers to correctly marshal create/update requests and avoid sending unchanged nested blocks
  - Updates `Read` to only sync `control_plane` from the API when it is already present in Terraform state
- `castai/sdk/omni/api.gen.go`: Adds `EdgeClusterNetworking`, `TunneledCidrs`, and wires `EdgeClusterSpec` into `EdgeLocationUpdate`
- `castai/sdk/api.gen.go`, `client.gen.go`, `mock/client.go`: Regenerated SDK including new workload-optimization HPA types and the `WorkloadOptimizationAPIListClusterHPAs` endpoint
- `castai/resource_workload_custom_metrics_data_source.go`: Adapts to renamed SDK enum `WorkloadoptimizationV1CustomMetricsDataSourceTypePROMETHEUS`
- `docs/resources/edge_location.md`: Documents the `networking` schema and marks `control_plane.ha` as optional

### Impact
- Removing the `networking` or `control_plane` block from configuration resets those values to API defaults on the next apply.
- Existing edge locations without `control_plane` specified will no longer show perpetual drift.
- SDK enum renames are internal-only and do not affect end-user configuration.