### PR TITLE
chore: build against latest SDK

### DIFF
--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -3938,6 +3938,9 @@ type CastaiUsersV1beta1UserOrganization struct {
 	// Id id of the organization.
 	Id *string `json:"id,omitempty"`
 
+	// Internal Whether the organization is internal.
+	Internal *bool `json:"internal,omitempty"`
+
 	// Name name of the organization.
 	Name string `json:"name"`
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds the `internal` flag to the generated SDK's organization model to indicate whether a user organization is internal.

### Why
Keeps the Terraform provider's generated SDK in sync with the latest CAST AI API schema.

### Key changes
- `castai/sdk/api.gen.go`: Introduced `Internal *bool` field to the `CastaiUsersV1beta1UserOrganization` struct with JSON tag `internal`.