### PR TITLE
chore: use new core AKS acceptance test cluster

### DIFF
--- a/castai/resource_aks_cluster_test.go
+++ b/castai/resource_aks_cluster_test.go
@@ -419,8 +419,8 @@ func TestAccAKS_ResourceAKSCluster(t *testing.T) {
 	rName := fmt.Sprintf("%v-node-cfg-aks-%v", ResourcePrefix, acctest.RandString(8))
 	const (
 		clusterResourceName  = "castai_aks_cluster.test"
-		clusterName          = "terraform-tests-december-2025"
-		resourceGroupName    = "terraform-tests-december-2025"
+		clusterName          = "core-tf-acc-aks-2026-06-05"
+		resourceGroupName    = "core-tf-acc-aks-2026-06-05"
 		nodeConfResourceName = "castai_node_configuration.test"
 	)
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Updates the `TestAccAKS_ResourceAKSCluster` acceptance test to target a new AKS test fixture by changing the hard-coded `clusterName` and `resourceGroupName` constants.

### Why
Redirects the acceptance tests to the newly provisioned core AKS testing environment, replacing the previous December 2025 resources.

### Key changes
- `castai/resource_aks_cluster_test.go`: Updated `clusterName` and `resourceGroupName` constants in `TestAccAKS_ResourceAKSCluster` from `terraform-tests-december-2025` to `core-tf-acc-aks-2026-06-05`.