### PR TITLE
CSU-5202: Clarify aggressive mode configuration parameters

### DIFF
--- a/castai/resource_rebalancing_schedule.go
+++ b/castai/resource_rebalancing_schedule.go
@@ -282,7 +282,7 @@ func warnIfAggressiveModeShadowsConfig(d *schema.ResourceData) diag.Diagnostics 
 	return diag.Diagnostics{{
 		Severity:      diag.Warning,
 		Summary:       "aggressive_mode_config is ignored while aggressive_mode = true",
-		Detail:        "The legacy `aggressive_mode` overrides `aggressive_mode_config`, so the granular settings will not be applied and Terraform will report a perpetual diff. Set `aggressive_mode = false` to use `aggressive_mode_config`, or remove the `aggressive_mode_config` block.",
+		Detail:        "The legacy `aggressive_mode` overrides `aggressive_mode_config`, so the granular settings will not be applied and Terraform will report a perpetual diff. Set `aggressive_mode=false` to use `aggressive_mode_config`, or remove the `aggressive_mode_config` block.",
 		AttributePath: cty.GetAttrPath("launch_configuration").IndexInt(0).GetAttr("aggressive_mode_config"),
 	}}
 }

--- a/castai/resource_rebalancing_schedule.go
+++ b/castai/resource_rebalancing_schedule.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -120,7 +121,7 @@ func resourceRebalancingSchedule() *schema.Resource {
 						"aggressive_mode": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Description: "When enabled, rebalancing considers all problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic — equivalent to enabling every option in `aggressive_mode_config`.",
+							Description: "When enabled, rebalancing considers all problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic.",
 						},
 						"aggressive_mode_config": {
 							Type:     schema.TypeList,
@@ -206,6 +207,8 @@ func resourceRebalancingScheduleCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
+	diags := warnIfAggressiveModeShadowsConfig(d)
+
 	req := sdk.ScheduledRebalancingAPICreateRebalancingScheduleJSONRequestBody{
 		Name:                schedule.Name,
 		Schedule:            schedule.Schedule,
@@ -215,12 +218,12 @@ func resourceRebalancingScheduleCreate(ctx context.Context, d *schema.ResourceDa
 
 	resp, err := client.ScheduledRebalancingAPICreateRebalancingScheduleWithResponse(ctx, req)
 	if checkErr := sdk.CheckOKResponse(resp, err); checkErr != nil {
-		return diag.FromErr(checkErr)
+		return append(diags, diag.FromErr(checkErr)...)
 	}
 
 	d.SetId(*resp.JSON200.Id)
 
-	return resourceRebalancingScheduleRead(ctx, d, meta)
+	return append(diags, resourceRebalancingScheduleRead(ctx, d, meta)...)
 }
 
 func resourceRebalancingScheduleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -248,6 +251,8 @@ func resourceRebalancingScheduleUpdate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
+	diags := warnIfAggressiveModeShadowsConfig(d)
+
 	req := sdk.ScheduledRebalancingAPIUpdateRebalancingScheduleJSONRequestBody{
 		Name:                lo.ToPtr(schedule.Name),
 		Schedule:            &schedule.Schedule,
@@ -259,9 +264,27 @@ func resourceRebalancingScheduleUpdate(ctx context.Context, d *schema.ResourceDa
 		Id: lo.ToPtr(d.Id()),
 	}, req)
 	if checkErr := sdk.CheckOKResponse(resp, err); checkErr != nil {
-		return diag.FromErr(checkErr)
+		return append(diags, diag.FromErr(checkErr)...)
 	}
-	return resourceRebalancingScheduleRead(ctx, d, meta)
+	return append(diags, resourceRebalancingScheduleRead(ctx, d, meta)...)
+}
+
+func warnIfAggressiveModeShadowsConfig(d *schema.ResourceData) diag.Diagnostics {
+	launchCfg := toSection(d, "launch_configuration")
+	if launchCfg == nil {
+		return nil
+	}
+	aggressive, _ := launchCfg["aggressive_mode"].(bool)
+	modeCfg, _ := launchCfg["aggressive_mode_config"].([]any)
+	if !aggressive || len(modeCfg) == 0 {
+		return nil
+	}
+	return diag.Diagnostics{{
+		Severity:      diag.Warning,
+		Summary:       "aggressive_mode_config is ignored while aggressive_mode = true",
+		Detail:        "The legacy `aggressive_mode` overrides `aggressive_mode_config`, so the granular settings will not be applied and Terraform will report a perpetual diff. Set `aggressive_mode = false` to use `aggressive_mode_config`, or remove the `aggressive_mode_config` block.",
+		AttributePath: cty.GetAttrPath("launch_configuration").IndexInt(0).GetAttr("aggressive_mode_config"),
+	}}
 }
 
 func resourceRebalancingScheduleDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/castai/resource_rebalancing_schedule.go
+++ b/castai/resource_rebalancing_schedule.go
@@ -120,7 +120,7 @@ func resourceRebalancingSchedule() *schema.Resource {
 						"aggressive_mode": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Description: "When enabled rebalancing will also consider problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic.",
+							Description: "When enabled, rebalancing considers all problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic — equivalent to enabling every option in `aggressive_mode_config`.",
 						},
 						"aggressive_mode_config": {
 							Type:     schema.TypeList,
@@ -150,7 +150,7 @@ func resourceRebalancingSchedule() *schema.Resource {
 									},
 								},
 							},
-							Description: "Advanced configuration for aggressive rebalancing mode.",
+							Description: "Advanced configuration for aggressive rebalancing mode. Only takes effect when `aggressive_mode = false` (or unset); while the `aggressive_mode` is `true`, these values are ignored by the backend.",
 						},
 						"execution_conditions": {
 							Type:     schema.TypeList,

--- a/castai/resource_rebalancing_schedule.go
+++ b/castai/resource_rebalancing_schedule.go
@@ -150,7 +150,7 @@ func resourceRebalancingSchedule() *schema.Resource {
 									},
 								},
 							},
-							Description: "Advanced configuration for aggressive rebalancing mode. Only takes effect when `aggressive_mode = false` (or unset); while the `aggressive_mode` is `true`, these values are ignored by the backend.",
+							Description: "Advanced configuration for the aggressive rebalancing mode. This is the recommended way to configure aggressive rebalancing. Please keep the `aggressive_mode` parameter unset or set it `aggressive_mode=false` before using this config option. When the legacy `aggressive_mode` is set to `true`, it takes precedence over this option.",
 						},
 						"execution_conditions": {
 							Type:     schema.TypeList,

--- a/docs/resources/rebalancing_schedule.md
+++ b/docs/resources/rebalancing_schedule.md
@@ -27,6 +27,12 @@ resource "castai_rebalancing_schedule" "spots" {
     num_targeted_nodes       = 3
     rebalancing_min_nodes    = 2
     keep_drain_timeout_nodes = false
+    aggressive_mode_config {
+      ignore_local_persistent_volumes        = false
+      ignore_problem_job_pods                = false
+      ignore_problem_pods_without_controller = true
+      ignore_problem_removal_disabled_pods   = false
+    }
     selector = jsonencode({
       nodeSelectorTerms = [{
         matchExpressions = [
@@ -69,7 +75,7 @@ resource "castai_rebalancing_schedule" "spots" {
 Optional:
 
 - `aggressive_mode` (Boolean) When enabled, rebalancing considers all problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic — equivalent to enabling every option in `aggressive_mode_config`.
-- `aggressive_mode_config` (Block List, Max: 1) Advanced configuration for aggressive rebalancing mode. Only takes effect when `aggressive_mode = false` (or unset); while the `aggressive_mode` is `true`, these values are ignored by the backend. (see [below for nested schema](#nestedblock--launch_configuration--aggressive_mode_config))
+- `aggressive_mode_config` (Block List, Max: 1) Advanced configuration for the aggressive rebalancing mode. This is the recommended way to configure aggressive rebalancing. Please keep the `aggressive_mode` parameter unset or set it `aggressive_mode=false` before using this config option. When the legacy `aggressive_mode` is set to `true`, it takes precedence over this option. (see [below for nested schema](#nestedblock--launch_configuration--aggressive_mode_config))
 - `execution_conditions` (Block List, Max: 1) (see [below for nested schema](#nestedblock--launch_configuration--execution_conditions))
 - `keep_drain_timeout_nodes` (Boolean) Defines whether the nodes that failed to get drained until a predefined timeout, will be kept with a rebalancing.cast.ai/status=drain-failed annotation instead of forcefully drained.
 - `node_ttl_seconds` (Number) Specifies amount of time since node creation before the node is allowed to be considered for automated rebalancing.

--- a/docs/resources/rebalancing_schedule.md
+++ b/docs/resources/rebalancing_schedule.md
@@ -74,7 +74,7 @@ resource "castai_rebalancing_schedule" "spots" {
 
 Optional:
 
-- `aggressive_mode` (Boolean) When enabled, rebalancing considers all problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic — equivalent to enabling every option in `aggressive_mode_config`.
+- `aggressive_mode` (Boolean) When enabled, rebalancing considers all problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic.
 - `aggressive_mode_config` (Block List, Max: 1) Advanced configuration for the aggressive rebalancing mode. This is the recommended way to configure aggressive rebalancing. Please keep the `aggressive_mode` parameter unset or set it `aggressive_mode=false` before using this config option. When the legacy `aggressive_mode` is set to `true`, it takes precedence over this option. (see [below for nested schema](#nestedblock--launch_configuration--aggressive_mode_config))
 - `execution_conditions` (Block List, Max: 1) (see [below for nested schema](#nestedblock--launch_configuration--execution_conditions))
 - `keep_drain_timeout_nodes` (Boolean) Defines whether the nodes that failed to get drained until a predefined timeout, will be kept with a rebalancing.cast.ai/status=drain-failed annotation instead of forcefully drained.

--- a/docs/resources/rebalancing_schedule.md
+++ b/docs/resources/rebalancing_schedule.md
@@ -68,8 +68,8 @@ resource "castai_rebalancing_schedule" "spots" {
 
 Optional:
 
-- `aggressive_mode` (Boolean) When enabled rebalancing will also consider problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic.
-- `aggressive_mode_config` (Block List, Max: 1) Advanced configuration for aggressive rebalancing mode. (see [below for nested schema](#nestedblock--launch_configuration--aggressive_mode_config))
+- `aggressive_mode` (Boolean) When enabled, rebalancing considers all problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic — equivalent to enabling every option in `aggressive_mode_config`.
+- `aggressive_mode_config` (Block List, Max: 1) Advanced configuration for aggressive rebalancing mode. Only takes effect when `aggressive_mode = false` (or unset); while the `aggressive_mode` is `true`, these values are ignored by the backend. (see [below for nested schema](#nestedblock--launch_configuration--aggressive_mode_config))
 - `execution_conditions` (Block List, Max: 1) (see [below for nested schema](#nestedblock--launch_configuration--execution_conditions))
 - `keep_drain_timeout_nodes` (Boolean) Defines whether the nodes that failed to get drained until a predefined timeout, will be kept with a rebalancing.cast.ai/status=drain-failed annotation instead of forcefully drained.
 - `node_ttl_seconds` (Number) Specifies amount of time since node creation before the node is allowed to be considered for automated rebalancing.

--- a/examples/resources/castai_rebalancing_schedule/resource.tf
+++ b/examples/resources/castai_rebalancing_schedule/resource.tf
@@ -12,6 +12,12 @@ resource "castai_rebalancing_schedule" "spots" {
     num_targeted_nodes       = 3
     rebalancing_min_nodes    = 2
     keep_drain_timeout_nodes = false
+    aggressive_mode_config {
+      ignore_local_persistent_volumes        = false
+      ignore_problem_job_pods                = false
+      ignore_problem_pods_without_controller = true
+      ignore_problem_removal_disabled_pods   = false
+    }
     selector = jsonencode({
       nodeSelectorTerms = [{
         matchExpressions = [


### PR DESCRIPTION
aggressive_mode_config takes precedence only when the legacy aggressive_mode is false

---
### Kimchi Summary
### What changed
Emits a Terraform warning when the legacy `aggressive_mode` parameter shadows the newer `aggressive_mode_config` block in `castai_rebalancing_schedule`, and clarifies field descriptions to explain precedence.

### Why
Setting both options simultaneously causes silent shadowing and a perpetual diff, because `aggressive_mode=true` overrides the granular config. This surfaces the conflict to the user and steers them toward the recommended `aggressive_mode_config`.

### Key changes
- `castai/resource_rebalancing_schedule.go`
  - Added `warnIfAggressiveModeShadowsConfig` to return a diagnostic warning when both `aggressive_mode=true` and `aggressive_mode_config` are present.
  - Updated `resourceRebalancingScheduleCreate` and `resourceRebalancingScheduleUpdate` to invoke the check and append warnings to the result.
  - Refined schema descriptions for `aggressive_mode` and `aggressive_mode_config` to document precedence.
- `docs/resources/rebalancing_schedule.md`
  - Updated argument descriptions and added an `aggressive_mode_config` example block.
- `examples/resources/castai_rebalancing_schedule/resource.tf`
  - Added an example `aggressive_mode_config` block.

### Impact
During create and update operations, Terraform now surfaces a warning if the legacy `aggressive_mode` flag is set alongside `aggressive_mode_config`, indicating that the config block is ignored and providing remediation steps. This is fully backward compatible.