### PR TITLE
feat: Allow the default value of rolloutBehavior.type

### DIFF
--- a/castai/resource_workload_scaling_policy.go
+++ b/castai/resource_workload_scaling_policy.go
@@ -53,6 +53,7 @@ const (
 	FieldRolloutBehavior                           = "rollout_behavior"
 	FieldRolloutBehaviorType                       = "type"
 	FieldRolloutBehaviorNoDisruptionType           = "NO_DISRUPTION"
+	FieldRolloutBehaviorUnspecifiedType            = "UNSPECIFIED"
 	FieldRolloutBehaviorPreferOneByOneType         = "prefer_one_by_one"
 	FieldRolloutBehaviorDelaySeconds               = "delay_seconds"
 	FieldJVM                                       = "jvm"
@@ -317,9 +318,11 @@ It can be either:
 						FieldRolloutBehaviorType: {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  FieldRolloutBehaviorUnspecifiedType,
 							Description: `Defines the rollout type to be used when applying recommendations.
-	- NO_DISRUPTION - pods are restarted without causing service disruption.`,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{FieldRolloutBehaviorNoDisruptionType}, false)),
+	- NO_DISRUPTION - pods are restarted without causing service disruption.
+	- UNSPECIFIED - rollout type is not specified.`,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{FieldRolloutBehaviorNoDisruptionType, FieldRolloutBehaviorUnspecifiedType}, false)),
 						},
 						FieldRolloutBehaviorPreferOneByOneType: {
 							Type:        schema.TypeBool,

--- a/castai/resource_workload_scaling_policy_test.go
+++ b/castai/resource_workload_scaling_policy_test.go
@@ -720,6 +720,14 @@ func Test_toRolloutBehavior(t *testing.T) {
 				Type: lo.ToPtr(sdk.NODISRUPTION),
 			},
 		},
+		"should return rollout behavior settings with UNSPECIFIED type": {
+			args: map[string]any{
+				FieldRolloutBehaviorType: FieldRolloutBehaviorUnspecifiedType,
+			},
+			exp: &sdk.WorkloadoptimizationV1RolloutBehaviorSettings{
+				Type: lo.ToPtr(sdk.UNSPECIFIED),
+			},
+		},
 		"should return rollout behavior settings with prefer_one_by_one": {
 			args: map[string]any{
 				FieldRolloutBehaviorType:               FieldRolloutBehaviorNoDisruptionType,

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -9190,6 +9190,18 @@ type WorkloadoptimizationV1GetWorkloadNativeVpaSpecResponse struct {
 	OrganizationId string                  `json:"organizationId"`
 }
 
+// WorkloadoptimizationV1GetWorkloadRecommendationManifestResponse defines model for workloadoptimization.v1.GetWorkloadRecommendationManifestResponse.
+type WorkloadoptimizationV1GetWorkloadRecommendationManifestResponse struct {
+	ClusterId string `json:"clusterId"`
+	Id        string `json:"id"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+
+	// Object Unstructured view of the Recommendation CR (autoscaling.cast.ai/v1, kind=Recommendation).
+	Object         map[string]interface{} `json:"object"`
+	OrganizationId string                 `json:"organizationId"`
+}
+
 // WorkloadoptimizationV1GetWorkloadResponse defines model for workloadoptimization.v1.GetWorkloadResponse.
 type WorkloadoptimizationV1GetWorkloadResponse struct {
 	Metrics *WorkloadoptimizationV1WorkloadMetrics `json:"metrics,omitempty"`

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -1017,6 +1017,9 @@ type ClientInterface interface {
 	// WorkloadOptimizationAPIGetWorkloadNativeVpaSpec request
 	WorkloadOptimizationAPIGetWorkloadNativeVpaSpec(ctx context.Context, clusterId string, workloadId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// WorkloadOptimizationAPIGetWorkloadRecommendationManifest request
+	WorkloadOptimizationAPIGetWorkloadRecommendationManifest(ctx context.Context, clusterId string, workloadId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// WorkloadOptimizationAPIGetWorkloadSpec request
 	WorkloadOptimizationAPIGetWorkloadSpec(ctx context.Context, clusterId string, workloadId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -5091,6 +5094,18 @@ func (c *Client) WorkloadOptimizationAPIGetWorkload(ctx context.Context, cluster
 
 func (c *Client) WorkloadOptimizationAPIGetWorkloadNativeVpaSpec(ctx context.Context, clusterId string, workloadId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewWorkloadOptimizationAPIGetWorkloadNativeVpaSpecRequest(c.Server, clusterId, workloadId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) WorkloadOptimizationAPIGetWorkloadRecommendationManifest(ctx context.Context, clusterId string, workloadId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewWorkloadOptimizationAPIGetWorkloadRecommendationManifestRequest(c.Server, clusterId, workloadId)
 	if err != nil {
 		return nil, err
 	}
@@ -20870,6 +20885,47 @@ func NewWorkloadOptimizationAPIGetWorkloadNativeVpaSpecRequest(server string, cl
 	return req, nil
 }
 
+// NewWorkloadOptimizationAPIGetWorkloadRecommendationManifestRequest generates requests for WorkloadOptimizationAPIGetWorkloadRecommendationManifest
+func NewWorkloadOptimizationAPIGetWorkloadRecommendationManifestRequest(server string, clusterId string, workloadId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "clusterId", runtime.ParamLocationPath, clusterId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "workloadId", runtime.ParamLocationPath, workloadId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/workload-autoscaling/clusters/%s/workloads/%s/recommendation-manifest", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewWorkloadOptimizationAPIGetWorkloadSpecRequest generates requests for WorkloadOptimizationAPIGetWorkloadSpec
 func NewWorkloadOptimizationAPIGetWorkloadSpecRequest(server string, clusterId string, workloadId string) (*http.Request, error) {
 	var err error
@@ -22690,6 +22746,9 @@ type ClientWithResponsesInterface interface {
 
 	// WorkloadOptimizationAPIGetWorkloadNativeVpaSpec request
 	WorkloadOptimizationAPIGetWorkloadNativeVpaSpecWithResponse(ctx context.Context, clusterId string, workloadId string) (*WorkloadOptimizationAPIGetWorkloadNativeVpaSpecResponse, error)
+
+	// WorkloadOptimizationAPIGetWorkloadRecommendationManifest request
+	WorkloadOptimizationAPIGetWorkloadRecommendationManifestWithResponse(ctx context.Context, clusterId string, workloadId string) (*WorkloadOptimizationAPIGetWorkloadRecommendationManifestResponse, error)
 
 	// WorkloadOptimizationAPIGetWorkloadSpec request
 	WorkloadOptimizationAPIGetWorkloadSpecWithResponse(ctx context.Context, clusterId string, workloadId string) (*WorkloadOptimizationAPIGetWorkloadSpecResponse, error)
@@ -30328,6 +30387,36 @@ func (r WorkloadOptimizationAPIGetWorkloadNativeVpaSpecResponse) GetBody() []byt
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
+type WorkloadOptimizationAPIGetWorkloadRecommendationManifestResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *WorkloadoptimizationV1GetWorkloadRecommendationManifestResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r WorkloadOptimizationAPIGetWorkloadRecommendationManifestResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r WorkloadOptimizationAPIGetWorkloadRecommendationManifestResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r WorkloadOptimizationAPIGetWorkloadRecommendationManifestResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
 type WorkloadOptimizationAPIGetWorkloadSpecResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -33604,6 +33693,15 @@ func (c *ClientWithResponses) WorkloadOptimizationAPIGetWorkloadNativeVpaSpecWit
 		return nil, err
 	}
 	return ParseWorkloadOptimizationAPIGetWorkloadNativeVpaSpecResponse(rsp)
+}
+
+// WorkloadOptimizationAPIGetWorkloadRecommendationManifestWithResponse request returning *WorkloadOptimizationAPIGetWorkloadRecommendationManifestResponse
+func (c *ClientWithResponses) WorkloadOptimizationAPIGetWorkloadRecommendationManifestWithResponse(ctx context.Context, clusterId string, workloadId string) (*WorkloadOptimizationAPIGetWorkloadRecommendationManifestResponse, error) {
+	rsp, err := c.WorkloadOptimizationAPIGetWorkloadRecommendationManifest(ctx, clusterId, workloadId)
+	if err != nil {
+		return nil, err
+	}
+	return ParseWorkloadOptimizationAPIGetWorkloadRecommendationManifestResponse(rsp)
 }
 
 // WorkloadOptimizationAPIGetWorkloadSpecWithResponse request returning *WorkloadOptimizationAPIGetWorkloadSpecResponse
@@ -40268,6 +40366,32 @@ func ParseWorkloadOptimizationAPIGetWorkloadNativeVpaSpecResponse(rsp *http.Resp
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest WorkloadoptimizationV1GetWorkloadNativeVpaSpecResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseWorkloadOptimizationAPIGetWorkloadRecommendationManifestResponse parses an HTTP response from a WorkloadOptimizationAPIGetWorkloadRecommendationManifestWithResponse call
+func ParseWorkloadOptimizationAPIGetWorkloadRecommendationManifestResponse(rsp *http.Response) (*WorkloadOptimizationAPIGetWorkloadRecommendationManifestResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &WorkloadOptimizationAPIGetWorkloadRecommendationManifestResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest WorkloadoptimizationV1GetWorkloadRecommendationManifestResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -6615,6 +6615,26 @@ func (mr *MockClientInterfaceMockRecorder) WorkloadOptimizationAPIGetWorkloadNat
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetWorkloadNativeVpaSpec", reflect.TypeOf((*MockClientInterface)(nil).WorkloadOptimizationAPIGetWorkloadNativeVpaSpec), varargs...)
 }
 
+// WorkloadOptimizationAPIGetWorkloadRecommendationManifest mocks base method.
+func (m *MockClientInterface) WorkloadOptimizationAPIGetWorkloadRecommendationManifest(ctx context.Context, clusterId, workloadId string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, clusterId, workloadId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIGetWorkloadRecommendationManifest", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadOptimizationAPIGetWorkloadRecommendationManifest indicates an expected call of WorkloadOptimizationAPIGetWorkloadRecommendationManifest.
+func (mr *MockClientInterfaceMockRecorder) WorkloadOptimizationAPIGetWorkloadRecommendationManifest(ctx, clusterId, workloadId interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, clusterId, workloadId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetWorkloadRecommendationManifest", reflect.TypeOf((*MockClientInterface)(nil).WorkloadOptimizationAPIGetWorkloadRecommendationManifest), varargs...)
+}
+
 // WorkloadOptimizationAPIGetWorkloadScalingPolicy mocks base method.
 func (m *MockClientInterface) WorkloadOptimizationAPIGetWorkloadScalingPolicy(ctx context.Context, clusterId, policyId string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -18546,6 +18566,41 @@ func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIGetWorkloadNat
 func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIGetWorkloadNativeVpaSpecWithResponse(ctx, clusterId, workloadId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetWorkloadNativeVpaSpecWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIGetWorkloadNativeVpaSpecWithResponse), ctx, clusterId, workloadId)
+}
+
+// WorkloadOptimizationAPIGetWorkloadRecommendationManifest mocks base method.
+func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIGetWorkloadRecommendationManifest(ctx context.Context, clusterId, workloadId string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, clusterId, workloadId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIGetWorkloadRecommendationManifest", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadOptimizationAPIGetWorkloadRecommendationManifest indicates an expected call of WorkloadOptimizationAPIGetWorkloadRecommendationManifest.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIGetWorkloadRecommendationManifest(ctx, clusterId, workloadId interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, clusterId, workloadId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetWorkloadRecommendationManifest", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIGetWorkloadRecommendationManifest), varargs...)
+}
+
+// WorkloadOptimizationAPIGetWorkloadRecommendationManifestWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIGetWorkloadRecommendationManifestWithResponse(ctx context.Context, clusterId, workloadId string) (*sdk.WorkloadOptimizationAPIGetWorkloadRecommendationManifestResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIGetWorkloadRecommendationManifestWithResponse", ctx, clusterId, workloadId)
+	ret0, _ := ret[0].(*sdk.WorkloadOptimizationAPIGetWorkloadRecommendationManifestResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadOptimizationAPIGetWorkloadRecommendationManifestWithResponse indicates an expected call of WorkloadOptimizationAPIGetWorkloadRecommendationManifestWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIGetWorkloadRecommendationManifestWithResponse(ctx, clusterId, workloadId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetWorkloadRecommendationManifestWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIGetWorkloadRecommendationManifestWithResponse), ctx, clusterId, workloadId)
 }
 
 // WorkloadOptimizationAPIGetWorkloadScalingPolicy mocks base method.

--- a/docs/resources/workload_scaling_policy.md
+++ b/docs/resources/workload_scaling_policy.md
@@ -416,6 +416,7 @@ Optional:
 - `prefer_one_by_one` (Boolean) Defines if pods should be restarted one by one to avoid service disruption.
 - `type` (String) Defines the rollout type to be used when applying recommendations.
 	- NO_DISRUPTION - pods are restarted without causing service disruption.
+	- UNSPECIFIED - rollout type is not specified.
 
 
 <a id="nestedblock--startup"></a>


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for the `UNSPECIFIED` rollout behavior type in workload scaling policies and regenerates the CAST AI SDK to include the workload recommendation manifest endpoint.

### Why
Allows users to explicitly leave the rollout type unspecified when applying recommendations, keeping the provider in sync with the latest API behavior.

### Key changes
- `castai/resource_workload_scaling_policy.go`: Adds `FieldRolloutBehaviorUnspecifiedType` constant, sets `UNSPECIFIED` as the default value for `rollout_behavior.type`, and updates validation and description to accept `UNSPECIFIED`.
- `castai/resource_workload_scaling_policy_test.go`: Adds test coverage for mapping the `UNSPECIFIED` rollout behavior type to the SDK enum.
- `castai/sdk/api.gen.go`, `castai/sdk/client.gen.go`, `castai/sdk/mock/client.go`: Introduces the `WorkloadOptimizationAPIGetWorkloadRecommendationManifest` endpoint, request builders, response types, and mocks.
- `docs/resources/workload_scaling_policy.md`: Documents the new `UNSPECIFIED` option for `rollout_behavior.type`.

### Impact
- Existing `castai_workload_scaling_policy` resources without an explicit `rollout_behavior.type` will now show `UNSPECIFIED` as the default value in Terraform state and plans. No manual migration is required.