### PR TITLE
fix: cri conversion in case of empty values

### DIFF
--- a/castai/resource_edge_configuration.go
+++ b/castai/resource_edge_configuration.go
@@ -317,6 +317,17 @@ func (r *edgeConfigurationResource) Create(ctx context.Context, req resource.Cre
 	state := r.edgeConfigurationToTFModel(ctx, apiResp.JSON200, plan.OrganizationID, plan.ClusterID)
 	state.EdgeLocationID = plan.EdgeLocationID
 
+	// Normalize CRI state to prevent spurious diffs when the API returns
+	// a non-nil CRI object with an empty string socket.
+	if state.CRI != nil && state.CRI.Socket.ValueString() == "" {
+		state.CRI.Socket = types.StringNull()
+	}
+
+	// if the entire cri block was removed; match by returning nil.
+	if plan.CRI == nil {
+		state.CRI = nil
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -447,6 +458,17 @@ func (r *edgeConfigurationResource) Update(ctx context.Context, req resource.Upd
 	}
 
 	state := r.edgeConfigurationToTFModel(ctx, apiResp.JSON200, plan.OrganizationID, plan.ClusterID)
+
+	// Normalize CRI state to prevent spurious diffs when the API returns
+	// a non-nil CRI object with an empty string socket.
+	if state.CRI != nil && state.CRI.Socket.ValueString() == "" {
+		state.CRI.Socket = types.StringNull()
+	}
+
+	// if the entire cri block was removed; match by returning nil.
+	if plan.CRI == nil {
+		state.CRI = nil
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
@@ -856,14 +878,15 @@ func (r *edgeConfigurationResource) toCRIConfigurationModel(_ context.Context, c
 		return nil
 	}
 
-	// Normalize: a CRI object with no socket is semantically equivalent to no CRI configuration at all.
-	if config.Socket == nil || *config.Socket == "" {
-		return nil
+	model := &criConfigurationModel{
+		Socket: types.StringNull(),
 	}
 
-	return &criConfigurationModel{
-		Socket: types.StringValue(*config.Socket),
+	if config.Socket != nil {
+		model.Socket = types.StringValue(*config.Socket)
 	}
+
+	return model
 }
 
 func normalizeStringPtr(s *string) types.String {

--- a/castai/resource_edge_configuration.go
+++ b/castai/resource_edge_configuration.go
@@ -317,18 +317,9 @@ func (r *edgeConfigurationResource) Create(ctx context.Context, req resource.Cre
 	state := r.edgeConfigurationToTFModel(ctx, apiResp.JSON200, plan.OrganizationID, plan.ClusterID)
 	state.EdgeLocationID = plan.EdgeLocationID
 
-	// Normalize CRI state to prevent spurious diffs when the API returns
-	// a non-nil CRI object with an empty string socket.
-	if state.CRI != nil && state.CRI.Socket.ValueString() == "" {
-		state.CRI.Socket = types.StringNull()
-	}
+	r.normalizeCRIState(&state, plan.CRI)
 
-	// if the entire cri block was removed; match by returning nil.
-	if plan.CRI == nil {
-		state.CRI = nil
-	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 func (r *edgeConfigurationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -459,18 +450,9 @@ func (r *edgeConfigurationResource) Update(ctx context.Context, req resource.Upd
 
 	state := r.edgeConfigurationToTFModel(ctx, apiResp.JSON200, plan.OrganizationID, plan.ClusterID)
 
-	// Normalize CRI state to prevent spurious diffs when the API returns
-	// a non-nil CRI object with an empty string socket.
-	if state.CRI != nil && state.CRI.Socket.ValueString() == "" {
-		state.CRI.Socket = types.StringNull()
-	}
+	r.normalizeCRIState(&state, plan.CRI)
 
-	// if the entire cri block was removed; match by returning nil.
-	if plan.CRI == nil {
-		state.CRI = nil
-	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 func (r *edgeConfigurationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -851,6 +833,19 @@ func (r *edgeConfigurationResource) toCustomConfigurationModel(ctx context.Conte
 
 	return &customConfigurationModel{
 		Custom: custom,
+	}
+}
+
+func (r *edgeConfigurationResource) normalizeCRIState(state *edgeConfigurationModel, planCRI *criConfigurationModel) {
+	// Normalize CRI state to prevent spurious diffs when the API returns
+	// a non-nil CRI object with an empty string socket.
+	if state.CRI != nil && state.CRI.Socket.ValueString() == "" {
+		state.CRI.Socket = types.StringNull()
+	}
+
+	// If the entire cri block was removed; match by returning nil.
+	if planCRI == nil {
+		state.CRI = nil
 	}
 }
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed  
Fix spurious diff detection in the `castai_edge_configuration` resource when the API returns a CRI configuration object with an empty or absent `socket` value. State is now normalized after `Create` and `Update` to align empty CRI blocks with the Terraform plan.

### Why  
When the API returns a non-nil CRI object containing an empty or missing socket, Terraform incorrectly reports a diff against configurations that omit the CRI block entirely. This change prevents perpetual configuration drift by treating empty/absent sockets as null and dropping the CRI state when the plan leaves it unspecified.

### Key changes  
- `castai/resource_edge_configuration.go`: Added `normalizeCRIState` helper invoked after `Create` and `Update` to convert empty-string CRI sockets to `types.StringNull()` and clear `state.CRI` to `nil` when the plan omits the CRI block.  
- `castai/resource_edge_configuration.go`: Updated `toCRIConfigurationModel` to return a non-nil `criConfigurationModel` with a null `Socket` instead of returning `nil` when the API omits the socket value, preserving structural parity before normalization.