### PR TITLE
chore: remove clusterTokenDiff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ terraform-provider-castai
 examples/**/.terraform/
 examples/**/terraform.d/
 examples/**/crash.log
+examples/**/.terraformrc
 examples/**/*.tfstate
 examples/**/*.tfstate.lock.info
 examples/**/*.tfstate.backup

--- a/castai/cluster.go
+++ b/castai/cluster.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -218,22 +217,4 @@ func createClusterToken(ctx context.Context, client sdk.ClientWithResponsesInter
 	}
 
 	return *resp.JSON200.Token, nil
-}
-
-func clusterTokenDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
-	if diff.Id() == "" {
-		return nil
-	}
-	if diff.Get(FieldClusterToken).(string) != "" {
-		return nil
-	}
-
-	// During migration to the latest version, cluster resource might have empty token as it was introduced later on.
-	// If that's the case - we are forcing re-creation by providing random new value and setting "ForceNew" flag.
-	log.Print("[INFO] token not set, forcing re-create")
-	if err := diff.SetNew(FieldClusterToken, uuid.NewString()); err != nil {
-		return fmt.Errorf("setting cluster token: %w", err)
-	}
-
-	return diff.ForceNew(FieldClusterToken)
 }

--- a/castai/resource_aks_cluster.go
+++ b/castai/resource_aks_cluster.go
@@ -35,7 +35,6 @@ func resourceAKSCluster() *schema.Resource {
 		CreateContext: resourceCastaiAKSClusterCreate,
 		UpdateContext: resourceCastaiAKSClusterUpdate,
 		DeleteContext: resourceCastaiClusterDelete,
-		CustomizeDiff: clusterTokenDiff,
 		Description:   "AKS cluster resource allows connecting an existing AKS cluster to CAST AI.",
 
 		Timeouts: &schema.ResourceTimeout{

--- a/castai/resource_aks_cluster_test.go
+++ b/castai/resource_aks_cluster_test.go
@@ -545,6 +545,9 @@ resource "castai_aks_cluster" "test" {
   client_secret   = %[5]q
   node_resource_group = "%[1]s-ng"
 
+  timeouts {
+    delete = "30m"
+  }
 }
 
 `, clusterName, subscriptionID, tenantID, clientID, clientSecret)
@@ -566,6 +569,10 @@ resource "castai_aks_cluster" "test" {
   client_id           = %[5]q
   federation_id       = %[2]q
   node_resource_group = "%[3]s-ng"
+
+  timeouts {
+    delete = "30m"
+  }
 }
 `, subscriptionID, federationID, clusterName, tenantID, clientID)
 }

--- a/castai/resource_eks_cluster.go
+++ b/castai/resource_eks_cluster.go
@@ -27,7 +27,6 @@ func resourceEKSCluster() *schema.Resource {
 		UpdateContext: resourceCastaiEKSClusterUpdate,
 		DeleteContext: resourceCastaiClusterDelete,
 		Description:   "EKS cluster resource allows connecting an existing EKS cluster to CAST AI.",
-		CustomizeDiff: clusterTokenDiff,
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),

--- a/castai/resource_gke_cluster.go
+++ b/castai/resource_gke_cluster.go
@@ -27,7 +27,6 @@ func resourceGKECluster() *schema.Resource {
 		ReadContext:   resourceCastaiGKEClusterRead,
 		UpdateContext: resourceCastaiGKEClusterUpdate,
 		DeleteContext: resourceCastaiGKEClusterDelete,
-		CustomizeDiff: clusterTokenDiff,
 		Description:   "GKE cluster resource allows connecting an existing GKE cluster to CAST AI.",
 
 		Timeouts: &schema.ResourceTimeout{

--- a/castai/resource_gke_cluster_id.go
+++ b/castai/resource_gke_cluster_id.go
@@ -28,7 +28,6 @@ func resourceGKEClusterId() *schema.Resource {
 		ReadContext:   resourceCastaiGKEClusterIdRead,
 		UpdateContext: resourceCastaiGKEClusterIdUpdate,
 		DeleteContext: resourceCastaiGKEClusterIdDelete,
-		CustomizeDiff: clusterTokenDiff,
 		Description:   "GKE cluster resource allows connecting an existing GKE cluster to CAST AI.",
 
 		Timeouts: &schema.ResourceTimeout{


### PR DESCRIPTION
Removing the `CustomizeDiff` function from the cluster resources. This was introduced in [2.0.6](https://github.com/castai/terraform-provider-castai/releases/tag/v2.0.6) as a migration step for old clusters not yet having a `cluster_token`. The reson for removal is that this diff is leading to unexpected behaviour when the state is lost and rebuilt (experinced in the `castai` Crossplane provider that is built from this TF provider).

It should be safe to remove as `2.0.6` was released 3+ years ago. For those running earlier versions, it's expected they'll migrate major versions one by one and then any version after 2.0.6 will take care of the migration. For already migrated clusters, this removal should have no affect.

Also fixing AKS tests that failed due to deletion taking too long. This is expected for these clusters that spend most of their time disconnected. When we're running init data collection after reconnecting them, the delete can take longer because of that.

## Proof of Work

Verified that this will have no effect on clusters onboarded after 2.0.6 by:

1. Onboarding an EKS cluster without this fix
2. Verified that provider with this fix included produces no diff on planning

Verified that this version will work as expested with new clusters by onboarding an EKS cluster with the fix in place.

---
### Kimchi Summary
### What changed
Removed the legacy `clusterTokenDiff` custom diff logic from all CAST AI cluster resources. The provider will no longer force recreation of a cluster resource when the `token` field is empty. Also added `.terraformrc` to `.gitignore` in the examples directory.

### Why
The `clusterTokenDiff` function was a temporary migration helper for state files created before the `token` field was added to cluster resources. That migration path is now obsolete.

### Key changes
- `castai/cluster.go`: Deleted the `clusterTokenDiff` function and removed the unused `github.com/google/uuid` import.
- `castai/resource_aks_cluster.go`: Removed `CustomizeDiff: clusterTokenDiff` from the AKS cluster schema.
- `castai/resource_eks_cluster.go`: Removed `CustomizeDiff: clusterTokenDiff` from the EKS cluster schema.
- `castai/resource_gke_cluster.go`: Removed `CustomizeDiff: clusterTokenDiff` from the GKE cluster schema.
- `castai/resource_gke_cluster_id.go`: Removed `CustomizeDiff: clusterTokenDiff` from the GKE cluster ID schema.
- `.gitignore`: Added `examples/**/.terraformrc` to ignore Terraform CLI configuration files in examples.

### Impact
Clusters with an empty `token` in state will no longer be forced to recreate. Verify that existing state files no longer rely on this legacy behavior before upgrading.

---
### Kimchi Summary
### What changed
Remove the legacy `clusterTokenDiff` custom diff logic from AKS, EKS, GKE, and GKE cluster ID resources so that an empty `token` no longer forces cluster recreation. Also updates `.gitignore` for example Terraform CLI config files and adds explicit delete timeouts to AKS test fixtures.

### Why
The `clusterTokenDiff` function was a migration helper for states created before the cluster `token` field existed. That migration is complete, making the forced-recreation behavior obsolete.

### Key changes
- `castai/cluster.go`: Deleted `clusterTokenDiff` and removed the unused `uuid` import.
- `castai/resource_aks_cluster.go`, `castai/resource_eks_cluster.go`, `castai/resource_gke_cluster.go`, `castai/resource_gke_cluster_id.go`: Removed `CustomizeDiff: clusterTokenDiff` from schema definitions.
- `castai/resource_aks_cluster_test.go`: Added `timeouts { delete = "30m" }` to AKS test configurations.
- `.gitignore`: Added `examples/**/.terraformrc`.

### Impact
Empty `token` values will no longer trigger a forced replacement of the cluster resource. This is a behavioral change for any remaining legacy states that still lack a token, which must now be handled explicitly by the operator.

---
### Kimchi Summary
### What changed
Remove the legacy `clusterTokenDiff` custom diff logic from AKS, EKS, GKE, and GKE ID cluster resources to stop forcing recreation when the cluster `token` field is empty. Also adds `.terraformrc` to `.gitignore` and explicit delete timeouts to AKS cluster test fixtures.

### Why
The `clusterTokenDiff` function was originally added as a temporary migration aid when the cluster token field was introduced. That migration period has passed, so the workaround is now obsolete and risks unnecessarily destroying and recreating existing cluster resources.

### Key changes
- `castai/cluster.go`: Removed the `clusterTokenDiff` function and the `github.com/google/uuid` import.
- `castai/resource_aks_cluster.go`, `castai/resource_eks_cluster.go`, `castai/resource_gke_cluster.go`, `castai/resource_gke_cluster_id.go`: Removed `CustomizeDiff: clusterTokenDiff` from each resource schema.
- `.gitignore`: Added `examples/**/.terraformrc`.
- `castai/resource_aks_cluster_test.go`: Added `timeouts { delete = "30m" }` to AKS test configurations.

### Impact
Existing clusters with an empty or unset `token` value will no longer be planned for replacement on apply. Review any existing state for token drift before upgrading, and run a state refresh if needed to populate the field.