### PR TITLE
feat: update live examples

### DIFF
--- a/castai/resource_node_template.go
+++ b/castai/resource_node_template.go
@@ -803,7 +803,7 @@ func resourceNodeTemplate() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: "Marks whether CLM should be enabled for nodes created from this template.",
+				Description: "Marks whether Container Live Migration (CLM) should be enabled for nodes created from this template. Supported on EKS, GKE, and AKS clusters. CLM-enabled nodes participate in live workload migration during rebalancing, scale-down, and node lifecycle events.",
 			},
 			FieldNodeTemplateEdgeLocationIDs: {
 				Type:     schema.TypeList,

--- a/castai/resource_node_template_test.go
+++ b/castai/resource_node_template_test.go
@@ -596,10 +596,6 @@ func TestNodeTemplateResourceCreate_customNodeTemplate(t *testing.T) {
 		    "minCpu": 10,
 		    "maxCpu": 10000,
 		    "architectures": ["amd64", "arm64"],
-		    "instanceFamilies": {
-		      "include": ["m6i", "m5"],
-		      "exclude": []
-		    },
 		    "resourceLimits": {
 		  	"cpuLimitEnabled": true,
 		  	"cpuLimitMaxCores": 20
@@ -842,10 +838,7 @@ func TestAccEKS_ResourceNodeTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.use_spot_fallbacks", "true"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.spot", "true"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.on_demand", "true"),
-					resource.TestCheckResourceAttr(resourceName, "constraints.0.instance_families.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "constraints.0.instance_families.0.include.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "constraints.0.instance_families.0.include.0", "m6i"),
-					resource.TestCheckResourceAttr(resourceName, "constraints.0.instance_families.0.include.1", "m5"),
+					resource.TestCheckResourceAttr(resourceName, "constraints.0.instance_families.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.gpu.0.manufacturers.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.gpu.0.include_names.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.gpu.0.exclude_names.#", "0"),
@@ -1146,10 +1139,6 @@ func testNodeTemplateUpdated(rName, clusterName string) string {
 				customer_specific = "enabled"
 				azs = ["eu-central-1a", "eu-central-1b", "eu-central-1c"]
 				bare_metal = false
-
-				instance_families {
-					include = ["m6i", "m5"]
-				}
 
 				custom_priority {
 					instance_families = ["a", "b"]

--- a/castai/resource_node_template_test.go
+++ b/castai/resource_node_template_test.go
@@ -596,6 +596,10 @@ func TestNodeTemplateResourceCreate_customNodeTemplate(t *testing.T) {
 		    "minCpu": 10,
 		    "maxCpu": 10000,
 		    "architectures": ["amd64", "arm64"],
+		    "instanceFamilies": {
+		      "include": ["m6i", "m5"],
+		      "exclude": []
+		    },
 		    "resourceLimits": {
 		  	"cpuLimitEnabled": true,
 		  	"cpuLimitMaxCores": 20
@@ -838,7 +842,10 @@ func TestAccEKS_ResourceNodeTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.use_spot_fallbacks", "true"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.spot", "true"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.on_demand", "true"),
-					resource.TestCheckResourceAttr(resourceName, "constraints.0.instance_families.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "constraints.0.instance_families.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "constraints.0.instance_families.0.include.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "constraints.0.instance_families.0.include.0", "m6i"),
+					resource.TestCheckResourceAttr(resourceName, "constraints.0.instance_families.0.include.1", "m5"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.gpu.0.manufacturers.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.gpu.0.include_names.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.gpu.0.exclude_names.#", "0"),
@@ -1139,6 +1146,10 @@ func testNodeTemplateUpdated(rName, clusterName string) string {
 				customer_specific = "enabled"
 				azs = ["eu-central-1a", "eu-central-1b", "eu-central-1c"]
 				bare_metal = false
+
+				instance_families {
+					include = ["m6i", "m5"]
+				}
 
 				custom_priority {
 					instance_families = ["a", "b"]

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -76,7 +76,7 @@ resource "castai_node_template" "default_by_castai" {
 
 ### Optional
 
-- `clm_enabled` (Boolean) Marks whether CLM should be enabled for nodes created from this template.
+- `clm_enabled` (Boolean) Marks whether Container Live Migration (CLM) should be enabled for nodes created from this template. Supported on EKS, GKE, and AKS clusters. CLM-enabled nodes participate in live workload migration during rebalancing, scale-down, and node lifecycle events.
 - `cluster_id` (String) CAST AI cluster id.
 - `configuration_id` (String) CAST AI node configuration id to be used for node template.
 - `constraints` (Block List, Max: 1) (see [below for nested schema](#nestedblock--constraints))

--- a/examples/aks/aks_cluster_live_migration/README.MD
+++ b/examples/aks/aks_cluster_live_migration/README.MD
@@ -1,0 +1,43 @@
+## AKS and CAST AI example with CAST AI Live Migration (CLM)
+
+Following this example shows how to onboard an AKS cluster to CAST AI and configure CAST AI Live Migration capability.
+
+CAST AI modules are placed in one umbrella module that can be reused for different clusters and enabled/disabled.
+
+Example configuration should be analysed in the following order:
+1. Create Virtual network and resource group - `main.tf`
+2. Create AKS cluster - `main.tf`
+3. Create CAST AI related resources to connect AKS cluster to CAST AI, configure Autoscaler, Node Configurations, and Live Migration - `main.tf` and `module/castai/castai.tf`.
+
+CLM is enabled by having:
+1. `clm_enabled = true` in `module/castai/castai.tf` in the CAST AI node template.
+2. `install_live = true` (`install_live = var.install_helm_live`, default value is `true`) in the CAST AI module configuration (`module "castai-aks-cluster"`).
+Both are in the `module/castai/castai.tf` file.
+
+All other AKS/CAST AI resources mostly manage the AKS cluster and its connection to CAST AI, not specifically the CLM feature.
+
+# Usage
+1. Copy `terraform.tfvars.example` to `terraform.tfvars`
+2. Update `terraform.tfvars` file with your cluster name, cluster region, subscription ID, and CAST AI API token.
+
+| Variable | Description |
+| --- | --- |
+| cluster_name       | Name of the AKS cluster |
+| cluster_region     | Azure region for the cluster |
+| subscription_id    | Azure subscription ID |
+| castai_api_token   | CAST AI API token |
+
+3. Initialize Terraform. Under example root folder run:
+```
+terraform init
+```
+4. Run Terraform apply:
+```
+terraform apply
+```
+5. To destroy resources created by this example:
+```
+terraform destroy
+```
+
+Please refer to this guide if you run into any issues https://docs.cast.ai/docs/terraform-troubleshooting

--- a/examples/aks/aks_cluster_live_migration/main.tf
+++ b/examples/aks/aks_cluster_live_migration/main.tf
@@ -1,0 +1,100 @@
+# 1. Create virtual network and resource group for the cluster.
+
+resource "azurerm_resource_group" "this" {
+  name     = var.cluster_name
+  location = var.cluster_region
+}
+
+resource "azurerm_virtual_network" "this" {
+  name                = "${var.cluster_name}-network"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  address_space       = ["10.1.0.0/16"]
+}
+
+resource "azurerm_subnet" "internal" {
+  name                 = "internal"
+  virtual_network_name = azurerm_virtual_network.this.name
+  resource_group_name  = azurerm_resource_group.this.name
+  address_prefixes     = ["10.1.0.0/22"]
+}
+
+# 2. Create AKS cluster.
+
+resource "azurerm_kubernetes_cluster" "this" {
+  name                = var.cluster_name
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+  dns_prefix          = var.cluster_name
+  node_resource_group = "${var.cluster_name}-ng"
+  kubernetes_version  = var.cluster_version
+
+  default_node_pool {
+    name = "default"
+    # Node count has to be > 2 to successfully deploy CAST AI controller.
+    node_count     = 2
+    vm_size        = "Standard_D2_v2"
+    vnet_subnet_id = azurerm_subnet.internal.id
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    Environment = "Test"
+  }
+}
+
+# Configure Data sources and providers required for CAST AI connection.
+data "azurerm_subscription" "current" {}
+
+provider "castai" {
+  api_url   = var.castai_api_url
+  api_token = var.castai_api_token
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = azurerm_kubernetes_cluster.this.kube_config.0.host
+    client_certificate     = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_certificate)
+    client_key             = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.client_key)
+    cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.this.kube_config.0.cluster_ca_certificate)
+  }
+}
+
+# Following providers required by AKS and Vnet resources.
+provider "azurerm" {
+  subscription_id = var.subscription_id
+  features {}
+}
+
+provider "azuread" {
+  tenant_id = data.azurerm_subscription.current.tenant_id
+}
+
+# 3. Connect AKS cluster to CAST AI and configure live migration.
+
+module "cluster" {
+  source = "./module/castai"
+  count  = var.enable_castai ? 1 : 0
+
+  cluster_name     = var.cluster_name
+  cluster_region   = var.cluster_region
+  castai_api_token = var.castai_api_token
+  castai_api_url   = var.castai_api_url
+  castai_grpc_url  = var.castai_grpc_url
+
+  node_resource_group = azurerm_kubernetes_cluster.this.node_resource_group
+  resource_group      = azurerm_kubernetes_cluster.this.resource_group_name
+  subscription_id     = data.azurerm_subscription.current.subscription_id
+  tenant_id           = data.azurerm_subscription.current.tenant_id
+  subnet_id           = azurerm_subnet.internal.id
+
+  tags                       = var.tags
+  delete_nodes_on_disconnect = var.delete_nodes_on_disconnect
+  install_helm_live          = var.install_helm_live
+  live_helm_version          = var.live_helm_version
+
+  depends_on = [azurerm_kubernetes_cluster.this]
+}

--- a/examples/aks/aks_cluster_live_migration/module/castai/castai.tf
+++ b/examples/aks/aks_cluster_live_migration/module/castai/castai.tf
@@ -1,39 +1,35 @@
-# Configure Data sources and providers required for CAST AI connection.
-data "aws_caller_identity" "current" {}
-
-module "castai-eks-cluster" {
-  source  = "castai/eks-cluster/castai"
-  version = "~> 14.1"
+module "castai-aks-cluster" {
+  source  = "castai/aks/castai"
+  version = "~> 10.3"
 
   api_url                = var.castai_api_url
   castai_api_token       = var.castai_api_token
   grpc_url               = var.castai_grpc_url
   wait_for_cluster_ready = true
 
-  aws_account_id     = data.aws_caller_identity.current.account_id
-  aws_cluster_region = var.cluster_region
-  aws_cluster_name   = var.cluster_name
+  aks_cluster_name    = var.cluster_name
+  aks_cluster_region  = var.cluster_region
+  node_resource_group = var.node_resource_group
+  resource_group      = var.resource_group
 
-  aws_assume_role_arn        = var.castai-eks-role-iam_role_arn
   delete_nodes_on_disconnect = var.delete_nodes_on_disconnect
+
+  subscription_id = var.subscription_id
+  tenant_id       = var.tenant_id
 
   default_node_configuration_name = "default"
 
   node_configurations = {
     default = {
-      subnets              = var.subnets
-      tags                 = var.tags
-      security_groups      = var.security_groups
-      instance_profile_arn = var.castai-eks-role-iam_instance_profile_arn
+      disk_cpu_ratio = 25
+      subnets        = [var.subnet_id]
+      tags           = var.tags
     }
 
     live = {
-      subnets              = var.subnets
-      instance_profile_arn = var.castai-eks-role-iam_instance_profile_arn
-      security_groups      = var.security_groups
-
-      container_runtime = "containerd"
-      eks_image_family  = "al2023"
+      disk_cpu_ratio = 25
+      subnets        = [var.subnet_id]
+      tags           = var.tags
     }
   }
 
@@ -52,9 +48,6 @@ module "castai-eks-cluster" {
 
         enable_spot_diversity                       = false
         spot_diversity_price_increase_limit_percent = 20
-
-        spot_interruption_predictions_enabled = true
-        spot_interruption_predictions_type    = "aws-rebalance-recommendations"
       }
     }
 
@@ -65,12 +58,9 @@ module "castai-eks-cluster" {
       clm_enabled        = true
 
       constraints = {
-        on_demand          = true
-        spot               = false
-        use_spot_fallbacks = false
-
         instance_families = {
-          enabled = ["m6i", "m5", "m5a", "c6i", "c5", "c5a"]
+          exclude = []
+          include = ["standard_dsv2", "standard_dsv3", "standard_dsv4", "standard_dsv5", "standard_ev3", "standard_ev4"]
         }
       }
     }

--- a/examples/aks/aks_cluster_live_migration/module/castai/output.tf
+++ b/examples/aks/aks_cluster_live_migration/module/castai/output.tf
@@ -1,0 +1,4 @@
+output "cluster_id" {
+  value       = module.castai-aks-cluster.cluster_id
+  description = "CAST AI cluster ID."
+}

--- a/examples/aks/aks_cluster_live_migration/module/castai/variables.tf
+++ b/examples/aks/aks_cluster_live_migration/module/castai/variables.tf
@@ -1,0 +1,75 @@
+variable "cluster_name" {
+  type        = string
+  description = "AKS cluster name."
+}
+
+variable "cluster_region" {
+  type        = string
+  description = "AKS cluster region."
+}
+
+variable "castai_api_url" {
+  type        = string
+  description = "URL of alternative CAST AI API to be used during development or testing"
+  default     = "https://api.cast.ai"
+}
+
+variable "castai_grpc_url" {
+  type        = string
+  description = "CAST AI gRPC URL"
+  default     = "grpc.cast.ai:443"
+}
+
+variable "castai_api_token" {
+  type        = string
+  description = "CAST AI API token created in console.cast.ai API Access keys section"
+}
+
+variable "delete_nodes_on_disconnect" {
+  type        = bool
+  description = "Optional parameter, if set to true - CAST AI provisioned nodes will be deleted from cloud on cluster disconnection."
+  default     = true
+}
+
+variable "tags" {
+  type        = map(any)
+  description = "Optional tags for new cluster nodes."
+  default     = {}
+}
+
+variable "node_resource_group" {
+  type        = string
+  description = "AKS node resource group name."
+}
+
+variable "resource_group" {
+  type        = string
+  description = "AKS cluster resource group name."
+}
+
+variable "subscription_id" {
+  type        = string
+  description = "Azure subscription ID."
+}
+
+variable "tenant_id" {
+  type        = string
+  description = "Azure tenant ID."
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "Azure subnet ID for CAST AI nodes."
+}
+
+variable "install_helm_live" {
+  type        = bool
+  description = "If set to true - the 'castai-live' Helm chart will be installed on the cluster. Required for live migration functionality."
+  default     = true
+}
+
+variable "live_helm_version" {
+  type        = string
+  description = "Version of the castai-live Helm chart to install."
+  default     = "0.91.0"
+}

--- a/examples/aks/aks_cluster_live_migration/module/castai/versions.tf
+++ b/examples/aks/aks_cluster_live_migration/module/castai/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.3.2"
+
+  required_providers {
+    castai = {
+      source  = "castai/castai"
+      version = ">= 6.0.0"
+    }
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/examples/aks/aks_cluster_live_migration/variables.tf
+++ b/examples/aks/aks_cluster_live_migration/variables.tf
@@ -1,18 +1,17 @@
-# EKS module variables.
 variable "cluster_name" {
   type        = string
-  description = "EKS cluster name in AWS account."
+  description = "Name of the AKS cluster, resources will be created for."
 }
 
 variable "cluster_region" {
   type        = string
-  description = "AWS Region in which EKS cluster and supporting resources will be created."
+  description = "Region of the AKS cluster, resources will be created for."
 }
 
 variable "cluster_version" {
   type        = string
-  description = "EKS cluster version."
-  default     = "1.34"
+  description = "AKS cluster version."
+  default     = "1.32"
 }
 
 variable "castai_api_url" {
@@ -21,7 +20,6 @@ variable "castai_api_url" {
   default     = "https://api.cast.ai"
 }
 
-# Variables required for connecting EKS cluster to CAST AI.
 variable "castai_api_token" {
   type        = string
   description = "CAST AI API token created in console.cast.ai API Access keys section"
@@ -45,13 +43,19 @@ variable "tags" {
   default     = {}
 }
 
+variable "subscription_id" {
+  type        = string
+  description = "Azure subscription ID"
+}
+
 variable "enable_castai" {
+  type    = bool
   default = true
 }
 
 variable "install_helm_live" {
   type        = bool
-  description = "Optional parameter, if set to true - the 'castai-live' Helm chart will be installed on the cluster. Helm chart must be installed to enable live migration functionality, the option exists only for developers."
+  description = "Optional parameter, if set to true - the 'castai-live' Helm chart will be installed on the cluster. Helm chart must be installed to enable live migration functionality."
   default     = true
 }
 

--- a/examples/aks/aks_cluster_live_migration/versions.tf
+++ b/examples/aks/aks_cluster_live_migration/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    azuread = {
+      source = "hashicorp/azuread"
+    }
+    castai = {
+      source = "castai/castai"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+  }
+  required_version = ">= 1.3.2"
+}

--- a/examples/eks/eks_cluster_live_migration/module/castai/variables.tf
+++ b/examples/eks/eks_cluster_live_migration/module/castai/variables.tf
@@ -8,7 +8,8 @@ variable "cluster_region" {
 }
 
 variable "live_helm_version" {
-  type = string
+  type    = string
+  default = "0.91.0"
 }
 
 variable "tags" {

--- a/examples/eks/eks_cluster_live_migration/terraform.tfvars.example
+++ b/examples/eks/eks_cluster_live_migration/terraform.tfvars.example
@@ -2,4 +2,4 @@ cluster_name     = "<place-holder>"
 cluster_region   = "<place-holder>"
 castai_api_token = "<place-holder>"
 
-live_helm_version = "0.65.0"
+live_helm_version = "0.91.0"

--- a/examples/gke/gke_live_migration/README.MD
+++ b/examples/gke/gke_live_migration/README.MD
@@ -28,6 +28,13 @@ tofu destroy
 
 Please refer to this guide if you run into any issues https://docs.cast.ai/docs/terraform-troubleshooting
 
+# CLM Configuration
+
+CLM is enabled by having:
+1. A dedicated `live` node configuration in `castai.tf` using a COS or Ubuntu image with the appropriate init script (`init_cos.sh` or `init_ubuntu.sh`) to prepare nodes for live migration.
+2. A `live_tmpl` node template with `clm_enabled = true` and `should_taint = true` that uses the `live` node configuration. The taint ensures only workloads that tolerate the live-migration taint will be scheduled on CLM-enabled nodes.
+3. The `default_by_castai` template has `clm_enabled = true` for general cluster nodes.
+
 # Notes
 
 - Make sure to rebalance the cluster after it is fully onboarded, we replace the original image with a new image we know that contains a new version of containerd and is compatible with live.

--- a/examples/gke/gke_live_migration/castai.tf
+++ b/examples/gke/gke_live_migration/castai.tf
@@ -45,10 +45,18 @@ module "castai-gke-cluster" {
   gke_credentials            = module.castai-gke-iam.private_key
   delete_nodes_on_disconnect = true
 
-  default_node_configuration = module.castai-gke-cluster.castai_node_configurations["default"]
+  default_node_configuration_name = "default"
 
   node_configurations = {
     default = {
+      disk_cpu_ratio = 25
+      subnets        = [module.vpc.subnets_ids[0]]
+      # https://cloud.google.com/container-optimized-os/docs/release-notes/m121
+      image       = "projects/cos-cloud/global/images/cos-121-18867-90-59"
+      init_script = base64encode(file(local.init_script))
+    }
+
+    live = {
       disk_cpu_ratio = 25
       subnets        = [module.vpc.subnets_ids[0]]
       # https://cloud.google.com/container-optimized-os/docs/release-notes/m121
@@ -59,11 +67,11 @@ module "castai-gke-cluster" {
 
   node_templates = {
     default_by_castai = {
-      name             = "default-by-castai"
-      configuration_id = module.castai-gke-cluster.castai_node_configurations["default"]
-      is_default       = true
-      is_enabled       = true
-      should_taint     = false
+      name               = "default-by-castai"
+      configuration_name = "default"
+      is_default         = true
+      is_enabled         = true
+      should_taint       = false
 
       constraints = {
         on_demand          = true
@@ -72,6 +80,21 @@ module "castai-gke-cluster" {
 
         enable_spot_diversity                       = false
         spot_diversity_price_increase_limit_percent = 20
+      }
+    }
+
+    live_tmpl = {
+      configuration_name = "live"
+      is_enabled         = true
+      should_taint       = true
+      clm_enabled        = true
+
+      constraints = {
+        on_demand = true
+        spot      = true
+        instance_families = {
+          enabled = ["n2", "n2d", "c2", "c2d"]
+        }
       }
     }
   }


### PR DESCRIPTION
- Adding proper examples of node configuration
- bumping live chart to latest
- improving comments in docs to make sure do not cause ambiquiti

---
### Kimchi Summary
### What changed
Updated the `clm_enabled` field description in `castai_node_template` to clarify that Container Live Migration is supported on EKS, GKE, and AKS. Added a new AKS live migration example and refreshed the EKS and GKE examples to use named node configurations, current Helm chart defaults, and explicit live-migration node templates.

### Why
Provides clearer schema documentation and adds a complete AKS reference implementation for CLM, complementing the existing EKS and GKE examples.

### Key changes
- `castai/resource_node_template.go` — Expanded the `clm_enabled` field description to state that Container Live Migration is supported on EKS, GKE, and AKS, and that CLM-enabled nodes participate in live workload migration during rebalancing, scale-down, and node lifecycle events.
- `docs/resources/node_template.md` — Synchronized the `clm_enabled` documentation with the updated schema description.
- `examples/aks/aks_cluster_live_migration/` — Added a full AKS example including README, root Terraform files, and a reusable `castai` module that provisions an AKS cluster, connects it to CAST AI, enables CLM via `clm_enabled = true`, and installs the `castai-live` Helm chart.
- `examples/eks/eks_cluster_live_migration/module/castai/castai.tf` — Refactored node configurations and templates to reference `configuration_name` instead of `configuration_id`, removed intermediate `locals`, and added instance family constraints to the `live_tmpl` template.
- `examples/eks/eks_cluster_live_migration/` — Bumped `live_helm_version` default to `0.91.0` in root and module `variables.tf`, and updated `terraform.tfvars.example`.
- `examples/gke/gke_live_migration/castai.tf` — Switched from `default_node_configuration` to `default_node_configuration_name`, added a dedicated `live` node configuration, and introduced a `live_tmpl` node template with `clm_enabled = true` and `should_taint = true`.
- `examples/gke/gke_live_migration/README.MD` — Added a section detailing the required CLM configuration components for the GKE example.

### Impact
The EKS and GKE examples now use `configuration_name` instead of `configuration_id` when linking node configurations to templates. Users copying these patterns should update their configurations accordingly. No breaking changes to the provider resource schema.