### PR TITLE
PRICE-1410: Expose pod mutations tolerations filter in terraform

### DIFF
--- a/castai/resource_pod_mutation.go
+++ b/castai/resource_pod_mutation.go
@@ -73,7 +73,18 @@ const (
 	FieldPodMutationLabelMatcherKey                = "key"
 	FieldPodMutationLabelMatcherValue              = "value"
 	FieldPodMutationValues                         = "values"
+	FieldPodMutationFilterTolerationsFilter        = "tolerations_filter"
+	FieldPodMutationTolerationsFilterOperator      = "operator"
+	FieldPodMutationTolerationsFilterMatchers      = "matchers"
+	FieldPodMutationTolerationMatcherKey           = "key"
+	FieldPodMutationTolerationMatcherValue         = "value"
+	FieldPodMutationTolerationMatcherOperator      = "operator"
 )
+
+var tolerationsFilterOperatorValues = []string{
+	string(patching_engine.ObjectFilterV2TolerationsFilterOperatorAND),
+	string(patching_engine.ObjectFilterV2TolerationsFilterOperatorOR),
+}
 
 var spotModeValues = []string{
 	string(patching_engine.PodMutationSpotTypeOPTIONALSPOT),
@@ -120,6 +131,46 @@ var labelMatcherElemSchema = &schema.Resource{
 			Optional: true,
 			MaxItems: 1,
 			Elem:     matcherSchema,
+		},
+	},
+}
+
+var tolerationMatcherSchema = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		FieldPodMutationTolerationMatcherKey: {
+			Type:     schema.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem:     matcherSchema,
+		},
+		FieldPodMutationTolerationMatcherValue: {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem:     matcherSchema,
+		},
+		FieldPodMutationTolerationMatcherOperator: {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem:     matcherSchema,
+		},
+	},
+}
+
+var tolerationsFilterSchema = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		FieldPodMutationTolerationsFilterOperator: {
+			Type:             schema.TypeString,
+			Required:         true,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(tolerationsFilterOperatorValues, false)),
+			Description:      "Logical operator to combine toleration matchers: AND or OR.",
+		},
+		FieldPodMutationTolerationsFilterMatchers: {
+			Type:     schema.TypeSet,
+			Required: true,
+			Set:      schema.HashResource(tolerationMatcherSchema),
+			Elem:     tolerationMatcherSchema,
 		},
 	},
 }
@@ -423,6 +474,13 @@ func resourcePodMutation() *schema.Resource {
 									MaxItems: 1,
 									Elem:     labelsFilterSchema,
 								},
+								FieldPodMutationFilterTolerationsFilter: {
+									Type:        schema.TypeList,
+									Optional:    true,
+									MaxItems:    1,
+									Description: "Tolerations filter for matching pods by their tolerations.",
+									Elem:        tolerationsFilterSchema,
+								},
 							},
 						},
 					},
@@ -524,6 +582,7 @@ func validatePodMutationFilter(filterV2 []interface{}) error {
 	podFields := []string{
 		FieldPodMutationFilterLabelsFilter,
 		FieldPodMutationFilterExcludeLabels,
+		FieldPodMutationFilterTolerationsFilter,
 	}
 
 	if wl, ok := fm[FieldPodMutationFilterWorkload].([]interface{}); ok && len(wl) > 0 && wl[0] != nil {
@@ -934,6 +993,12 @@ func stateToObjectFilterV2(m map[string]interface{}) *patching_engine.ObjectFilt
 					filter.ExcludeLabels = stateToLabelsFilter(filterList[0].(map[string]interface{}))
 				}
 			}
+			if v, ok := pm[FieldPodMutationFilterTolerationsFilter]; ok {
+				filterList := v.([]interface{})
+				if len(filterList) > 0 && filterList[0] != nil {
+					filter.Tolerations = stateToTolerationsFilter(filterList[0].(map[string]interface{}))
+				}
+			}
 		}
 	}
 
@@ -1004,6 +1069,69 @@ func stateToLabelsFilter(m map[string]interface{}) *patching_engine.ObjectFilter
 			}
 
 			matchers = append(matchers, labelMatcher)
+		}
+		filter.Matchers = &matchers
+	}
+
+	return filter
+}
+
+func stateToTolerationsFilter(m map[string]interface{}) *patching_engine.ObjectFilterV2TolerationsFilter {
+	op := patching_engine.ObjectFilterV2TolerationsFilterOperator(m[FieldPodMutationTolerationsFilterOperator].(string))
+	filter := &patching_engine.ObjectFilterV2TolerationsFilter{
+		Operator: &op,
+	}
+
+	if set, ok := m[FieldPodMutationTolerationsFilterMatchers].(*schema.Set); ok && set != nil {
+		matchersList := set.List()
+		matchers := make([]patching_engine.ObjectFilterV2TolerationMatcher, 0, len(matchersList))
+		for _, item := range matchersList {
+			if item == nil {
+				continue
+			}
+			tm := item.(map[string]interface{})
+			tolerationMatcher := patching_engine.ObjectFilterV2TolerationMatcher{}
+
+			if keyList, ok := tm[FieldPodMutationTolerationMatcherKey]; ok {
+				kl := keyList.([]interface{})
+				if len(kl) > 0 && kl[0] != nil {
+					km := kl[0].(map[string]interface{})
+					keyType := patching_engine.ObjectFilterV2MatcherType(km[FieldPodMutationMatcherType].(string))
+					keyValue := km[FieldPodMutationMatcherValue].(string)
+					tolerationMatcher.Key = &patching_engine.ObjectFilterV2Matcher{
+						Type:  &keyType,
+						Value: &keyValue,
+					}
+				}
+			}
+
+			if valList, ok := tm[FieldPodMutationTolerationMatcherValue]; ok {
+				vl := valList.([]interface{})
+				if len(vl) > 0 && vl[0] != nil {
+					vm := vl[0].(map[string]interface{})
+					valType := patching_engine.ObjectFilterV2MatcherType(vm[FieldPodMutationMatcherType].(string))
+					valValue := vm[FieldPodMutationMatcherValue].(string)
+					tolerationMatcher.Value = &patching_engine.ObjectFilterV2Matcher{
+						Type:  &valType,
+						Value: &valValue,
+					}
+				}
+			}
+
+			if opList, ok := tm[FieldPodMutationTolerationMatcherOperator]; ok {
+				ol := opList.([]interface{})
+				if len(ol) > 0 && ol[0] != nil {
+					om := ol[0].(map[string]interface{})
+					opType := patching_engine.ObjectFilterV2MatcherType(om[FieldPodMutationMatcherType].(string))
+					opValue := om[FieldPodMutationMatcherValue].(string)
+					tolerationMatcher.Operator = &patching_engine.ObjectFilterV2Matcher{
+						Type:  &opType,
+						Value: &opValue,
+					}
+				}
+			}
+
+			matchers = append(matchers, tolerationMatcher)
 		}
 		filter.Matchers = &matchers
 	}
@@ -1364,6 +1492,10 @@ func flattenObjectFilterV2(filter *patching_engine.ObjectFilterV2) []map[string]
 		pm[FieldPodMutationFilterExcludeLabels] = flattenLabelsFilter(filter.ExcludeLabels)
 		hasPod = true
 	}
+	if filter.Tolerations != nil {
+		pm[FieldPodMutationFilterTolerationsFilter] = flattenTolerationsFilter(filter.Tolerations)
+		hasPod = true
+	}
 	if hasPod {
 		m[FieldPodMutationFilterPod] = []map[string]interface{}{pm}
 	}
@@ -1410,6 +1542,47 @@ func flattenLabelsFilter(filter *patching_engine.ObjectFilterV2LabelsFilter) []m
 			matchersList = append(matchersList, entry)
 		}
 		m[FieldPodMutationLabelsFilterMatchers] = matchersList
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenTolerationsFilter(filter *patching_engine.ObjectFilterV2TolerationsFilter) []map[string]interface{} {
+	m := map[string]interface{}{
+		FieldPodMutationTolerationsFilterOperator: string(lo.FromPtr(filter.Operator)),
+	}
+
+	if filter.Matchers != nil {
+		matchersList := make([]map[string]interface{}, 0, len(*filter.Matchers))
+		for _, tm := range *filter.Matchers {
+			entry := map[string]interface{}{}
+			if tm.Key != nil {
+				entry[FieldPodMutationTolerationMatcherKey] = []map[string]interface{}{
+					{
+						FieldPodMutationMatcherType:  string(lo.FromPtr(tm.Key.Type)),
+						FieldPodMutationMatcherValue: lo.FromPtr(tm.Key.Value),
+					},
+				}
+			}
+			if tm.Value != nil {
+				entry[FieldPodMutationTolerationMatcherValue] = []map[string]interface{}{
+					{
+						FieldPodMutationMatcherType:  string(lo.FromPtr(tm.Value.Type)),
+						FieldPodMutationMatcherValue: lo.FromPtr(tm.Value.Value),
+					},
+				}
+			}
+			if tm.Operator != nil {
+				entry[FieldPodMutationTolerationMatcherOperator] = []map[string]interface{}{
+					{
+						FieldPodMutationMatcherType:  string(lo.FromPtr(tm.Operator.Type)),
+						FieldPodMutationMatcherValue: lo.FromPtr(tm.Operator.Value),
+					},
+				}
+			}
+			matchersList = append(matchersList, entry)
+		}
+		m[FieldPodMutationTolerationsFilterMatchers] = matchersList
 	}
 
 	return []map[string]interface{}{m}

--- a/castai/resource_pod_mutation.go
+++ b/castai/resource_pod_mutation.go
@@ -1032,46 +1032,49 @@ func stateToLabelsFilter(m map[string]interface{}) *patching_engine.ObjectFilter
 		Operator: &op,
 	}
 
-	if set, ok := m[FieldPodMutationLabelsFilterMatchers].(*schema.Set); ok && set != nil {
-		matchersList := set.List()
-		matchers := make([]patching_engine.ObjectFilterV2LabelMatcher, 0, len(matchersList))
-		for _, item := range matchersList {
-			if item == nil {
-				continue
-			}
-			lm := item.(map[string]interface{})
-			labelMatcher := patching_engine.ObjectFilterV2LabelMatcher{}
-
-			if keyList, ok := lm[FieldPodMutationLabelMatcherKey]; ok {
-				kl := keyList.([]interface{})
-				if len(kl) > 0 && kl[0] != nil {
-					km := kl[0].(map[string]interface{})
-					keyType := patching_engine.ObjectFilterV2MatcherType(km[FieldPodMutationMatcherType].(string))
-					keyValue := km[FieldPodMutationMatcherValue].(string)
-					labelMatcher.Key = &patching_engine.ObjectFilterV2Matcher{
-						Type:  &keyType,
-						Value: &keyValue,
-					}
-				}
-			}
-
-			if valList, ok := lm[FieldPodMutationLabelMatcherValue]; ok {
-				vl := valList.([]interface{})
-				if len(vl) > 0 && vl[0] != nil {
-					vm := vl[0].(map[string]interface{})
-					valType := patching_engine.ObjectFilterV2MatcherType(vm[FieldPodMutationMatcherType].(string))
-					valValue := vm[FieldPodMutationMatcherValue].(string)
-					labelMatcher.Value = &patching_engine.ObjectFilterV2Matcher{
-						Type:  &valType,
-						Value: &valValue,
-					}
-				}
-			}
-
-			matchers = append(matchers, labelMatcher)
-		}
-		filter.Matchers = &matchers
+	set, ok := m[FieldPodMutationLabelsFilterMatchers].(*schema.Set)
+	if !ok || set == nil {
+		return filter
 	}
+
+	matchersList := set.List()
+	matchers := make([]patching_engine.ObjectFilterV2LabelMatcher, 0, len(matchersList))
+	for _, item := range matchersList {
+		if item == nil {
+			continue
+		}
+		lm := item.(map[string]interface{})
+		labelMatcher := patching_engine.ObjectFilterV2LabelMatcher{}
+
+		if keyList, ok := lm[FieldPodMutationLabelMatcherKey]; ok {
+			kl := keyList.([]interface{})
+			if len(kl) > 0 && kl[0] != nil {
+				km := kl[0].(map[string]interface{})
+				keyType := patching_engine.ObjectFilterV2MatcherType(km[FieldPodMutationMatcherType].(string))
+				keyValue := km[FieldPodMutationMatcherValue].(string)
+				labelMatcher.Key = &patching_engine.ObjectFilterV2Matcher{
+					Type:  &keyType,
+					Value: &keyValue,
+				}
+			}
+		}
+
+		if valList, ok := lm[FieldPodMutationLabelMatcherValue]; ok {
+			vl := valList.([]interface{})
+			if len(vl) > 0 && vl[0] != nil {
+				vm := vl[0].(map[string]interface{})
+				valType := patching_engine.ObjectFilterV2MatcherType(vm[FieldPodMutationMatcherType].(string))
+				valValue := vm[FieldPodMutationMatcherValue].(string)
+				labelMatcher.Value = &patching_engine.ObjectFilterV2Matcher{
+					Type:  &valType,
+					Value: &valValue,
+				}
+			}
+		}
+
+		matchers = append(matchers, labelMatcher)
+	}
+	filter.Matchers = &matchers
 
 	return filter
 }
@@ -1082,59 +1085,62 @@ func stateToTolerationsFilter(m map[string]interface{}) *patching_engine.ObjectF
 		Operator: &op,
 	}
 
-	if set, ok := m[FieldPodMutationTolerationsFilterMatchers].(*schema.Set); ok && set != nil {
-		matchersList := set.List()
-		matchers := make([]patching_engine.ObjectFilterV2TolerationMatcher, 0, len(matchersList))
-		for _, item := range matchersList {
-			if item == nil {
-				continue
-			}
-			tm := item.(map[string]interface{})
-			tolerationMatcher := patching_engine.ObjectFilterV2TolerationMatcher{}
-
-			if keyList, ok := tm[FieldPodMutationTolerationMatcherKey]; ok {
-				kl := keyList.([]interface{})
-				if len(kl) > 0 && kl[0] != nil {
-					km := kl[0].(map[string]interface{})
-					keyType := patching_engine.ObjectFilterV2MatcherType(km[FieldPodMutationMatcherType].(string))
-					keyValue := km[FieldPodMutationMatcherValue].(string)
-					tolerationMatcher.Key = &patching_engine.ObjectFilterV2Matcher{
-						Type:  &keyType,
-						Value: &keyValue,
-					}
-				}
-			}
-
-			if valList, ok := tm[FieldPodMutationTolerationMatcherValue]; ok {
-				vl := valList.([]interface{})
-				if len(vl) > 0 && vl[0] != nil {
-					vm := vl[0].(map[string]interface{})
-					valType := patching_engine.ObjectFilterV2MatcherType(vm[FieldPodMutationMatcherType].(string))
-					valValue := vm[FieldPodMutationMatcherValue].(string)
-					tolerationMatcher.Value = &patching_engine.ObjectFilterV2Matcher{
-						Type:  &valType,
-						Value: &valValue,
-					}
-				}
-			}
-
-			if opList, ok := tm[FieldPodMutationTolerationMatcherOperator]; ok {
-				ol := opList.([]interface{})
-				if len(ol) > 0 && ol[0] != nil {
-					om := ol[0].(map[string]interface{})
-					opType := patching_engine.ObjectFilterV2MatcherType(om[FieldPodMutationMatcherType].(string))
-					opValue := om[FieldPodMutationMatcherValue].(string)
-					tolerationMatcher.Operator = &patching_engine.ObjectFilterV2Matcher{
-						Type:  &opType,
-						Value: &opValue,
-					}
-				}
-			}
-
-			matchers = append(matchers, tolerationMatcher)
-		}
-		filter.Matchers = &matchers
+	set, ok := m[FieldPodMutationTolerationsFilterMatchers].(*schema.Set)
+	if !ok || set == nil {
+		return filter
 	}
+
+	matchersList := set.List()
+	matchers := make([]patching_engine.ObjectFilterV2TolerationMatcher, 0, len(matchersList))
+	for _, item := range matchersList {
+		if item == nil {
+			continue
+		}
+		tm := item.(map[string]interface{})
+		tolerationMatcher := patching_engine.ObjectFilterV2TolerationMatcher{}
+
+		if keyList, ok := tm[FieldPodMutationTolerationMatcherKey]; ok {
+			kl := keyList.([]interface{})
+			if len(kl) > 0 && kl[0] != nil {
+				km := kl[0].(map[string]interface{})
+				keyType := patching_engine.ObjectFilterV2MatcherType(km[FieldPodMutationMatcherType].(string))
+				keyValue := km[FieldPodMutationMatcherValue].(string)
+				tolerationMatcher.Key = &patching_engine.ObjectFilterV2Matcher{
+					Type:  &keyType,
+					Value: &keyValue,
+				}
+			}
+		}
+
+		if valList, ok := tm[FieldPodMutationTolerationMatcherValue]; ok {
+			vl := valList.([]interface{})
+			if len(vl) > 0 && vl[0] != nil {
+				vm := vl[0].(map[string]interface{})
+				valType := patching_engine.ObjectFilterV2MatcherType(vm[FieldPodMutationMatcherType].(string))
+				valValue := vm[FieldPodMutationMatcherValue].(string)
+				tolerationMatcher.Value = &patching_engine.ObjectFilterV2Matcher{
+					Type:  &valType,
+					Value: &valValue,
+				}
+			}
+		}
+
+		if opList, ok := tm[FieldPodMutationTolerationMatcherOperator]; ok {
+			ol := opList.([]interface{})
+			if len(ol) > 0 && ol[0] != nil {
+				om := ol[0].(map[string]interface{})
+				opType := patching_engine.ObjectFilterV2MatcherType(om[FieldPodMutationMatcherType].(string))
+				opValue := om[FieldPodMutationMatcherValue].(string)
+				tolerationMatcher.Operator = &patching_engine.ObjectFilterV2Matcher{
+					Type:  &opType,
+					Value: &opValue,
+				}
+			}
+		}
+
+		matchers = append(matchers, tolerationMatcher)
+	}
+	filter.Matchers = &matchers
 
 	return filter
 }

--- a/castai/resource_pod_mutation_test.go
+++ b/castai/resource_pod_mutation_test.go
@@ -1113,6 +1113,52 @@ func TestFlattenObjectFilterV2(t *testing.T) {
 		_, hasPod := m[FieldPodMutationFilterPod]
 		r.False(hasPod)
 	})
+
+	t.Run("tolerations filter", func(t *testing.T) {
+		r := require.New(t)
+
+		op := patching_engine.ObjectFilterV2TolerationsFilterOperatorAND
+		filter := &patching_engine.ObjectFilterV2{
+			Tolerations: &patching_engine.ObjectFilterV2TolerationsFilter{
+				Operator: &op,
+				Matchers: &[]patching_engine.ObjectFilterV2TolerationMatcher{
+					{
+						Key: &patching_engine.ObjectFilterV2Matcher{Type: lo.ToPtr(patching_engine.EXACT), Value: lo.ToPtr("dedicated")},
+						Value: &patching_engine.ObjectFilterV2Matcher{Type: lo.ToPtr(patching_engine.EXACT), Value: lo.ToPtr("spot")},
+						Operator: &patching_engine.ObjectFilterV2Matcher{Type: lo.ToPtr(patching_engine.EXACT), Value: lo.ToPtr("Equal")},
+					},
+				},
+			},
+		}
+
+		result := flattenObjectFilterV2(filter)
+		r.Len(result, 1)
+		m := result[0]
+
+		_, hasWorkload := m[FieldPodMutationFilterWorkload]
+		r.False(hasWorkload)
+
+		pod := m[FieldPodMutationFilterPod].([]map[string]interface{})
+		r.Len(pod, 1)
+		tf := pod[0][FieldPodMutationFilterTolerationsFilter].([]map[string]interface{})
+		r.Len(tf, 1)
+		r.Equal("AND", tf[0][FieldPodMutationTolerationsFilterOperator])
+
+		matchers := tf[0][FieldPodMutationTolerationsFilterMatchers].([]map[string]interface{})
+		r.Len(matchers, 1)
+
+		key := matchers[0][FieldPodMutationTolerationMatcherKey].([]map[string]interface{})
+		r.Equal("EXACT", key[0][FieldPodMutationMatcherType])
+		r.Equal("dedicated", key[0][FieldPodMutationMatcherValue])
+
+		val := matchers[0][FieldPodMutationTolerationMatcherValue].([]map[string]interface{})
+		r.Equal("EXACT", val[0][FieldPodMutationMatcherType])
+		r.Equal("spot", val[0][FieldPodMutationMatcherValue])
+
+		tolOp := matchers[0][FieldPodMutationTolerationMatcherOperator].([]map[string]interface{})
+		r.Equal("EXACT", tolOp[0][FieldPodMutationMatcherType])
+		r.Equal("Equal", tolOp[0][FieldPodMutationMatcherValue])
+	})
 }
 
 func TestStateToObjectFilterV2(t *testing.T) {
@@ -1271,6 +1317,49 @@ func TestStateToObjectFilterV2(t *testing.T) {
 		r.Equal("env", lo.FromPtr((*filter.ExcludeLabels.Matchers)[0].Key.Value))
 		r.Equal("dev", lo.FromPtr((*filter.ExcludeLabels.Matchers)[0].Value.Value))
 	})
+
+	t.Run("pod tolerations", func(t *testing.T) {
+		r := require.New(t)
+
+		state := map[string]interface{}{
+			FieldPodMutationFilterWorkload: []interface{}{},
+			FieldPodMutationFilterPod: []interface{}{
+				map[string]interface{}{
+					FieldPodMutationFilterLabelsFilter:    []interface{}{},
+					FieldPodMutationFilterExcludeLabels:   []interface{}{},
+					FieldPodMutationFilterTolerationsFilter: []interface{}{
+						map[string]interface{}{
+							FieldPodMutationTolerationsFilterOperator: "AND",
+							FieldPodMutationTolerationsFilterMatchers: tolerationMatcherSet(
+								map[string]interface{}{
+									FieldPodMutationTolerationMatcherKey: []interface{}{
+										map[string]interface{}{FieldPodMutationMatcherType: "EXACT", FieldPodMutationMatcherValue: "dedicated"},
+									},
+									FieldPodMutationTolerationMatcherValue: []interface{}{
+										map[string]interface{}{FieldPodMutationMatcherType: "EXACT", FieldPodMutationMatcherValue: "spot"},
+									},
+									FieldPodMutationTolerationMatcherOperator: []interface{}{
+										map[string]interface{}{FieldPodMutationMatcherType: "EXACT", FieldPodMutationMatcherValue: "Equal"},
+									},
+								},
+							),
+						},
+					},
+				},
+			},
+		}
+
+		filter := stateToObjectFilterV2(state)
+
+		r.Nil(filter.Labels)
+		r.Nil(filter.ExcludeLabels)
+		r.NotNil(filter.Tolerations)
+		r.Equal(patching_engine.ObjectFilterV2TolerationsFilterOperatorAND, lo.FromPtr(filter.Tolerations.Operator))
+		r.Len(*filter.Tolerations.Matchers, 1)
+		r.Equal("dedicated", lo.FromPtr((*filter.Tolerations.Matchers)[0].Key.Value))
+		r.Equal("spot", lo.FromPtr((*filter.Tolerations.Matchers)[0].Value.Value))
+		r.Equal("Equal", lo.FromPtr((*filter.Tolerations.Matchers)[0].Operator.Value))
+	})
 }
 
 func TestFlattenObjectFilterV2_MatcherValues(t *testing.T) {
@@ -1368,6 +1457,41 @@ func TestFlattenObjectFilterV2_MatcherValues(t *testing.T) {
 		r.Len(exNames, 1)
 		r.Equal("^skip-.*", exNames[0][FieldPodMutationMatcherValue])
 		r.Equal("REGEX", exNames[0][FieldPodMutationMatcherType])
+	})
+
+	t.Run("tolerations_filter matcher content is preserved", func(t *testing.T) {
+		r := require.New(t)
+
+		op := patching_engine.ObjectFilterV2TolerationsFilterOperatorAND
+		filter := &patching_engine.ObjectFilterV2{
+			Tolerations: &patching_engine.ObjectFilterV2TolerationsFilter{
+				Operator: &op,
+				Matchers: &[]patching_engine.ObjectFilterV2TolerationMatcher{
+					{
+						Key:      &patching_engine.ObjectFilterV2Matcher{Type: lo.ToPtr(patching_engine.EXACT), Value: lo.ToPtr("dedicated")},
+						Value:    &patching_engine.ObjectFilterV2Matcher{Type: lo.ToPtr(patching_engine.EXACT), Value: lo.ToPtr("spot")},
+						Operator: &patching_engine.ObjectFilterV2Matcher{Type: lo.ToPtr(patching_engine.EXACT), Value: lo.ToPtr("Equal")},
+					},
+				},
+			},
+		}
+
+		result := flattenObjectFilterV2(filter)
+		pod := result[0][FieldPodMutationFilterPod].([]map[string]interface{})
+		tf := pod[0][FieldPodMutationFilterTolerationsFilter].([]map[string]interface{})
+		r.Equal("AND", tf[0][FieldPodMutationTolerationsFilterOperator])
+
+		matchers := tf[0][FieldPodMutationTolerationsFilterMatchers].([]map[string]interface{})
+		r.Len(matchers, 1)
+
+		key := matchers[0][FieldPodMutationTolerationMatcherKey].([]map[string]interface{})
+		r.Equal("dedicated", key[0][FieldPodMutationMatcherValue])
+
+		val := matchers[0][FieldPodMutationTolerationMatcherValue].([]map[string]interface{})
+		r.Equal("spot", val[0][FieldPodMutationMatcherValue])
+
+		tolOp := matchers[0][FieldPodMutationTolerationMatcherOperator].([]map[string]interface{})
+		r.Equal("Equal", tolOp[0][FieldPodMutationMatcherValue])
 	})
 }
 
@@ -2045,4 +2169,12 @@ func labelMatcherSet(items ...map[string]interface{}) *schema.Set {
 		raw = append(raw, it)
 	}
 	return schema.NewSet(schema.HashResource(labelMatcherElemSchema), raw)
+}
+
+func tolerationMatcherSet(items ...map[string]interface{}) *schema.Set {
+	raw := make([]interface{}, 0, len(items))
+	for _, it := range items {
+		raw = append(raw, it)
+	}
+	return schema.NewSet(schema.HashResource(tolerationMatcherSchema), raw)
 }

--- a/docs/resources/pod_mutation.md
+++ b/docs/resources/pod_mutation.md
@@ -399,6 +399,7 @@ Optional:
 
 - `exclude_labels_filter` (Block List, Max: 1) (see [below for nested schema](#nestedblock--filter_v2--pod--exclude_labels_filter))
 - `labels_filter` (Block List, Max: 1) (see [below for nested schema](#nestedblock--filter_v2--pod--labels_filter))
+- `tolerations_filter` (Block List, Max: 1) Tolerations filter for matching pods by their tolerations. (see [below for nested schema](#nestedblock--filter_v2--pod--tolerations_filter))
 
 <a id="nestedblock--filter_v2--pod--exclude_labels_filter"></a>
 ### Nested Schema for `filter_v2.pod.exclude_labels_filter`
@@ -469,6 +470,55 @@ Required:
 
 <a id="nestedblock--filter_v2--pod--labels_filter--matchers--value"></a>
 ### Nested Schema for `filter_v2.pod.labels_filter.matchers.value`
+
+Required:
+
+- `type` (String) Matcher type: EXACT or REGEX.
+- `value` (String) Value to match against.
+
+
+
+
+<a id="nestedblock--filter_v2--pod--tolerations_filter"></a>
+### Nested Schema for `filter_v2.pod.tolerations_filter`
+
+Required:
+
+- `matchers` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--filter_v2--pod--tolerations_filter--matchers))
+- `operator` (String) Logical operator to combine toleration matchers: AND or OR.
+
+<a id="nestedblock--filter_v2--pod--tolerations_filter--matchers"></a>
+### Nested Schema for `filter_v2.pod.tolerations_filter.matchers`
+
+Required:
+
+- `key` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--filter_v2--pod--tolerations_filter--matchers--key))
+
+Optional:
+
+- `operator` (Block List, Max: 1) (see [below for nested schema](#nestedblock--filter_v2--pod--tolerations_filter--matchers--operator))
+- `value` (Block List, Max: 1) (see [below for nested schema](#nestedblock--filter_v2--pod--tolerations_filter--matchers--value))
+
+<a id="nestedblock--filter_v2--pod--tolerations_filter--matchers--key"></a>
+### Nested Schema for `filter_v2.pod.tolerations_filter.matchers.key`
+
+Required:
+
+- `type` (String) Matcher type: EXACT or REGEX.
+- `value` (String) Value to match against.
+
+
+<a id="nestedblock--filter_v2--pod--tolerations_filter--matchers--operator"></a>
+### Nested Schema for `filter_v2.pod.tolerations_filter.matchers.operator`
+
+Required:
+
+- `type` (String) Matcher type: EXACT or REGEX.
+- `value` (String) Value to match against.
+
+
+<a id="nestedblock--filter_v2--pod--tolerations_filter--matchers--value"></a>
+### Nested Schema for `filter_v2.pod.tolerations_filter.matchers.value`
 
 Required:
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds `tolerations_filter` support to the `filter_v2.pod` block in the `castai_pod_mutation` resource, enabling users to match pods by their Kubernetes tolerations using key, value, and operator matchers combined with `AND` or `OR` logic.

### Key changes
- `castai/resource_pod_mutation.go`:
  - Added `tolerationsFilterSchema` and `tolerationMatcherSchema` definitions with fields `operator`, `key`, `value`, and toleration `operator`.
  - Introduced constants `FieldPodMutationFilterTolerationsFilter`, `FieldPodMutationTolerationsFilterOperator`, `FieldPodMutationTolerationsFilterMatchers`, and related matcher field names.
  - Implemented `stateToTolerationsFilter()` and `flattenTolerationsFilter()` for bidirectional conversion between Terraform state and `patching_engine.ObjectFilterV2TolerationsFilter`.
  - Wired `tolerations_filter` into the `filter_v2.pod` schema as an optional nested block and updated `validatePodMutationFilter()` to recognize it as a valid pod filter field.
  - Updated `stateToObjectFilterV2()` and `flattenObjectFilterV2()` to read and write the `Tolerations` field.
- `castai/resource_pod_mutation_test.go`:
  - Added test coverage for `flattenObjectFilterV2` and `stateToObjectFilterV2` tolerations round-trips.
  - Added `tolerationMatcherSet` test helper.
- `docs/resources/pod_mutation.md`:
  - Documented the new `tolerations_filter` nested schema under `filter_v2.pod`.