### PR TITLE
fix: redo example for castai_workload_scaling_policies

### DIFF
--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -8639,15 +8639,6 @@ type WorkloadoptimizationV1ConfigurationChangedV2 struct {
 	WorkloadConfig      WorkloadoptimizationV1WorkloadConfigV2    `json:"workloadConfig"`
 }
 
-// WorkloadoptimizationV1Constraints defines model for workloadoptimization.v1.Constraints.
-type WorkloadoptimizationV1Constraints struct {
-	// Max Defines the maximum value. For memory - this is in MiB, for CPU - this is in cores.
-	Max *float64 `json:"max"`
-
-	// Min Defines the minimum value. For memory - this is in MiB, for CPU - this is in cores.
-	Min *float64 `json:"min"`
-}
-
 // WorkloadoptimizationV1ConstraintsV2 ConstraintsV2 defines min/max bounds for the recommendation.
 // Each bound can be configured as a fixed constant value or as a percentage
 // of the original pod-spec request.
@@ -8730,13 +8721,22 @@ type WorkloadoptimizationV1ContainerConstraints struct {
 // WorkloadoptimizationV1ContainerConstraintsV2 defines model for workloadoptimization.v1.ContainerConstraintsV2.
 type WorkloadoptimizationV1ContainerConstraintsV2 struct {
 	// ContainerName Defines the container name for which the constraints are for.
-	ContainerName string                             `json:"containerName"`
-	Cpu           *WorkloadoptimizationV1Constraints `json:"cpu,omitempty"`
-	Memory        *WorkloadoptimizationV1Constraints `json:"memory,omitempty"`
+	ContainerName string `json:"containerName"`
+
+	// Cpu ContainerConstraintsV3 defines min and max resource constraints for container recommendations.
+	Cpu *WorkloadoptimizationV1ContainerConstraintsV3 `json:"cpu,omitempty"`
+
+	// Memory ContainerConstraintsV3 defines min and max resource constraints for container recommendations.
+	Memory *WorkloadoptimizationV1ContainerConstraintsV3 `json:"memory,omitempty"`
 }
 
 // WorkloadoptimizationV1ContainerConstraintsV3 ContainerConstraintsV3 defines min and max resource constraints for container recommendations.
 type WorkloadoptimizationV1ContainerConstraintsV3 struct {
+	// Constraints ConstraintsV2 defines min/max bounds for the recommendation.
+	// Each bound can be configured as a fixed constant value or as a percentage
+	// of the original pod-spec request.
+	Constraints *WorkloadoptimizationV1ConstraintsV2 `json:"constraints,omitempty"`
+
 	// Max Max values for the recommendation. For memory - this is in MiB, for CPU - this is in cores.
 	Max *float64 `json:"max"`
 
@@ -10329,6 +10329,11 @@ type WorkloadoptimizationV1ResourceConfigOverrides struct {
 	// Args The arguments for the function - i.e. for a quantile, this should be a [0, 1] float.
 	Args *[]string `json:"args,omitempty"`
 
+	// Constraints ConstraintsV2 defines min/max bounds for the recommendation.
+	// Each bound can be configured as a fixed constant value or as a percentage
+	// of the original pod-spec request.
+	Constraints *WorkloadoptimizationV1ConstraintsV2 `json:"constraints,omitempty"`
+
 	// Function The function which to use when calculating the resource recommendation.
 	// QUANTILE - the quantile function.
 	// MAX - the max function.
@@ -10360,6 +10365,11 @@ type WorkloadoptimizationV1ResourceConfigOverridesFunction string
 
 // WorkloadoptimizationV1ResourceConfigUpdate defines model for workloadoptimization.v1.ResourceConfigUpdate.
 type WorkloadoptimizationV1ResourceConfigUpdate struct {
+	// Constraints ConstraintsV2 defines min/max bounds for the recommendation.
+	// Each bound can be configured as a fixed constant value or as a percentage
+	// of the original pod-spec request.
+	Constraints *WorkloadoptimizationV1ConstraintsV2 `json:"constraints,omitempty"`
+
 	// Max Max values for the recommendation. For memory - this is in MiB, for CPU - this is in cores.
 	// If not set, there will be no upper bound for the recommendation (default behaviour).
 	Max *float64 `json:"max"`
@@ -10997,7 +11007,11 @@ type WorkloadoptimizationV1WorkloadRecommendation struct {
 
 // WorkloadoptimizationV1WorkloadResourceConfigUpdate defines model for workloadoptimization.v1.WorkloadResourceConfigUpdate.
 type WorkloadoptimizationV1WorkloadResourceConfigUpdate struct {
-	Limit *WorkloadoptimizationV1ResourceLimitStrategy `json:"limit,omitempty"`
+	// Constraints ConstraintsV2 defines min/max bounds for the recommendation.
+	// Each bound can be configured as a fixed constant value or as a percentage
+	// of the original pod-spec request.
+	Constraints *WorkloadoptimizationV1ConstraintsV2         `json:"constraints,omitempty"`
+	Limit       *WorkloadoptimizationV1ResourceLimitStrategy `json:"limit,omitempty"`
 
 	// LookBackPeriodSeconds Period of time over which the resource recommendation is calculated (default value is 24 hours).
 	LookBackPeriodSeconds *int32 `json:"lookBackPeriodSeconds"`

--- a/docs/data-sources/workload_scaling_policies.md
+++ b/docs/data-sources/workload_scaling_policies.md
@@ -22,9 +22,9 @@ data "castai_workload_scaling_policies" "cluster" {
 # policies list is also available for custom filtering with for expressions.
 
 # Define managed policies as normal resources.
-resource "castai_workload_scaling_policy" "htz_balanced" {
+resource "castai_workload_scaling_policy" "my_policy" {
   cluster_id        = castai_gke_cluster.cluster.id
-  name              = "htz-balanced"
+  name              = "my-policy"
   apply_type        = "IMMEDIATE"
   management_option = "MANAGED"
   cpu {
@@ -43,7 +43,7 @@ resource "castai_workload_scaling_policy" "htz_balanced" {
 resource "castai_workload_scaling_policy_order" "custom" {
   cluster_id = castai_gke_cluster.cluster.id
   policy_ids = [
-    castai_workload_scaling_policy.htz_balanced.id,                             # managed — reference directly
+    castai_workload_scaling_policy.my_policy.id,                                # managed — reference directly
     data.castai_workload_scaling_policies.cluster.policies_by_name["readonly"], # auto-generated castware policy
   ]
 }

--- a/examples/data-sources/castai_workload_scaling_policies/data-source.tf
+++ b/examples/data-sources/castai_workload_scaling_policies/data-source.tf
@@ -7,9 +7,9 @@ data "castai_workload_scaling_policies" "cluster" {
 # policies list is also available for custom filtering with for expressions.
 
 # Define managed policies as normal resources.
-resource "castai_workload_scaling_policy" "htz_balanced" {
+resource "castai_workload_scaling_policy" "my_policy" {
   cluster_id        = castai_gke_cluster.cluster.id
-  name              = "htz-balanced"
+  name              = "my-policy"
   apply_type        = "IMMEDIATE"
   management_option = "MANAGED"
   cpu {
@@ -28,7 +28,7 @@ resource "castai_workload_scaling_policy" "htz_balanced" {
 resource "castai_workload_scaling_policy_order" "custom" {
   cluster_id = castai_gke_cluster.cluster.id
   policy_ids = [
-    castai_workload_scaling_policy.htz_balanced.id,                             # managed — reference directly
+    castai_workload_scaling_policy.my_policy.id,                                # managed — reference directly
     data.castai_workload_scaling_policies.cluster.policies_by_name["readonly"], # auto-generated castware policy
   ]
 }


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Updates the generated workload optimization SDK models to adopt the latest API constraint definitions (`ConstraintsV2`) and removes the obsolete `WorkloadoptimizationV1Constraints` type. Documentation and examples are also refreshed to use generic policy names.

### Why
Aligns the provider with the updated workload optimization API schema, which now expresses container and workload resource bounds via percentage-aware `ConstraintsV2` definitions rather than legacy fixed-value constraints.

### Key changes
- `castai/sdk/api.gen.go`
  - Removed `WorkloadoptimizationV1Constraints`.
  - Updated `WorkloadoptimizationV1ContainerConstraintsV2.Cpu` and `.Memory` to reference `WorkloadoptimizationV1ContainerConstraintsV3`.
  - Added `Constraints` field of type `*WorkloadoptimizationV1ConstraintsV2` to `WorkloadoptimizationV1ContainerConstraintsV3`, `WorkloadoptimizationV1ResourceConfigOverrides`, `WorkloadoptimizationV1ResourceConfigUpdate`, and `WorkloadoptimizationV1WorkloadResourceConfigUpdate`.
- `docs/data-sources/workload_scaling_policies.md`
  - Renamed example `castai_workload_scaling_policy` resource from `htz_balanced` to `my_policy` and policy name from `htz-balanced` to `my-policy`.
- `examples/data-sources/castai_workload_scaling_policies/data-source.tf`
  - Renamed example `castai_workload_scaling_policy` resource from `htz_balanced` to `my_policy` and policy name from `htz-balanced` to `my-policy`.