### PR TITLE
chore: update pod mutation constants and build against latest SDK

### DIFF
--- a/castai/resource_pod_mutation.go
+++ b/castai/resource_pod_mutation.go
@@ -87,8 +87,8 @@ var matcherTypeValues = []string{
 }
 
 var labelsFilterOperatorValues = []string{
-	string(patching_engine.AND),
-	string(patching_engine.OR),
+	string(patching_engine.ObjectFilterV2LabelsFilterOperatorAND),
+	string(patching_engine.ObjectFilterV2LabelsFilterOperatorOR),
 }
 
 var matcherSchema = &schema.Resource{

--- a/castai/resource_pod_mutation_test.go
+++ b/castai/resource_pod_mutation_test.go
@@ -1042,7 +1042,7 @@ func TestFlattenObjectFilterV2(t *testing.T) {
 	t.Run("pod only", func(t *testing.T) {
 		r := require.New(t)
 
-		op := patching_engine.AND
+		op := patching_engine.ObjectFilterV2LabelsFilterOperatorAND
 		filter := &patching_engine.ObjectFilterV2{
 			Labels: &patching_engine.ObjectFilterV2LabelsFilter{
 				Operator: &op,
@@ -1072,7 +1072,7 @@ func TestFlattenObjectFilterV2(t *testing.T) {
 	t.Run("workload and pod combined", func(t *testing.T) {
 		r := require.New(t)
 
-		op := patching_engine.OR
+		op := patching_engine.ObjectFilterV2LabelsFilterOperatorOR
 		filter := &patching_engine.ObjectFilterV2{
 			Names: &[]patching_engine.ObjectFilterV2Matcher{
 				{Type: lo.ToPtr(patching_engine.EXACT), Value: lo.ToPtr("my-deploy")},
@@ -1185,7 +1185,7 @@ func TestStateToObjectFilterV2(t *testing.T) {
 		r.Nil(filter.Namespaces)
 		r.Nil(filter.Kinds)
 		r.NotNil(filter.Labels)
-		r.Equal(patching_engine.AND, lo.FromPtr(filter.Labels.Operator))
+		r.Equal(patching_engine.ObjectFilterV2LabelsFilterOperatorAND, lo.FromPtr(filter.Labels.Operator))
 		r.Len(*filter.Labels.Matchers, 1)
 		r.Equal("app", lo.FromPtr((*filter.Labels.Matchers)[0].Key.Value))
 		r.Equal("web", lo.FromPtr((*filter.Labels.Matchers)[0].Value.Value))
@@ -1266,7 +1266,7 @@ func TestStateToObjectFilterV2(t *testing.T) {
 
 		r.Nil(filter.Labels)
 		r.NotNil(filter.ExcludeLabels)
-		r.Equal(patching_engine.OR, lo.FromPtr(filter.ExcludeLabels.Operator))
+		r.Equal(patching_engine.ObjectFilterV2LabelsFilterOperatorOR, lo.FromPtr(filter.ExcludeLabels.Operator))
 		r.Len(*filter.ExcludeLabels.Matchers, 1)
 		r.Equal("env", lo.FromPtr((*filter.ExcludeLabels.Matchers)[0].Key.Value))
 		r.Equal("dev", lo.FromPtr((*filter.ExcludeLabels.Matchers)[0].Value.Value))
@@ -1279,7 +1279,7 @@ func TestFlattenObjectFilterV2_MatcherValues(t *testing.T) {
 	t.Run("labels_filter matcher key and value are preserved", func(t *testing.T) {
 		r := require.New(t)
 
-		op := patching_engine.AND
+		op := patching_engine.ObjectFilterV2LabelsFilterOperatorAND
 		filter := &patching_engine.ObjectFilterV2{
 			Labels: &patching_engine.ObjectFilterV2LabelsFilter{
 				Operator: &op,
@@ -1310,7 +1310,7 @@ func TestFlattenObjectFilterV2_MatcherValues(t *testing.T) {
 	t.Run("exclude_labels matcher content is preserved", func(t *testing.T) {
 		r := require.New(t)
 
-		op := patching_engine.OR
+		op := patching_engine.ObjectFilterV2LabelsFilterOperatorOR
 		filter := &patching_engine.ObjectFilterV2{
 			ExcludeLabels: &patching_engine.ObjectFilterV2LabelsFilter{
 				Operator: &op,

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -4081,6 +4081,9 @@ type CostreportV1beta1GetAllocationGroupCostSummariesResponseSummary struct {
 	// RequestedStorageGibHours Total requested storage GiB hours for the given time period.
 	RequestedStorageGibHours *string `json:"requestedStorageGibHours,omitempty"`
 
+	// RequestedTpuHours Total requested TPU chip hours for the given time period.
+	RequestedTpuHours *string `json:"requestedTpuHours,omitempty"`
+
 	// TotalCostOnDemand Total cost of on-demand instances for the given time period.
 	TotalCostOnDemand *string `json:"totalCostOnDemand,omitempty"`
 
@@ -4089,7 +4092,13 @@ type CostreportV1beta1GetAllocationGroupCostSummariesResponseSummary struct {
 
 	// TotalCostSpotFallback Total cost of spot-fallback instances for the given time period.
 	TotalCostSpotFallback *string `json:"totalCostSpotFallback,omitempty"`
-	WorkloadCount         *string `json:"workloadCount,omitempty"`
+
+	// TpuCost Total TPU cost of on-demand instances for the given time period.
+	TpuCost *string `json:"tpuCost,omitempty"`
+
+	// TpuCount Average number of TPU chips for the given time period.
+	TpuCount      *string `json:"tpuCount,omitempty"`
+	WorkloadCount *string `json:"workloadCount,omitempty"`
 }
 
 // CostreportV1beta1GetAllocationGroupCostTimedSummariesResponse defines model for costreport.v1beta1.GetAllocationGroupCostTimedSummariesResponse.
@@ -4144,6 +4153,9 @@ type CostreportV1beta1GetAllocationGroupCostTimedSummariesResponseSummary struct
 	// RequestedStorageGibHours Total requested storage GiB hours for the given time period.
 	RequestedStorageGibHours *string `json:"requestedStorageGibHours,omitempty"`
 
+	// RequestedTpuHours Total requested TPU chip hours for the given time period.
+	RequestedTpuHours *string `json:"requestedTpuHours,omitempty"`
+
 	// Timestamp Timestamp of entry.
 	Timestamp *time.Time `json:"timestamp,omitempty"`
 
@@ -4155,7 +4167,13 @@ type CostreportV1beta1GetAllocationGroupCostTimedSummariesResponseSummary struct
 
 	// TotalCostSpotFallback Total cost of spot-fallback instances for the given time period.
 	TotalCostSpotFallback *string `json:"totalCostSpotFallback,omitempty"`
-	WorkloadCount         *string `json:"workloadCount,omitempty"`
+
+	// TpuCost Total TPU cost of on-demand instances for the given time period.
+	TpuCost *string `json:"tpuCost,omitempty"`
+
+	// TpuCount Average number of TPU chips for the given time period.
+	TpuCount      *string `json:"tpuCount,omitempty"`
+	WorkloadCount *string `json:"workloadCount,omitempty"`
 }
 
 // CostreportV1beta1GetAllocationGroupEfficiencySummaryResponse defines model for costreport.v1beta1.GetAllocationGroupEfficiencySummaryResponse.
@@ -4301,6 +4319,12 @@ type CostreportV1beta1GetAllocationGroupWorkloadCostsResponseWorkloadItem struct
 	// TotalCostSpotFallback Total cost of spot-fallback instances for the given time period.
 	TotalCostSpotFallback *string `json:"totalCostSpotFallback,omitempty"`
 	TotalPodCount         *string `json:"totalPodCount,omitempty"`
+
+	// TpuCost Total TPU cost of on-demand instances for the given time period.
+	TpuCost *string `json:"tpuCost,omitempty"`
+
+	// TpuCount Average number of TPU chips for the given time period.
+	TpuCount *string `json:"tpuCount,omitempty"`
 
 	// WorkloadName Name of the workload.
 	WorkloadName *string `json:"workloadName,omitempty"`
@@ -11690,6 +11714,9 @@ type ExternalClusterAPIGetConnectAndEnableCASTAICmdParams struct {
 
 	// UseUmbrella Whether to use umbrella Helm chart for onboarding.
 	UseUmbrella *bool `form:"useUmbrella,omitempty" json:"useUmbrella,omitempty"`
+
+	// UseCastctl Whether to use castctl to connect a cluster.
+	UseCastctl *bool `form:"useCastctl,omitempty" json:"useCastctl,omitempty"`
 }
 
 // ExternalClusterAPIGetCredentialsScriptParams defines parameters for ExternalClusterAPIGetCredentialsScript.

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -11522,6 +11522,22 @@ func NewExternalClusterAPIGetConnectAndEnableCASTAICmdRequest(server string, par
 
 		}
 
+		if params.UseCastctl != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "useCastctl", runtime.ParamLocationQuery, *params.UseCastctl); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 

--- a/castai/sdk/patching_engine/api.gen.go
+++ b/castai/sdk/patching_engine/api.gen.go
@@ -38,9 +38,9 @@ const (
 
 // Defines values for ObjectFilterV2LabelsFilterOperator.
 const (
-	AND                       ObjectFilterV2LabelsFilterOperator = "AND"
-	FILTEROPERATORUNSPECIFIED ObjectFilterV2LabelsFilterOperator = "FILTER_OPERATOR_UNSPECIFIED"
-	OR                        ObjectFilterV2LabelsFilterOperator = "OR"
+	ObjectFilterV2LabelsFilterOperatorAND                       ObjectFilterV2LabelsFilterOperator = "AND"
+	ObjectFilterV2LabelsFilterOperatorFILTEROPERATORUNSPECIFIED ObjectFilterV2LabelsFilterOperator = "FILTER_OPERATOR_UNSPECIFIED"
+	ObjectFilterV2LabelsFilterOperatorOR                        ObjectFilterV2LabelsFilterOperator = "OR"
 )
 
 // Defines values for ObjectFilterV2MatcherType.
@@ -48,6 +48,13 @@ const (
 	EXACT           ObjectFilterV2MatcherType = "EXACT"
 	REGEX           ObjectFilterV2MatcherType = "REGEX"
 	TYPEUNSPECIFIED ObjectFilterV2MatcherType = "TYPE_UNSPECIFIED"
+)
+
+// Defines values for ObjectFilterV2TolerationsFilterOperator.
+const (
+	ObjectFilterV2TolerationsFilterOperatorAND                       ObjectFilterV2TolerationsFilterOperator = "AND"
+	ObjectFilterV2TolerationsFilterOperatorFILTEROPERATORUNSPECIFIED ObjectFilterV2TolerationsFilterOperator = "FILTER_OPERATOR_UNSPECIFIED"
+	ObjectFilterV2TolerationsFilterOperatorOR                        ObjectFilterV2TolerationsFilterOperator = "OR"
 )
 
 // Defines values for PodMutationSource.
@@ -363,6 +370,9 @@ type ObjectFilterV2 struct {
 
 	// Namespaces Namespaces of the objects that the pod mutation should apply to. Empty means all namespaces.
 	Namespaces *[]ObjectFilterV2Matcher `json:"namespaces,omitempty"`
+
+	// Tolerations Tolerations filter that the pod mutation should apply to.
+	Tolerations *ObjectFilterV2TolerationsFilter `json:"tolerations,omitempty"`
 }
 
 // ObjectFilterV2LabelMatcher LabelMatcher defines a key-value pair for label matching.
@@ -397,6 +407,30 @@ type ObjectFilterV2Matcher struct {
 
 // ObjectFilterV2MatcherType Type of the matcher.
 type ObjectFilterV2MatcherType string
+
+// ObjectFilterV2TolerationMatcher TolerationMatcher defines a key-value-operator triple for toleration matching.
+type ObjectFilterV2TolerationMatcher struct {
+	// Key Key matcher.
+	Key *ObjectFilterV2Matcher `json:"key,omitempty"`
+
+	// Operator Operator matcher.
+	Operator *ObjectFilterV2Matcher `json:"operator,omitempty"`
+
+	// Value Value matcher.
+	Value *ObjectFilterV2Matcher `json:"value,omitempty"`
+}
+
+// ObjectFilterV2TolerationsFilter TolerationsFilter defines a set of toleration matchers combined with a logical operator.
+type ObjectFilterV2TolerationsFilter struct {
+	// Matchers List of toleration matchers.
+	Matchers *[]ObjectFilterV2TolerationMatcher `json:"matchers,omitempty"`
+
+	// Operator Operator to combine the toleration matchers.
+	Operator *ObjectFilterV2TolerationsFilterOperator `json:"operator,omitempty"`
+}
+
+// ObjectFilterV2TolerationsFilterOperator Operator to combine the toleration matchers.
+type ObjectFilterV2TolerationsFilterOperator string
 
 // ObjectFilterLabelValue LabelValue represents a label and its value.
 type ObjectFilterLabelValue struct {


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Synchronizes the Terraform provider with the latest generated CAST AI Go SDK. This adapts internal code to renamed patching-engine enum constants, adds TPU cost and utilization fields to cost-report models, introduces tolerations-filter SDK types, and supports a new `useCastctl` cluster-connection parameter.

### Key changes
- `castai/sdk/patching_engine/api.gen.go`  
  - Renamed `ObjectFilterV2LabelsFilterOperator` constants to type-prefixed names (`ObjectFilterV2LabelsFilterOperatorAND`, `ObjectFilterV2LabelsFilterOperatorOR`).  
  - Added `ObjectFilterV2TolerationsFilter`, `ObjectFilterV2TolerationMatcher`, `ObjectFilterV2TolerationsFilterOperator`, and a new `Tolerations` field on `ObjectFilterV2`.
- `castai/resource_pod_mutation.go`  
  - Updated `labelsFilterOperatorValues` to reference the renamed SDK constants.
- `castai/resource_pod_mutation_test.go`  
  - Updated all test assertions to use `ObjectFilterV2LabelsFilterOperatorAND` and `ObjectFilterV2LabelsFilterOperatorOR`.
- `castai/sdk/api.gen.go`  
  - Added `RequestedTpuHours`, `TpuCost`, and `TpuCount` fields to cost-report summary structs and workload-cost items.  
  - Added `UseCastctl` boolean parameter to `ExternalClusterAPIGetConnectAndEnableCASTAICmdParams`.
- `castai/sdk/client.gen.go`  
  - Added query-parameter serialization for `useCastctl` in external-cluster onboarding requests.

### Impact
The renamed patching-engine enums are a breaking change for any internal code referencing the previous short constant names. There are no expected user-facing breaking changes; validation values for label-filter operators remain `"AND"` and `"OR"`.