### PR TITLE
feat: add custom cloud provider support to edge location resource

### DIFF
--- a/castai/data_source_omni_cluster_test.go
+++ b/castai/data_source_omni_cluster_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccCloudAgnostic_DataSourceOmniCluster(t *testing.T) {
-	clusterName := "omni-tf-acc-gcp"
+	clusterName := "omni-tf-acc-ds"
 	dataSourceName := "data.castai_omni_cluster.test"
 	resourceName := "castai_omni_cluster.test"
 

--- a/castai/resource_edge_location.go
+++ b/castai/resource_edge_location.go
@@ -665,15 +665,6 @@ func (r *edgeLocationResource) Read(ctx context.Context, req resource.ReadReques
 		state.Zones = r.toZoneModel(edgeLocation.Zones)
 	}
 
-	// Reset all provider blocks before populating from the API response.
-	// This ensures that if a user switches providers (e.g. aws -> custom),
-	// the old provider block is cleared and does not break the exactly-one-of
-	// invariant or interfere with future provider switches.
-	state.AWS = nil
-	state.GCP = nil
-	state.OCI = nil
-	state.Custom = nil
-
 	var diags diag.Diagnostics
 	if edgeLocation.Aws != nil {
 		state.AWS, diags = r.toAWSModel(ctx, edgeLocation.Aws)

--- a/castai/resource_edge_location.go
+++ b/castai/resource_edge_location.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -52,6 +51,7 @@ type edgeLocationModel struct {
 	AWS              *awsModel          `tfsdk:"aws"`
 	GCP              *gcpModel          `tfsdk:"gcp"`
 	OCI              *ociModel          `tfsdk:"oci"`
+	Custom           *customModel       `tfsdk:"custom"`
 	// Computed revision number incremented each time credentials have changed.
 	CredentialsRevision types.Int64 `tfsdk:"credentials_revision"`
 }
@@ -121,6 +121,19 @@ type ociModel struct {
 	SecurityGroupID    types.String `tfsdk:"security_group_id"`
 }
 
+type customModel struct{}
+
+func (m customModel) credentials() types.String {
+	return types.StringNull()
+}
+
+func (m *customModel) Equal(other *customModel) bool {
+	if m == nil || other == nil {
+		return m == other
+	}
+	return true
+}
+
 func (m awsModel) credentials() types.String {
 	if m.AccessKeyIDWO.IsNull() && m.SecretAccessKeyWO.IsNull() {
 		return types.StringNull()
@@ -186,13 +199,56 @@ func newEdgeLocationResource() resource.Resource {
 	return &edgeLocationResource{}
 }
 
+type edgeLocationConfigValidator struct{}
+
+func (v edgeLocationConfigValidator) Description(_ context.Context) string {
+	return "Validates edge location configuration"
+}
+
+func (v edgeLocationConfigValidator) MarkdownDescription(_ context.Context) string {
+	return "Validates that exactly one cloud provider is specified and that region is provided for non-custom providers"
+}
+
+func (v edgeLocationConfigValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config edgeLocationModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Check exactly one provider is set.
+	providerCount := 0
+	if config.AWS != nil {
+		providerCount++
+	}
+	if config.GCP != nil {
+		providerCount++
+	}
+	if config.OCI != nil {
+		providerCount++
+	}
+	if config.Custom != nil {
+		providerCount++
+	}
+	if providerCount != 1 {
+		resp.Diagnostics.AddError(
+			"Invalid Configuration",
+			fmt.Sprintf("Exactly one of 'aws', 'gcp', 'oci', or 'custom' must be specified, got %d", providerCount),
+		)
+	}
+
+	// Region is required for non-custom providers.
+	if config.Custom == nil && config.Region.IsNull() {
+		resp.Diagnostics.AddError(
+			"Missing Required Argument",
+			"The argument 'region' is required when 'aws', 'gcp', or 'oci' is specified.",
+		)
+	}
+}
+
 func (r *edgeLocationResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
-		resourcevalidator.ExactlyOneOf(
-			path.MatchRoot("aws"),
-			path.MatchRoot("gcp"),
-			path.MatchRoot("oci"),
-		),
+		edgeLocationConfigValidator{},
 	}
 }
 
@@ -237,8 +293,8 @@ func (r *edgeLocationResource) Schema(_ context.Context, _ resource.SchemaReques
 				Description: "Description of the edge location",
 			},
 			"region": schema.StringAttribute{
-				Required:    true,
-				Description: "The region where the edge location is deployed",
+				Optional:    true,
+				Description: "The region where the edge location is deployed. Required for AWS, GCP and OCI providers.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -453,6 +509,11 @@ func (r *edgeLocationResource) Schema(_ context.Context, _ resource.SchemaReques
 					},
 				},
 			},
+			"custom": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Custom cloud provider configuration for the edge location",
+				Attributes:  map[string]schema.Attribute{},
+			},
 		},
 	}
 }
@@ -520,6 +581,10 @@ func (r *edgeLocationResource) Create(ctx context.Context, req resource.CreateRe
 		createReq.Oci = r.toOCI(plan.OCI, config.OCI)
 		mc = config.OCI
 	}
+	if plan.Custom != nil {
+		createReq.Custom = r.toCustom(plan.Custom, config.Custom)
+		mc = config.Custom
+	}
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -580,8 +645,12 @@ func (r *edgeLocationResource) Read(ctx context.Context, req resource.ReadReques
 
 	edgeLocation := apiResp.JSON200
 
-	if edgeLocation.Region != nil {
+	// For custom edge locations, region may be null or empty from the API.
+	// Always sync region to avoid perpetual diff when user didn't provide one.
+	if edgeLocation.Region != nil && *edgeLocation.Region != "" {
 		state.Region = types.StringValue(*edgeLocation.Region)
+	} else {
+		state.Region = types.StringNull()
 	}
 	state.Name = types.StringValue(edgeLocation.Name)
 	state.Description = types.StringNull()
@@ -599,7 +668,9 @@ func (r *edgeLocationResource) Read(ctx context.Context, req resource.ReadReques
 				Ha: types.BoolPointerValue(edgeLocation.EdgeClusterSpec.ControlPlane.Ha),
 			}
 		}
-		if edgeLocation.EdgeClusterSpec.Networking != nil && edgeLocation.EdgeClusterSpec.Networking.TunneledCidrs != nil {
+		// Only sync networking from API if it was already managed in state.
+		// Otherwise, we'd cause perpetual drift for users who never set the block.
+		if state.Networking != nil && edgeLocation.EdgeClusterSpec.Networking != nil && edgeLocation.EdgeClusterSpec.Networking.TunneledCidrs != nil {
 			cidrs, d := types.ListValueFrom(ctx, types.StringType, *edgeLocation.EdgeClusterSpec.Networking.TunneledCidrs)
 			resp.Diagnostics.Append(d...)
 			state.Networking = &networkingModel{TunneledCIDRs: cidrs}
@@ -610,6 +681,15 @@ func (r *edgeLocationResource) Read(ctx context.Context, req resource.ReadReques
 		state.Zones = r.toZoneModel(edgeLocation.Zones)
 	}
 
+	// Reset all provider blocks before populating from the API response.
+	// This ensures that if a user switches providers (e.g. aws -> custom),
+	// the old provider block is cleared and does not break the exactly-one-of
+	// invariant or interfere with future provider switches.
+	state.AWS = nil
+	state.GCP = nil
+	state.OCI = nil
+	state.Custom = nil
+
 	var diags diag.Diagnostics
 	if edgeLocation.Aws != nil {
 		state.AWS, diags = r.toAWSModel(ctx, edgeLocation.Aws)
@@ -619,6 +699,9 @@ func (r *edgeLocationResource) Read(ctx context.Context, req resource.ReadReques
 	}
 	if edgeLocation.Oci != nil {
 		state.OCI = r.toOCIModel(edgeLocation.Oci)
+	}
+	if edgeLocation.Custom != nil {
+		state.Custom = r.toCustomModel(edgeLocation.Custom)
 	}
 
 	resp.Diagnostics.Append(diags...)
@@ -683,6 +766,9 @@ func (r *edgeLocationResource) Update(ctx context.Context, req resource.UpdateRe
 	case plan.OCI != nil && (!plan.OCI.Equal(state.OCI) || credentialsChanged):
 		updateReq.Oci = r.toOCI(plan.OCI, config.OCI)
 		mc = config.OCI
+	case plan.Custom != nil && (!plan.Custom.Equal(state.Custom) || credentialsChanged):
+		updateReq.Custom = r.toCustom(plan.Custom, config.Custom)
+		mc = config.Custom
 	}
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -790,6 +876,8 @@ func (r *edgeLocationResource) ModifyPlan(ctx context.Context, req resource.Modi
 		mc = config.GCP
 	case config.OCI != nil:
 		mc = config.OCI
+	case config.Custom != nil:
+		mc = config.Custom
 	}
 
 	// Skip credentials comparison when no credentials are provided (e.g. impersonation flow)
@@ -1134,6 +1222,17 @@ func (r *edgeLocationResource) toOCIModel(config *omni.OCIParam) *ociModel {
 	}
 
 	return oci
+}
+
+func (r *edgeLocationResource) toCustom(plan, config *customModel) *omni.CustomProviderParam {
+	_ = plan
+	_ = config
+	out := omni.CustomProviderParam{}
+	return &out
+}
+
+func (r *edgeLocationResource) toCustomModel(_ *omni.CustomProviderParam) *customModel {
+	return &customModel{}
 }
 
 func (r *edgeLocationResource) woCredentialsStore(private store.PrivateState) *store.WriteOnlyStore {

--- a/castai/resource_edge_location.go
+++ b/castai/resource_edge_location.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -199,45 +200,23 @@ func newEdgeLocationResource() resource.Resource {
 	return &edgeLocationResource{}
 }
 
-type edgeLocationConfigValidator struct{}
+type edgeLocationRegionValidator struct{}
 
-func (v edgeLocationConfigValidator) Description(_ context.Context) string {
-	return "Validates edge location configuration"
+func (v edgeLocationRegionValidator) Description(_ context.Context) string {
+	return "Validates that region is provided when a non-custom cloud provider is specified"
 }
 
-func (v edgeLocationConfigValidator) MarkdownDescription(_ context.Context) string {
-	return "Validates that exactly one cloud provider is specified and that region is provided for non-custom providers"
+func (v edgeLocationRegionValidator) MarkdownDescription(_ context.Context) string {
+	return "Validates that `region` is required when `aws`, `gcp`, or `oci` is specified, and not required for `custom`"
 }
 
-func (v edgeLocationConfigValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+func (v edgeLocationRegionValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var config edgeLocationModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Check exactly one provider is set.
-	providerCount := 0
-	if config.AWS != nil {
-		providerCount++
-	}
-	if config.GCP != nil {
-		providerCount++
-	}
-	if config.OCI != nil {
-		providerCount++
-	}
-	if config.Custom != nil {
-		providerCount++
-	}
-	if providerCount != 1 {
-		resp.Diagnostics.AddError(
-			"Invalid Configuration",
-			fmt.Sprintf("Exactly one of 'aws', 'gcp', 'oci', or 'custom' must be specified, got %d", providerCount),
-		)
-	}
-
-	// Region is required for non-custom providers.
 	if config.Custom == nil && config.Region.IsNull() {
 		resp.Diagnostics.AddError(
 			"Missing Required Argument",
@@ -248,7 +227,13 @@ func (v edgeLocationConfigValidator) ValidateResource(ctx context.Context, req r
 
 func (r *edgeLocationResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
-		edgeLocationConfigValidator{},
+		resourcevalidator.ExactlyOneOf(
+			path.MatchRoot("aws"),
+			path.MatchRoot("gcp"),
+			path.MatchRoot("oci"),
+			path.MatchRoot("custom"),
+		),
+		edgeLocationRegionValidator{},
 	}
 }
 
@@ -583,7 +568,6 @@ func (r *edgeLocationResource) Create(ctx context.Context, req resource.CreateRe
 	}
 	if plan.Custom != nil {
 		createReq.Custom = r.toCustom(plan.Custom, config.Custom)
-		mc = config.Custom
 	}
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -766,9 +750,8 @@ func (r *edgeLocationResource) Update(ctx context.Context, req resource.UpdateRe
 	case plan.OCI != nil && (!plan.OCI.Equal(state.OCI) || credentialsChanged):
 		updateReq.Oci = r.toOCI(plan.OCI, config.OCI)
 		mc = config.OCI
-	case plan.Custom != nil && (!plan.Custom.Equal(state.Custom) || credentialsChanged):
+	case plan.Custom != nil && (!plan.Custom.Equal(state.Custom)):
 		updateReq.Custom = r.toCustom(plan.Custom, config.Custom)
-		mc = config.Custom
 	}
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -876,8 +859,7 @@ func (r *edgeLocationResource) ModifyPlan(ctx context.Context, req resource.Modi
 		mc = config.GCP
 	case config.OCI != nil:
 		mc = config.OCI
-	case config.Custom != nil:
-		mc = config.Custom
+
 	}
 
 	// Skip credentials comparison when no credentials are provided (e.g. impersonation flow)

--- a/castai/resource_edge_location_test.go
+++ b/castai/resource_edge_location_test.go
@@ -181,7 +181,7 @@ func TestAccCloudAgnostic_ResourceEdgeLocationAWSImpersonation(t *testing.T) {
 func TestAccCloudAgnostic_ResourceEdgeLocationGCPImpersonation(t *testing.T) {
 	rName := fmt.Sprintf("%v-edge-loc-%v", ResourcePrefix, acctest.RandString(8))
 	resourceName := "castai_edge_location.test"
-	clusterName := "omni-tf-acc-gcp"
+	clusterName := "omni-tf-acc-el-gcp"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/castai/resource_edge_location_test.go
+++ b/castai/resource_edge_location_test.go
@@ -384,6 +384,123 @@ resource "castai_edge_location" "test" {
 `, rName, description, zonesConfig, networkTagsConfig, organizationID, targetSA))
 }
 
+func TestAccCloudAgnostic_ResourceEdgeLocationCustom(t *testing.T) {
+	rName := fmt.Sprintf("%v-edge-loc-%v", ResourcePrefix, acctest.RandString(8))
+	resourceName := "castai_edge_location.test"
+	clusterName := "omni-tf-acc-custom"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckEdgeLocationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEdgeLocationCustomConfig(rName, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test custom edge location"),
+					resource.TestCheckNoResourceAttr(resourceName, "region"),
+					resource.TestCheckResourceAttr(resourceName, "zones.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "zones.0.id", "zone-1"),
+					resource.TestCheckResourceAttr(resourceName, "zones.0.name", "zone-1"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "credentials_revision", "1"),
+				),
+			},
+			{
+				ResourceName: resourceName,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					organizationID := testAccGetOrganizationID()
+					clusterID := s.RootModule().Resources["castai_omni_cluster.test"].Primary.ID
+					edgeLocationID := s.RootModule().Resources[resourceName].Primary.ID
+					return fmt.Sprintf("%v/%v/%v", organizationID, clusterID, edgeLocationID), nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEdgeLocationCustomWithRegion(rName, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "Custom edge location with region"),
+					resource.TestCheckResourceAttr(resourceName, "region", "us-west-1"),
+					resource.TestCheckResourceAttr(resourceName, "zones.#", "1"),
+				),
+			},
+			{
+				Config: testAccEdgeLocationCustomUpdated(rName, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated custom edge location"),
+					resource.TestCheckResourceAttr(resourceName, "zones.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccEdgeLocationCustomConfig(rName, clusterName string) string {
+	organizationID := testAccGetOrganizationID()
+
+	return ConfigCompose(testOmniClusterConfig(clusterName), fmt.Sprintf(`
+resource "castai_edge_location" "test" {
+  organization_id = %[3]q
+  cluster_id      = castai_omni_cluster.test.id
+  name            = %[1]q
+  description     = "Test custom edge location"
+  control_plane_mode = "SHARED"
+  zones = [{
+    id   = "zone-1"
+    name = "zone-1"
+  }]
+
+  custom = {}
+}
+`, rName, clusterName, organizationID))
+}
+
+func testAccEdgeLocationCustomWithRegion(rName, clusterName string) string {
+	organizationID := testAccGetOrganizationID()
+
+	return ConfigCompose(testOmniClusterConfig(clusterName), fmt.Sprintf(`
+resource "castai_edge_location" "test" {
+  organization_id = %[3]q
+  cluster_id      = castai_omni_cluster.test.id
+  name            = %[1]q
+  description     = "Custom edge location with region"
+  region          = "us-west-1"
+  control_plane_mode = "SHARED"
+  zones = [{
+    id   = "zone-1"
+    name = "zone-1"
+  }]
+
+  custom = {}
+}
+`, rName, clusterName, organizationID))
+}
+
+func testAccEdgeLocationCustomUpdated(rName, clusterName string) string {
+	organizationID := testAccGetOrganizationID()
+
+	return ConfigCompose(testOmniClusterConfig(clusterName), fmt.Sprintf(`
+resource "castai_edge_location" "test" {
+  organization_id = %[3]q
+  cluster_id      = castai_omni_cluster.test.id
+  name            = %[1]q
+  description     = "Updated custom edge location"
+  control_plane_mode = "SHARED"
+  zones = [{
+    id   = "zone-1"
+    name = "zone-1"
+  }, {
+    id   = "zone-2"
+    name = "zone-2"
+  }]
+
+  custom = {}
+}
+`, rName, clusterName, organizationID))
+}
+
 func testAccCheckEdgeLocationDestroy(s *terraform.State) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/castai/resource_omni_cluster.go
+++ b/castai/resource_omni_cluster.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/castai/terraform-provider-castai/castai/sdk/omni"
 )
 

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -9077,6 +9077,14 @@ type WorkloadoptimizationV1FailedHookEvent struct {
 	Time    time.Time `json:"time"`
 }
 
+// WorkloadoptimizationV1GPUSettings defines model for workloadoptimization.v1.GPUSettings.
+type WorkloadoptimizationV1GPUSettings struct {
+	// ManagementOption Defines possible options for workload management.
+	// READ_ONLY - workload watched (metrics collected), but no actions may be performed by CAST AI.
+	// MANAGED - workload watched (metrics collected), CAST AI may perform actions on the workload.
+	ManagementOption WorkloadoptimizationV1ManagementOption `json:"managementOption"`
+}
+
 // WorkloadoptimizationV1GetAgentStatusResponse defines model for workloadoptimization.v1.GetAgentStatusResponse.
 type WorkloadoptimizationV1GetAgentStatusResponse struct {
 	CastAgentCurrentVersion           *string    `json:"castAgentCurrentVersion"`
@@ -10132,6 +10140,7 @@ type WorkloadoptimizationV1RecommendationPolicies struct {
 	Cpu                WorkloadoptimizationV1ResourcePolicies          `json:"cpu"`
 	Downscaling        *WorkloadoptimizationV1DownscalingSettings      `json:"downscaling,omitempty"`
 	ExcludedContainers *[]string                                       `json:"excludedContainers,omitempty"`
+	Gpu                *WorkloadoptimizationV1GPUSettings              `json:"gpu,omitempty"`
 
 	// HpaConverters Configuration for converting existing HPAs when VPA is the sole optimization.
 	// If HPA management is enabled, it takes precedence over this setting.

--- a/castai/sdk/omni/api.gen.go
+++ b/castai/sdk/omni/api.gen.go
@@ -32,6 +32,21 @@ const (
 	ClusterStateWARNING          ClusterState = "WARNING"
 )
 
+// Defines values for EdgeClusterCNIOverlay.
+const (
+	OVERLAYFULL        EdgeClusterCNIOverlay = "OVERLAY_FULL"
+	OVERLAYOFF         EdgeClusterCNIOverlay = "OVERLAY_OFF"
+	OVERLAYSUBNET      EdgeClusterCNIOverlay = "OVERLAY_SUBNET"
+	OVERLAYUNSPECIFIED EdgeClusterCNIOverlay = "OVERLAY_UNSPECIFIED"
+)
+
+// Defines values for EdgeClusterCNIOverlayEncap.
+const (
+	OVERLAYENCAPFOU         EdgeClusterCNIOverlayEncap = "OVERLAY_ENCAP_FOU"
+	OVERLAYENCAPIPIP        EdgeClusterCNIOverlayEncap = "OVERLAY_ENCAP_IPIP"
+	OVERLAYENCAPUNSPECIFIED EdgeClusterCNIOverlayEncap = "OVERLAY_ENCAP_UNSPECIFIED"
+)
+
 // Defines values for EdgeLocationControlPlaneMode.
 const (
 	CONTROLPLANEMODEUNSPECIFIED EdgeLocationControlPlaneMode = "CONTROL_PLANE_MODE_UNSPECIFIED"
@@ -48,6 +63,14 @@ const (
 	EdgeLocationStatePENDINGONBOARDING EdgeLocationState = "PENDING_ONBOARDING"
 	EdgeLocationStateREADY             EdgeLocationState = "READY"
 	EdgeLocationStateSTATEUNSPECIFIED  EdgeLocationState = "STATE_UNSPECIFIED"
+)
+
+// Defines values for KubernetesTaintEffect.
+const (
+	NOEXECUTE              KubernetesTaintEffect = "NO_EXECUTE"
+	NOSCHEDULE             KubernetesTaintEffect = "NO_SCHEDULE"
+	PREFERNOSCHEDULE       KubernetesTaintEffect = "PREFER_NO_SCHEDULE"
+	TAINTEFFECTUNSPECIFIED KubernetesTaintEffect = "TAINT_EFFECT_UNSPECIFIED"
 )
 
 // Defines values for ObjectStatusPhase.
@@ -188,6 +211,21 @@ type Condition struct {
 // CustomProviderParam Custom cloud provider params.
 type CustomProviderParam = map[string]interface{}
 
+// EdgeClusterCNI EdgeClusterCNI contains CNI (kube-router) configuration for the edge cluster.
+type EdgeClusterCNI struct {
+	// Overlay Overlay mode for kube-router pod-to-pod traffic.
+	Overlay *EdgeClusterCNIOverlay `json:"overlay,omitempty"`
+
+	// OverlayEncap Encapsulation protocol used by the overlay.
+	OverlayEncap *EdgeClusterCNIOverlayEncap `json:"overlayEncap,omitempty"`
+}
+
+// EdgeClusterCNIOverlay Overlay mode for kube-router pod-to-pod traffic.
+type EdgeClusterCNIOverlay string
+
+// EdgeClusterCNIOverlayEncap Encapsulation protocol used by the overlay.
+type EdgeClusterCNIOverlayEncap string
+
 // EdgeClusterControlPlane EdgeClusterControlPlane contains control plane configuration overrides for the edge cluster.
 type EdgeClusterControlPlane struct {
 	// Ha Switch from HA mode to single control plane and etcd replica. If not set default is HA.
@@ -196,6 +234,9 @@ type EdgeClusterControlPlane struct {
 
 // EdgeClusterNetworking EdgeClusterNetworking contains networking configuration options for the edge cluster.
 type EdgeClusterNetworking struct {
+	// Cni CNI configuration for the edge cluster.
+	Cni *EdgeClusterCNI `json:"cni,omitempty"`
+
 	// TunneledCidrs A list of destination CIDR blocks whose traffic should be routed through the main cluster instead of directly from the
 	//  edge cluster. When specified, the edge cluster will forward packets destined to these CIDRs over the peering tunnel
 	//  to the main cluster, which then routes them on to their final destination.
@@ -211,6 +252,18 @@ type EdgeClusterSpec struct {
 
 	// Networking Networking configuration.
 	Networking *EdgeClusterNetworking `json:"networking,omitempty"`
+}
+
+// EdgeInitdOnboardingConfig Configuration for the OnboardEdgeInitd request.
+type EdgeInitdOnboardingConfig struct {
+	// GpuConfig GPU configuration for the edge node (INITD_GPU_CONFIG).
+	GpuConfig *GPUConfig `json:"gpuConfig,omitempty"`
+
+	// KubernetesLabels Kubernetes labels to set on the edge node (INITD_KUBERNETES_LABELS).
+	KubernetesLabels *map[string]string `json:"kubernetesLabels,omitempty"`
+
+	// KubernetesTaints Kubernetes taints to set on the edge node (INITD_KUBERNETES_TAINTS).
+	KubernetesTaints *[]KubernetesTaint `json:"kubernetesTaints,omitempty"`
 }
 
 // EdgeLocation Message to represent edge location.
@@ -345,12 +398,65 @@ type GCPParamGCPNetworking struct {
 	Tags []string `json:"tags"`
 }
 
+// GPUConfig GPUConfig describes instance GPU configuration.
+//
+//	Use for:
+//	* Creating GCP N1 with customer quantity and type of GPUs attached.
+//	Eg.: n1-standard-2 with 8 x NVIDIA Tesla K80
+type GPUConfig struct {
+	// Count Number of GPUs.
+	Count *uint32 `json:"count,omitempty"`
+
+	// Mig MIG configuration for the GPU.
+	Mig *GPUConfigMigConfig `json:"mig,omitempty"`
+
+	// TimeSharing TimeSharing configuration for the GPU.
+	TimeSharing *GPUConfigTimeSharing `json:"timeSharing,omitempty"`
+
+	// Type Accelerator type, eg nvidia-tesla-t4.
+	Type *string `json:"type,omitempty"`
+}
+
+// GPUConfigMigConfig Message to describe MIG configuration for the GPU.
+type GPUConfigMigConfig struct {
+	// MemoryGb MemoryGB is the amount of GPU memory in GB.
+	MemoryGb *uint32 `json:"memoryGb,omitempty"`
+
+	// PartitionSizes PartitionSizes is the sizes of the MIG partitions.
+	PartitionSizes *[]string `json:"partitionSizes,omitempty"`
+}
+
+// GPUConfigTimeSharing Message to describe time sharing configuration for the GPU.
+type GPUConfigTimeSharing struct {
+	// Replicas Replicas specifies the number of time-sliced GPU replicas to make available for
+	//  shared access to GPUs of the specified resource type.
+	Replicas *int32 `json:"replicas,omitempty"`
+}
+
 // GoogleProtobufAny Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 type GoogleProtobufAny struct {
 	// Type The type of the serialized message.
 	Type                 *string                `json:"@type,omitempty"`
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
+
+// KubernetesTaint Represents a Kubernetes taint to be applied to a node.
+type KubernetesTaint struct {
+	// AddTime The time at which the taint was added.
+	AddTime *time.Time `json:"addTime,omitempty"`
+
+	// Effect The taint effect.
+	Effect KubernetesTaintEffect `json:"effect"`
+
+	// Key The taint key.
+	Key string `json:"key"`
+
+	// Value The taint value.
+	Value *string `json:"value,omitempty"`
+}
+
+// KubernetesTaintEffect The taint effect.
+type KubernetesTaintEffect string
 
 // ListClustersResponse Message of the response to list clusters.
 type ListClustersResponse struct {
@@ -442,6 +548,12 @@ type OffboardEdgeLocationResponse struct {
 // OnboardClusterResponse Message of the response to onboard cluster.
 type OnboardClusterResponse struct {
 	// Script The script to be executed to onboard the cluster.
+	Script *string `json:"script,omitempty"`
+}
+
+// OnboardEdgeInitdResponse Message of the response to edge initd onboarding.
+type OnboardEdgeInitdResponse struct {
+	// Script A script snippet that downloads and executes the edge initd script.
 	Script *string `json:"script,omitempty"`
 }
 
@@ -584,6 +696,9 @@ type EdgeLocationsAPICreateEdgeLocationJSONRequestBody = EdgeLocation
 
 // EdgeLocationsAPIUpdateEdgeLocationJSONRequestBody defines body for EdgeLocationsAPIUpdateEdgeLocation for application/json ContentType.
 type EdgeLocationsAPIUpdateEdgeLocationJSONRequestBody = EdgeLocationUpdate
+
+// EdgeLocationsAPIOnboardEdgeInitdJSONRequestBody defines body for EdgeLocationsAPIOnboardEdgeInitd for application/json ContentType.
+type EdgeLocationsAPIOnboardEdgeInitdJSONRequestBody = EdgeInitdOnboardingConfig
 
 // ClustersAPIRegisterClusterJSONRequestBody defines body for ClustersAPIRegisterCluster for application/json ContentType.
 type ClustersAPIRegisterClusterJSONRequestBody = RegisteredCluster

--- a/castai/sdk/omni/client.gen.go
+++ b/castai/sdk/omni/client.gen.go
@@ -124,6 +124,11 @@ type ClientInterface interface {
 	// EdgeLocationsAPIOnboardEdgeLocation request
 	EdgeLocationsAPIOnboardEdgeLocation(ctx context.Context, organizationId string, clusterId string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// EdgeLocationsAPIOnboardEdgeInitdWithBody request with any body
+	EdgeLocationsAPIOnboardEdgeInitdWithBody(ctx context.Context, organizationId string, clusterId string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	EdgeLocationsAPIOnboardEdgeInitd(ctx context.Context, organizationId string, clusterId string, id string, body EdgeLocationsAPIOnboardEdgeInitdJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// EdgeLocationsAPIOnboardEdgeLocationScript request
 	EdgeLocationsAPIOnboardEdgeLocationScript(ctx context.Context, organizationId string, clusterId string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -284,6 +289,30 @@ func (c *Client) EdgeLocationsAPIOffboardEdgeLocationScript(ctx context.Context,
 
 func (c *Client) EdgeLocationsAPIOnboardEdgeLocation(ctx context.Context, organizationId string, clusterId string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewEdgeLocationsAPIOnboardEdgeLocationRequest(c.Server, organizationId, clusterId, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EdgeLocationsAPIOnboardEdgeInitdWithBody(ctx context.Context, organizationId string, clusterId string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEdgeLocationsAPIOnboardEdgeInitdRequestWithBody(c.Server, organizationId, clusterId, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EdgeLocationsAPIOnboardEdgeInitd(ctx context.Context, organizationId string, clusterId string, id string, body EdgeLocationsAPIOnboardEdgeInitdJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEdgeLocationsAPIOnboardEdgeInitdRequest(c.Server, organizationId, clusterId, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -994,6 +1023,67 @@ func NewEdgeLocationsAPIOnboardEdgeLocationRequest(server string, organizationId
 	return req, nil
 }
 
+// NewEdgeLocationsAPIOnboardEdgeInitdRequest calls the generic EdgeLocationsAPIOnboardEdgeInitd builder with application/json body
+func NewEdgeLocationsAPIOnboardEdgeInitdRequest(server string, organizationId string, clusterId string, id string, body EdgeLocationsAPIOnboardEdgeInitdJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEdgeLocationsAPIOnboardEdgeInitdRequestWithBody(server, organizationId, clusterId, id, "application/json", bodyReader)
+}
+
+// NewEdgeLocationsAPIOnboardEdgeInitdRequestWithBody generates requests for EdgeLocationsAPIOnboardEdgeInitd with any type of body
+func NewEdgeLocationsAPIOnboardEdgeInitdRequestWithBody(server string, organizationId string, clusterId string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "organizationId", runtime.ParamLocationPath, organizationId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "clusterId", runtime.ParamLocationPath, clusterId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/omni-provisioner/v1beta/organizations/%s/clusters/%s/edge-locations/%s:onboardEdgeInitd", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewEdgeLocationsAPIOnboardEdgeLocationScriptRequest generates requests for EdgeLocationsAPIOnboardEdgeLocationScript
 func NewEdgeLocationsAPIOnboardEdgeLocationScriptRequest(server string, organizationId string, clusterId string, id string) (*http.Request, error) {
 	var err error
@@ -1414,6 +1504,11 @@ type ClientWithResponsesInterface interface {
 	// EdgeLocationsAPIOnboardEdgeLocation request
 	EdgeLocationsAPIOnboardEdgeLocationWithResponse(ctx context.Context, organizationId string, clusterId string, id string) (*EdgeLocationsAPIOnboardEdgeLocationResponse, error)
 
+	// EdgeLocationsAPIOnboardEdgeInitd request  with any body
+	EdgeLocationsAPIOnboardEdgeInitdWithBodyWithResponse(ctx context.Context, organizationId string, clusterId string, id string, contentType string, body io.Reader) (*EdgeLocationsAPIOnboardEdgeInitdResponse, error)
+
+	EdgeLocationsAPIOnboardEdgeInitdWithResponse(ctx context.Context, organizationId string, clusterId string, id string, body EdgeLocationsAPIOnboardEdgeInitdJSONRequestBody) (*EdgeLocationsAPIOnboardEdgeInitdResponse, error)
+
 	// EdgeLocationsAPIOnboardEdgeLocationScript request
 	EdgeLocationsAPIOnboardEdgeLocationScriptWithResponse(ctx context.Context, organizationId string, clusterId string, id string) (*EdgeLocationsAPIOnboardEdgeLocationScriptResponse, error)
 
@@ -1756,6 +1851,37 @@ func (r EdgeLocationsAPIOnboardEdgeLocationResponse) GetBody() []byte {
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
+type EdgeLocationsAPIOnboardEdgeInitdResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *OnboardEdgeInitdResponse
+	JSONDefault  *Status
+}
+
+// Status returns HTTPResponse.Status
+func (r EdgeLocationsAPIOnboardEdgeInitdResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EdgeLocationsAPIOnboardEdgeInitdResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r EdgeLocationsAPIOnboardEdgeInitdResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
 type EdgeLocationsAPIOnboardEdgeLocationScriptResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -2074,6 +2200,23 @@ func (c *ClientWithResponses) EdgeLocationsAPIOnboardEdgeLocationWithResponse(ct
 		return nil, err
 	}
 	return ParseEdgeLocationsAPIOnboardEdgeLocationResponse(rsp)
+}
+
+// EdgeLocationsAPIOnboardEdgeInitdWithBodyWithResponse request with arbitrary body returning *EdgeLocationsAPIOnboardEdgeInitdResponse
+func (c *ClientWithResponses) EdgeLocationsAPIOnboardEdgeInitdWithBodyWithResponse(ctx context.Context, organizationId string, clusterId string, id string, contentType string, body io.Reader) (*EdgeLocationsAPIOnboardEdgeInitdResponse, error) {
+	rsp, err := c.EdgeLocationsAPIOnboardEdgeInitdWithBody(ctx, organizationId, clusterId, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEdgeLocationsAPIOnboardEdgeInitdResponse(rsp)
+}
+
+func (c *ClientWithResponses) EdgeLocationsAPIOnboardEdgeInitdWithResponse(ctx context.Context, organizationId string, clusterId string, id string, body EdgeLocationsAPIOnboardEdgeInitdJSONRequestBody) (*EdgeLocationsAPIOnboardEdgeInitdResponse, error) {
+	rsp, err := c.EdgeLocationsAPIOnboardEdgeInitd(ctx, organizationId, clusterId, id, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEdgeLocationsAPIOnboardEdgeInitdResponse(rsp)
 }
 
 // EdgeLocationsAPIOnboardEdgeLocationScriptWithResponse request returning *EdgeLocationsAPIOnboardEdgeLocationScriptResponse
@@ -2447,6 +2590,39 @@ func ParseEdgeLocationsAPIOnboardEdgeLocationResponse(rsp *http.Response) (*Edge
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest OnboardEdgeLocationResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest Status
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEdgeLocationsAPIOnboardEdgeInitdResponse parses an HTTP response from a EdgeLocationsAPIOnboardEdgeInitdWithResponse call
+func ParseEdgeLocationsAPIOnboardEdgeInitdResponse(rsp *http.Response) (*EdgeLocationsAPIOnboardEdgeInitdResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EdgeLocationsAPIOnboardEdgeInitdResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest OnboardEdgeInitdResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/castai/sdk/omni/mock/client.go
+++ b/castai/sdk/omni/mock/client.go
@@ -415,6 +415,46 @@ func (mr *MockClientInterfaceMockRecorder) EdgeLocationsAPIOffboardEdgeLocationS
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeLocationsAPIOffboardEdgeLocationScript", reflect.TypeOf((*MockClientInterface)(nil).EdgeLocationsAPIOffboardEdgeLocationScript), varargs...)
 }
 
+// EdgeLocationsAPIOnboardEdgeInitd mocks base method.
+func (m *MockClientInterface) EdgeLocationsAPIOnboardEdgeInitd(ctx context.Context, organizationId, clusterId, id string, body omni.EdgeLocationsAPIOnboardEdgeInitdJSONRequestBody, reqEditors ...omni.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, clusterId, id, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EdgeLocationsAPIOnboardEdgeInitd", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EdgeLocationsAPIOnboardEdgeInitd indicates an expected call of EdgeLocationsAPIOnboardEdgeInitd.
+func (mr *MockClientInterfaceMockRecorder) EdgeLocationsAPIOnboardEdgeInitd(ctx, organizationId, clusterId, id, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, clusterId, id, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeLocationsAPIOnboardEdgeInitd", reflect.TypeOf((*MockClientInterface)(nil).EdgeLocationsAPIOnboardEdgeInitd), varargs...)
+}
+
+// EdgeLocationsAPIOnboardEdgeInitdWithBody mocks base method.
+func (m *MockClientInterface) EdgeLocationsAPIOnboardEdgeInitdWithBody(ctx context.Context, organizationId, clusterId, id, contentType string, body io.Reader, reqEditors ...omni.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, clusterId, id, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EdgeLocationsAPIOnboardEdgeInitdWithBody", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EdgeLocationsAPIOnboardEdgeInitdWithBody indicates an expected call of EdgeLocationsAPIOnboardEdgeInitdWithBody.
+func (mr *MockClientInterfaceMockRecorder) EdgeLocationsAPIOnboardEdgeInitdWithBody(ctx, organizationId, clusterId, id, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, clusterId, id, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeLocationsAPIOnboardEdgeInitdWithBody", reflect.TypeOf((*MockClientInterface)(nil).EdgeLocationsAPIOnboardEdgeInitdWithBody), varargs...)
+}
+
 // EdgeLocationsAPIOnboardEdgeLocation mocks base method.
 func (m *MockClientInterface) EdgeLocationsAPIOnboardEdgeLocation(ctx context.Context, organizationId, clusterId, id string, reqEditors ...omni.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -1111,6 +1151,76 @@ func (m *MockClientWithResponsesInterface) EdgeLocationsAPIOffboardEdgeLocationW
 func (mr *MockClientWithResponsesInterfaceMockRecorder) EdgeLocationsAPIOffboardEdgeLocationWithResponse(ctx, organizationId, clusterId, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeLocationsAPIOffboardEdgeLocationWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EdgeLocationsAPIOffboardEdgeLocationWithResponse), ctx, organizationId, clusterId, id)
+}
+
+// EdgeLocationsAPIOnboardEdgeInitd mocks base method.
+func (m *MockClientWithResponsesInterface) EdgeLocationsAPIOnboardEdgeInitd(ctx context.Context, organizationId, clusterId, id string, body omni.EdgeLocationsAPIOnboardEdgeInitdJSONRequestBody, reqEditors ...omni.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, clusterId, id, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EdgeLocationsAPIOnboardEdgeInitd", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EdgeLocationsAPIOnboardEdgeInitd indicates an expected call of EdgeLocationsAPIOnboardEdgeInitd.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EdgeLocationsAPIOnboardEdgeInitd(ctx, organizationId, clusterId, id, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, clusterId, id, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeLocationsAPIOnboardEdgeInitd", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EdgeLocationsAPIOnboardEdgeInitd), varargs...)
+}
+
+// EdgeLocationsAPIOnboardEdgeInitdWithBody mocks base method.
+func (m *MockClientWithResponsesInterface) EdgeLocationsAPIOnboardEdgeInitdWithBody(ctx context.Context, organizationId, clusterId, id, contentType string, body io.Reader, reqEditors ...omni.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, clusterId, id, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EdgeLocationsAPIOnboardEdgeInitdWithBody", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EdgeLocationsAPIOnboardEdgeInitdWithBody indicates an expected call of EdgeLocationsAPIOnboardEdgeInitdWithBody.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EdgeLocationsAPIOnboardEdgeInitdWithBody(ctx, organizationId, clusterId, id, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, clusterId, id, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeLocationsAPIOnboardEdgeInitdWithBody", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EdgeLocationsAPIOnboardEdgeInitdWithBody), varargs...)
+}
+
+// EdgeLocationsAPIOnboardEdgeInitdWithBodyWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) EdgeLocationsAPIOnboardEdgeInitdWithBodyWithResponse(ctx context.Context, organizationId, clusterId, id, contentType string, body io.Reader) (*omni.EdgeLocationsAPIOnboardEdgeInitdResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EdgeLocationsAPIOnboardEdgeInitdWithBodyWithResponse", ctx, organizationId, clusterId, id, contentType, body)
+	ret0, _ := ret[0].(*omni.EdgeLocationsAPIOnboardEdgeInitdResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EdgeLocationsAPIOnboardEdgeInitdWithBodyWithResponse indicates an expected call of EdgeLocationsAPIOnboardEdgeInitdWithBodyWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EdgeLocationsAPIOnboardEdgeInitdWithBodyWithResponse(ctx, organizationId, clusterId, id, contentType, body interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeLocationsAPIOnboardEdgeInitdWithBodyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EdgeLocationsAPIOnboardEdgeInitdWithBodyWithResponse), ctx, organizationId, clusterId, id, contentType, body)
+}
+
+// EdgeLocationsAPIOnboardEdgeInitdWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) EdgeLocationsAPIOnboardEdgeInitdWithResponse(ctx context.Context, organizationId, clusterId, id string, body omni.EdgeLocationsAPIOnboardEdgeInitdJSONRequestBody) (*omni.EdgeLocationsAPIOnboardEdgeInitdResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EdgeLocationsAPIOnboardEdgeInitdWithResponse", ctx, organizationId, clusterId, id, body)
+	ret0, _ := ret[0].(*omni.EdgeLocationsAPIOnboardEdgeInitdResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EdgeLocationsAPIOnboardEdgeInitdWithResponse indicates an expected call of EdgeLocationsAPIOnboardEdgeInitdWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EdgeLocationsAPIOnboardEdgeInitdWithResponse(ctx, organizationId, clusterId, id, body interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EdgeLocationsAPIOnboardEdgeInitdWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EdgeLocationsAPIOnboardEdgeInitdWithResponse), ctx, organizationId, clusterId, id, body)
 }
 
 // EdgeLocationsAPIOnboardEdgeLocation mocks base method.

--- a/docs/resources/edge_location.md
+++ b/docs/resources/edge_location.md
@@ -55,17 +55,18 @@ resource "castai_edge_location" "aws_example" {
 - `cluster_id` (String) CAST AI cluster ID
 - `name` (String) Name of the edge location. Must be unique and relatively short as it's used for creating service accounts.
 - `organization_id` (String) CAST AI organization ID
-- `region` (String) The region where the edge location is deployed
 
 ### Optional
 
 - `aws` (Attributes) AWS configuration for the edge location (see [below for nested schema](#nestedatt--aws))
 - `control_plane` (Attributes) Control plane configuration. Only valid when control_plane_mode is SHARED. (see [below for nested schema](#nestedatt--control_plane))
 - `control_plane_mode` (String) The mode of control plane inside edge location. Valid values: DEDICATED, SHARED.
+- `custom` (Attributes) Custom cloud provider configuration for the edge location (see [below for nested schema](#nestedatt--custom))
 - `description` (String) Description of the edge location
 - `gcp` (Attributes) GCP configuration for the edge location (see [below for nested schema](#nestedatt--gcp))
 - `networking` (Attributes) Edge cluster networking configuration. (see [below for nested schema](#nestedatt--networking))
 - `oci` (Attributes) OCI configuration for the edge location (see [below for nested schema](#nestedatt--oci))
+- `region` (String) The region where the edge location is deployed. Required for AWS, GCP and OCI providers.
 - `zones` (Attributes List) List of availability zones for the edge location (see [below for nested schema](#nestedatt--zones))
 
 ### Read-Only
@@ -100,6 +101,10 @@ Optional:
 Optional:
 
 - `ha` (Boolean) Whether to use HA mode for control plane. If not set, default is HA.
+
+
+<a id="nestedatt--custom"></a>
+### Nested Schema for `custom`
 
 
 <a id="nestedatt--gcp"></a>


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for a `custom` cloud provider to the `castai_edge_location` resource, allowing edge locations to be provisioned without AWS, GCP, or OCI credentials. The `region` attribute is now optional when using the custom provider. Also regenerates the CAST AI SDK to incorporate the latest API schema changes.

### Why
Enables management of edge locations on custom or on-premises infrastructure where standard cloud provider configuration does not apply.

### Key changes
- `castai/resource_edge_location.go`
  - Added `custom` block (`schema.SingleNestedAttribute`) as an optional provider target alongside `aws`, `gcp`, and `oci`.
  - Changed `region` from `Required` to `Optional` and introduced `edgeLocationRegionValidator` to enforce that `region` is provided only for `aws`, `gcp`, or `oci`.
  - Fixed perpetual diff issues in `Read` by setting `region` to `null` when the API returns an empty value, and by only syncing `networking` when it already exists in state.
  - Added `customModel`, `toCustom`, and `toCustomModel` helpers.
- `castai/resource_edge_location_test.go`
  - Added `TestAccCloudAgnostic_ResourceEdgeLocationCustom` with acceptance tests covering create, import, adding a region, and updating zones for custom edge locations.
- `docs/resources/edge_location.md`
  - Documented the new `custom` nested attribute and updated the `region` description.
- `castai/sdk/*`
  - Regenerated SDK clients and models, adding workload optimization GPU settings, edge initd onboarding endpoints (`EdgeLocationsAPIOnboardEdgeInitd`), and supporting omni API types (CNI config, Kubernetes taints, GPU config, etc.).

### Impact
- **Behavior change**: `region` is no longer universally required; it is required only when `aws`, `gcp`, or `oci` is specified.
- **New capability**: Users can now specify `custom = {}` to create edge locations for custom provider environments.
- **SDK additions**: New mock interfaces and response types are available for the edge initd onboarding operations.