### PR TITLE
suppress diff in duration field e.g. 60s same as 1m

### DIFF
--- a/castai/resource_ai_optimizer_hosted_model.go
+++ b/castai/resource_ai_optimizer_hosted_model.go
@@ -53,9 +53,10 @@ const (
 var hibernationConditionSchema = &schema.Resource{
 	Schema: map[string]*schema.Schema{
 		fieldAIHostedModelConditionDuration: {
-			Type:        schema.TypeString,
-			Required:    true,
-			Description: "Time period for the condition evaluation.",
+			Type:             schema.TypeString,
+			Required:         true,
+			DiffSuppressFunc: diffSuppressDuration,
+			Description:      "Time period for the condition evaluation.",
 		},
 		fieldAIHostedModelConditionReqCount: {
 			Type:        schema.TypeInt,

--- a/castai/resource_autoscaler.go
+++ b/castai/resource_autoscaler.go
@@ -468,10 +468,11 @@ func resourceAutoscaler() *schema.Resource {
 													Description: "enable/disable scoped mode. By default, Evictor targets all nodes in the cluster. This mode will constrain it to just the nodes which were created by CAST AI.",
 												},
 												FieldEvictorCycleInterval: {
-													Type:        schema.TypeString,
-													Optional:    true,
-													Default:     "1m",
-													Description: "configure the interval duration between Evictor operations. This property can be used to lower or raise the frequency of the Evictor's find-and-drain operations.",
+													Type:             schema.TypeString,
+													Optional:         true,
+													Default:          "1m",
+													DiffSuppressFunc: diffSuppressDuration,
+													Description:      "configure the interval duration between Evictor operations. This property can be used to lower or raise the frequency of the Evictor's find-and-drain operations.",
 												},
 												FieldEvictorNodeGracePeriodMinutes: {
 													Type:        schema.TypeInt,
@@ -480,10 +481,11 @@ func resourceAutoscaler() *schema.Resource {
 													Description: "configure the node grace period which controls the duration which must pass after a node has been created before Evictor starts considering that node.",
 												},
 												FieldEvictorPodEvictionFailureBackOffInterval: {
-													Type:        schema.TypeString,
-													Optional:    true,
-													Default:     "5s",
-													Description: "configure the pod eviction failure back off interval. If pod eviction fails then Evictor will attempt to evict it again after the amount of time specified here.",
+													Type:             schema.TypeString,
+													Optional:         true,
+													Default:          "5s",
+													DiffSuppressFunc: diffSuppressDuration,
+													Description:      "configure the pod eviction failure back off interval. If pod eviction fails then Evictor will attempt to evict it again after the amount of time specified here.",
 												},
 												FieldEvictorIgnorePodDisruptionBudgets: {
 													Type:        schema.TypeBool,

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -9077,6 +9077,14 @@ type WorkloadoptimizationV1FailedHookEvent struct {
 	Time    time.Time `json:"time"`
 }
 
+// WorkloadoptimizationV1GPUSettings defines model for workloadoptimization.v1.GPUSettings.
+type WorkloadoptimizationV1GPUSettings struct {
+	// ManagementOption Defines possible options for workload management.
+	// READ_ONLY - workload watched (metrics collected), but no actions may be performed by CAST AI.
+	// MANAGED - workload watched (metrics collected), CAST AI may perform actions on the workload.
+	ManagementOption WorkloadoptimizationV1ManagementOption `json:"managementOption"`
+}
+
 // WorkloadoptimizationV1GetAgentStatusResponse defines model for workloadoptimization.v1.GetAgentStatusResponse.
 type WorkloadoptimizationV1GetAgentStatusResponse struct {
 	CastAgentCurrentVersion           *string    `json:"castAgentCurrentVersion"`
@@ -10132,6 +10140,7 @@ type WorkloadoptimizationV1RecommendationPolicies struct {
 	Cpu                WorkloadoptimizationV1ResourcePolicies          `json:"cpu"`
 	Downscaling        *WorkloadoptimizationV1DownscalingSettings      `json:"downscaling,omitempty"`
 	ExcludedContainers *[]string                                       `json:"excludedContainers,omitempty"`
+	Gpu                *WorkloadoptimizationV1GPUSettings              `json:"gpu,omitempty"`
 
 	// HpaConverters Configuration for converting existing HPAs when VPA is the sole optimization.
 	// If HPA management is enabled, it takes precedence over this setting.

--- a/castai/utils.go
+++ b/castai/utils.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -17,6 +18,18 @@ import (
 	"github.com/castai/terraform-provider-castai/castai/sdk"
 	"github.com/castai/terraform-provider-castai/castai/types"
 )
+
+// diffSuppressDuration suppresses diffs between two duration strings that represent
+// the same duration (e.g. "1m" and "60s"). When either value cannot be parsed as a
+// duration it falls back to plain string equality.
+func diffSuppressDuration(k, oldValue, newValue string, d *schema.ResourceData) bool {
+	oldDuration, oldErr := time.ParseDuration(oldValue)
+	newDuration, newErr := time.ParseDuration(newValue)
+	if oldErr != nil || newErr != nil {
+		return oldValue == newValue
+	}
+	return oldDuration == newDuration
+}
 
 func toPtr[S any](src S) *S {
 	return &src

--- a/castai/utils_test.go
+++ b/castai/utils_test.go
@@ -275,6 +275,96 @@ func Test_ExtractNestedValues(t *testing.T) {
 	}
 }
 
+func TestDiffSuppressDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		oldValue string
+		newValue string
+		want     bool
+	}{
+		{
+			name:     "equivalent durations same unit",
+			oldValue: "1m",
+			newValue: "1m",
+			want:     true,
+		},
+		{
+			name:     "equivalent durations different unit seconds to minutes",
+			oldValue: "60s",
+			newValue: "1m",
+			want:     true,
+		},
+		{
+			name:     "equivalent durations different unit minutes to hours",
+			oldValue: "60m",
+			newValue: "1h",
+			want:     true,
+		},
+		{
+			name:     "equivalent durations with nanoseconds",
+			oldValue: "1000000000ns",
+			newValue: "1s",
+			want:     true,
+		},
+		{
+			name:     "non-equivalent durations",
+			oldValue: "1m",
+			newValue: "2m",
+			want:     false,
+		},
+		{
+			name:     "non-equivalent durations different units",
+			oldValue: "1m",
+			newValue: "1h",
+			want:     false,
+		},
+		{
+			name:     "old value invalid falls back to string equality same",
+			oldValue: "not-a-duration",
+			newValue: "1m",
+			want:     false,
+		},
+		{
+			name:     "new value invalid falls back to string equality same",
+			oldValue: "1m",
+			newValue: "not-a-duration",
+			want:     false,
+		},
+		{
+			name:     "both values invalid string equality true",
+			oldValue: "not-a-duration",
+			newValue: "not-a-duration",
+			want:     true,
+		},
+		{
+			name:     "both values invalid string equality false",
+			oldValue: "not-a-duration",
+			newValue: "also-not",
+			want:     false,
+		},
+		{
+			name:     "empty strings equal",
+			oldValue: "",
+			newValue: "",
+			want:     true,
+		},
+		{
+			name:     "empty string and valid duration not equal",
+			oldValue: "",
+			newValue: "0s",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			got := diffSuppressDuration("test_key", tt.oldValue, tt.newValue, nil)
+			r.Equal(tt.want, got)
+		})
+	}
+}
+
 func testResource() *schema.Resource {
 	return &schema.Resource{
 		Description: "Terraform resource for testing",


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds a `diffSuppressDuration` helper and applies it to string-typed duration fields in the autoscaler and AI optimizer hosted model resources so that equivalent durations in different units no longer trigger plan diffs. Also updates the generated SDK to include GPU workload optimization settings.

### Why
Terraform was detecting changes when the API returned durations using different units than those specified in configuration (e.g., `1m` versus `60s`), causing noisy and unnecessary resource updates.

### Key changes
- `castai/utils.go`: Added `diffSuppressDuration` helper that parses duration strings via `time.ParseDuration` and suppresses diffs when old and new values represent the same duration; falls back to string equality for unparseable values.
- `castai/resource_autoscaler.go`: Added `DiffSuppressFunc: diffSuppressDuration` to `FieldEvictorCycleInterval` and `FieldEvictorPodEvictionFailureBackOffInterval`.
- `castai/resource_ai_optimizer_hosted_model.go`: Added `DiffSuppressFunc: diffSuppressDuration` to `fieldAIHostedModelConditionDuration`.
- `castai/sdk/api.gen.go`: Added `WorkloadoptimizationV1GPUSettings` type and the `Gpu` field to `WorkloadoptimizationV1RecommendationPolicies`.
- `castai/utils_test.go`: Added `TestDiffSuppressDuration` covering equivalent durations across units, non-equivalent durations, invalid inputs, and empty strings.