### PR TITLE
feat: added cni field for omni edgelocation

### DIFF
--- a/castai/resource_edge_location.go
+++ b/castai/resource_edge_location.go
@@ -69,15 +69,28 @@ func (m *controlPlaneModel) Equal(other *controlPlaneModel) bool {
 	return m.Ha.Equal(other.Ha)
 }
 
+type cniModel struct {
+	Overlay      types.String `tfsdk:"overlay"`
+	OverlayEncap types.String `tfsdk:"overlay_encap"`
+}
+
+func (m *cniModel) Equal(other *cniModel) bool {
+	if m == nil || other == nil {
+		return m == other
+	}
+	return m.Overlay.Equal(other.Overlay) && m.OverlayEncap.Equal(other.OverlayEncap)
+}
+
 type networkingModel struct {
 	TunneledCIDRs types.List `tfsdk:"tunneled_cidrs"`
+	CNI           *cniModel  `tfsdk:"cni"`
 }
 
 func (m *networkingModel) Equal(other *networkingModel) bool {
 	if m == nil || other == nil {
 		return m == other
 	}
-	return m.TunneledCIDRs.Equal(other.TunneledCIDRs)
+	return m.TunneledCIDRs.Equal(other.TunneledCIDRs) && m.CNI.Equal(other.CNI)
 }
 
 type zoneModel struct {
@@ -293,6 +306,35 @@ func (r *edgeLocationResource) Schema(_ context.Context, _ resource.SchemaReques
 						Optional:    true,
 						ElementType: types.StringType,
 						Description: "List of destination CIDR blocks whose traffic should be routed through the main cluster instead of directly from the edge cluster.",
+					},
+					"cni": schema.SingleNestedAttribute{
+						Optional:    true,
+						Description: "CNI (kube-router) configuration for the edge cluster.",
+						Attributes: map[string]schema.Attribute{
+							"overlay": schema.StringAttribute{
+								Optional:    true,
+								Description: "Overlay mode for kube-router pod-to-pod traffic. Valid values: OVERLAY_UNSPECIFIED, OVERLAY_OFF, OVERLAY_SUBNET, OVERLAY_FULL.",
+								Validators: []validator.String{
+									stringvalidator.OneOf(
+										string(omni.OVERLAYUNSPECIFIED),
+										string(omni.OVERLAYOFF),
+										string(omni.OVERLAYSUBNET),
+										string(omni.OVERLAYFULL),
+									),
+								},
+							},
+							"overlay_encap": schema.StringAttribute{
+								Optional:    true,
+								Description: "Encapsulation protocol used by the overlay. Valid values: OVERLAY_ENCAP_UNSPECIFIED, OVERLAY_ENCAP_IPIP, OVERLAY_ENCAP_FOU.",
+								Validators: []validator.String{
+									stringvalidator.OneOf(
+										string(omni.OVERLAYENCAPUNSPECIFIED),
+										string(omni.OVERLAYENCAPIPIP),
+										string(omni.OVERLAYENCAPFOU),
+									),
+								},
+							},
+						},
 					},
 				},
 			},
@@ -638,10 +680,19 @@ func (r *edgeLocationResource) Read(ctx context.Context, req resource.ReadReques
 		}
 		// Only sync networking from API if it was already managed in state.
 		// Otherwise, we'd cause perpetual drift for users who never set the block.
-		if state.Networking != nil && edgeLocation.EdgeClusterSpec.Networking != nil && edgeLocation.EdgeClusterSpec.Networking.TunneledCidrs != nil {
-			cidrs, d := types.ListValueFrom(ctx, types.StringType, *edgeLocation.EdgeClusterSpec.Networking.TunneledCidrs)
-			resp.Diagnostics.Append(d...)
-			state.Networking = &networkingModel{TunneledCIDRs: cidrs}
+		if state.Networking != nil && edgeLocation.EdgeClusterSpec.Networking != nil {
+			apiNet := edgeLocation.EdgeClusterSpec.Networking
+			if apiNet.TunneledCidrs != nil {
+				cidrs, d := types.ListValueFrom(ctx, types.StringType, *apiNet.TunneledCidrs)
+				resp.Diagnostics.Append(d...)
+				state.Networking.TunneledCIDRs = cidrs
+			}
+			if state.Networking.CNI != nil && apiNet.Cni != nil {
+				state.Networking.CNI = &cniModel{
+					Overlay:      types.StringPointerValue((*string)(apiNet.Cni.Overlay)),
+					OverlayEncap: types.StringPointerValue((*string)(apiNet.Cni.OverlayEncap)),
+				}
+			}
 		}
 	}
 
@@ -899,9 +950,26 @@ func (r *edgeLocationResource) edgeClusterSpecUpdate(ctx context.Context, plan, 
 				return nil, diags
 			}
 			spec.Networking.TunneledCidrs = &items
+			if plan.Networking.CNI != nil {
+				spec.Networking.Cni = r.toCNI(plan.Networking.CNI)
+			}
 		}
 	}
 	return spec, diags
+}
+
+func (r *edgeLocationResource) toCNI(cni *cniModel) *omni.EdgeClusterCNI {
+	if cni == nil {
+		return nil
+	}
+	out := &omni.EdgeClusterCNI{}
+	if !cni.Overlay.IsNull() && !cni.Overlay.IsUnknown() {
+		out.Overlay = (*omni.EdgeClusterCNIOverlay)(cni.Overlay.ValueStringPointer())
+	}
+	if !cni.OverlayEncap.IsNull() && !cni.OverlayEncap.IsUnknown() {
+		out.OverlayEncap = (*omni.EdgeClusterCNIOverlayEncap)(cni.OverlayEncap.ValueStringPointer())
+	}
+	return out
 }
 
 func (r *edgeLocationResource) toEdgeClusterSpec(ctx context.Context, cp *controlPlaneModel, net *networkingModel) (*omni.EdgeClusterSpec, diag.Diagnostics) {
@@ -925,6 +993,9 @@ func (r *edgeLocationResource) toEdgeClusterSpec(ctx context.Context, cp *contro
 		}
 		spec.Networking = &omni.EdgeClusterNetworking{
 			TunneledCidrs: &items,
+		}
+		if net.CNI != nil {
+			spec.Networking.Cni = r.toCNI(net.CNI)
 		}
 	}
 	return spec, diags

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -8372,10 +8372,9 @@ type ScheduledrebalancingV1DrainFailureConfig struct {
 
 // ScheduledrebalancingV1ExecutionConditions Defines the conditions which must be met in order to fully execute the plan.
 type ScheduledrebalancingV1ExecutionConditions struct {
-	// AchievedSavingsPercentage Identifies the minimum percentage of predicted savings that should be achieved.
+	// AchievedSavingsPercentage Identifies the minimum percentage of cost savings relative to the original (blue) cost that should be achieved.
 	// The rebalancing plan will not proceed after creating the nodes if the achieved savings percentage
-	// is not achieved.
-	// This field's value will not be considered if the initially predicted savings are negative.
+	// is not achieved. This field's value will not be considered if the initially predicted savings are negative.
 	AchievedSavingsPercentage *int32 `json:"achievedSavingsPercentage,omitempty"`
 	Enabled                   *bool  `json:"enabled,omitempty"`
 }
@@ -9119,6 +9118,61 @@ type WorkloadoptimizationV1FailedHookEvent struct {
 	Time    time.Time `json:"time"`
 }
 
+// WorkloadoptimizationV1GPUDeviceMetadata defines model for workloadoptimization.v1.GPUDeviceMetadata.
+type WorkloadoptimizationV1GPUDeviceMetadata struct {
+	// Count Number of devices of this type used by the workload in the queried range.
+	Count *int32 `json:"count,omitempty"`
+
+	// MemoryTotalMib Total framebuffer (VRAM) capacity in MiB for this device type.
+	MemoryTotalMib *float64 `json:"memoryTotalMib,omitempty"`
+
+	// ModelName GPU product name, e.g. "NVIDIA A100-SXM4-40GB".
+	ModelName *string `json:"modelName,omitempty"`
+}
+
+// WorkloadoptimizationV1GPUMetrics defines model for workloadoptimization.v1.GPUMetrics.
+type WorkloadoptimizationV1GPUMetrics struct {
+	// DeviceCount Effective GPU device count, accounting for cross-workload sharing (fractional).
+	DeviceCount *float64 `json:"deviceCount,omitempty"`
+
+	// GpuUtilization Average SM active utilization as a fraction (0.0–1.0).
+	GpuUtilization *float64 `json:"gpuUtilization,omitempty"`
+
+	// MemoryTotalMib Max GPU memory total (capacity) in MiB across devices in this bucket.
+	MemoryTotalMib *float64 `json:"memoryTotalMib,omitempty"`
+
+	// MemoryUsedMib Average GPU memory used in MiB.
+	MemoryUsedMib *float64 `json:"memoryUsedMib,omitempty"`
+
+	// OriginalDeviceCount Original requested GPU device count before optimization.
+	OriginalDeviceCount *float64 `json:"originalDeviceCount"`
+
+	// OriginalGpuUtilization Original requested GPU utilization before optimization, as a fraction (0.0–1.0).
+	OriginalGpuUtilization *float64 `json:"originalGpuUtilization"`
+
+	// OriginalMemoryUsedMib Original requested GPU memory used in MiB before optimization.
+	OriginalMemoryUsedMib *float64 `json:"originalMemoryUsedMib"`
+
+	// RecDeviceCount Recommended effective GPU device count (rec_gpu_utilization * device_count).
+	RecDeviceCount *float64 `json:"recDeviceCount"`
+
+	// RecGpuUtilization Recommended GPU compute utilization (from sm_active), as a fraction (0.0–1.0).
+	RecGpuUtilization *float64 `json:"recGpuUtilization"`
+
+	// RecMemoryUsedMib Recommended GPU memory usage in MiB (from max_used_memory_bytes, capped at 1 GiB minimum).
+	RecMemoryUsedMib *float64 `json:"recMemoryUsedMib"`
+
+	// RequestDeviceCount Current requested GPU device count after optimization.
+	RequestDeviceCount *float64 `json:"requestDeviceCount"`
+
+	// RequestGpuUtilization Current requested GPU utilization after optimization, as a fraction (0.0–1.0).
+	RequestGpuUtilization *float64 `json:"requestGpuUtilization"`
+
+	// RequestMemoryUsedMib Current requested GPU memory used in MiB after optimization.
+	RequestMemoryUsedMib *float64   `json:"requestMemoryUsedMib"`
+	Timestamp            *time.Time `json:"timestamp,omitempty"`
+}
+
 // WorkloadoptimizationV1GPUSettings defines model for workloadoptimization.v1.GPUSettings.
 type WorkloadoptimizationV1GPUSettings struct {
 	// ManagementOption Defines possible options for workload management.
@@ -9233,6 +9287,16 @@ type WorkloadoptimizationV1GetWorkloadFiltersResponse struct {
 	ScalingPolicyNames []string                                       `json:"scalingPolicyNames"`
 	WorkloadIds        []string                                       `json:"workloadIds"`
 	WorkloadNames      []string                                       `json:"workloadNames"`
+}
+
+// WorkloadoptimizationV1GetWorkloadGPUMetricsResponse defines model for workloadoptimization.v1.GetWorkloadGPUMetricsResponse.
+type WorkloadoptimizationV1GetWorkloadGPUMetricsResponse struct {
+	// GpuDevices Metadata about GPU device types used by this workload.
+	GpuDevices *[]WorkloadoptimizationV1GPUDeviceMetadata `json:"gpuDevices,omitempty"`
+	Items      *[]WorkloadoptimizationV1GPUMetrics        `json:"items,omitempty"`
+
+	// RecGpuDevices Recommended GPU device types (empty until GPU device recommendations are implemented).
+	RecGpuDevices *[]WorkloadoptimizationV1GPUDeviceMetadata `json:"recGpuDevices,omitempty"`
 }
 
 // WorkloadoptimizationV1GetWorkloadNativeVpaSpecResponse defines model for workloadoptimization.v1.GetWorkloadNativeVpaSpecResponse.
@@ -10022,10 +10086,13 @@ type WorkloadoptimizationV1NewWorkloadScalingPolicy struct {
 	// AssignmentRules AssignmentRules defines the ordered list of matching rules.
 	// The first matching rule is selected and assigned to workload.
 	// If none are matching then the default cluster policy is assigned.
-	AssignmentRules        *[]WorkloadoptimizationV1ScalingPolicyAssignmentRule `json:"assignmentRules,omitempty"`
-	HpaSettings            *WorkloadoptimizationV1ScalingPolicyHPASettings      `json:"hpaSettings,omitempty"`
-	Name                   string                                               `json:"name"`
-	RecommendationPolicies WorkloadoptimizationV1RecommendationPolicies         `json:"recommendationPolicies"`
+	AssignmentRules *[]WorkloadoptimizationV1ScalingPolicyAssignmentRule `json:"assignmentRules,omitempty"`
+	HpaSettings     *WorkloadoptimizationV1ScalingPolicyHPASettings      `json:"hpaSettings,omitempty"`
+
+	// IsOpsPilot Indicates that this scaling policy was created by OpsPilot and can be updated by it in subsequent runs.
+	IsOpsPilot             *bool                                        `json:"isOpsPilot,omitempty"`
+	Name                   string                                       `json:"name"`
+	RecommendationPolicies WorkloadoptimizationV1RecommendationPolicies `json:"recommendationPolicies"`
 }
 
 // WorkloadoptimizationV1OOMKillEvent defines model for workloadoptimization.v1.OOMKillEvent.
@@ -10797,10 +10864,13 @@ type WorkloadoptimizationV1UpdateWorkloadScalingPolicy struct {
 
 	// AssignmentRules AssignmentRules defines the ordered list of matching rules.
 	// BEWARE: If was defined on policy and not provided on update request, the assignment rules will be removed.
-	AssignmentRules        *[]WorkloadoptimizationV1ScalingPolicyAssignmentRule `json:"assignmentRules,omitempty"`
-	HpaSettings            *WorkloadoptimizationV1ScalingPolicyHPASettings      `json:"hpaSettings,omitempty"`
-	Name                   string                                               `json:"name"`
-	RecommendationPolicies WorkloadoptimizationV1RecommendationPolicies         `json:"recommendationPolicies"`
+	AssignmentRules *[]WorkloadoptimizationV1ScalingPolicyAssignmentRule `json:"assignmentRules,omitempty"`
+	HpaSettings     *WorkloadoptimizationV1ScalingPolicyHPASettings      `json:"hpaSettings,omitempty"`
+
+	// IsOpsPilot Indicates that this scaling policy was created by OpsPilot and can be updated by it in subsequent runs.
+	IsOpsPilot             *bool                                        `json:"isOpsPilot,omitempty"`
+	Name                   string                                       `json:"name"`
+	RecommendationPolicies WorkloadoptimizationV1RecommendationPolicies `json:"recommendationPolicies"`
 }
 
 // WorkloadoptimizationV1UpdateWorkloadV2 defines model for workloadoptimization.v1.UpdateWorkloadV2.
@@ -11099,8 +11169,11 @@ type WorkloadoptimizationV1WorkloadScalingPolicy struct {
 	Id                                  string                                               `json:"id"`
 
 	// IsCastware Indicates if policy is only for castware workloads. Such policy cannot be updated or assigned to non cast workloads.
-	IsCastware             bool                                         `json:"isCastware"`
-	IsDefault              bool                                         `json:"isDefault"`
+	IsCastware bool `json:"isCastware"`
+	IsDefault  bool `json:"isDefault"`
+
+	// IsOpsPilot Indicates that this scaling policy was created by OpsPilot and can be updated by it in subsequent runs.
+	IsOpsPilot             bool                                         `json:"isOpsPilot"`
 	IsReadonly             bool                                         `json:"isReadonly"`
 	Name                   string                                       `json:"name"`
 	OrganizationId         string                                       `json:"organizationId"`
@@ -11711,9 +11784,6 @@ type ExternalClusterAPIGetConnectAndEnableCASTAICmdParams struct {
 	// InstallAiOptimizerProxy Whether CAST AI AI-Optimizer Proxy should be installed.
 	InstallAiOptimizerProxy *bool `form:"installAiOptimizerProxy,omitempty" json:"installAiOptimizerProxy,omitempty"`
 
-	// GcpSaImpersonate Whether GCP SA Impersonate feature should be enabled.
-	GcpSaImpersonate *bool `form:"gcpSaImpersonate,omitempty" json:"gcpSaImpersonate,omitempty"`
-
 	// InstallNetflowExporter Whether Netflow network exporter should be installed.
 	InstallNetflowExporter *bool `form:"installNetflowExporter,omitempty" json:"installNetflowExporter,omitempty"`
 
@@ -11819,6 +11889,10 @@ type ExternalClusterAPITriggerHibernateClusterParams struct {
 	//  - OPERATION_MODE_DEFAULT: Normal operation - executes the hibernate/resume.
 	//  - OPERATION_MODE_DRY_RUN: Dry-run mode - validates only without executing.
 	Mode *ExternalClusterAPITriggerHibernateClusterParamsMode `form:"mode,omitempty" json:"mode,omitempty"`
+
+	// StopControlPlane Stops the cluster control plane during hibernation. Currently only supported on AKS.
+	// When enabled, hibernate fails on non-retryable errors (e.g. insufficient permissions).
+	StopControlPlane *bool `form:"stopControlPlane,omitempty" json:"stopControlPlane,omitempty"`
 }
 
 // ExternalClusterAPITriggerHibernateClusterParamsMode defines parameters for ExternalClusterAPITriggerHibernateCluster.
@@ -12483,6 +12557,12 @@ type WorkloadOptimizationAPIGetWorkloadParams struct {
 	IncludeCosts   *bool      `form:"includeCosts,omitempty" json:"includeCosts,omitempty"`
 	FromTime       *time.Time `form:"fromTime,omitempty" json:"fromTime,omitempty"`
 	ToTime         *time.Time `form:"toTime,omitempty" json:"toTime,omitempty"`
+}
+
+// WorkloadOptimizationAPIGetWorkloadGPUMetricsParams defines parameters for WorkloadOptimizationAPIGetWorkloadGPUMetrics.
+type WorkloadOptimizationAPIGetWorkloadGPUMetricsParams struct {
+	From *time.Time `form:"from,omitempty" json:"from,omitempty"`
+	To   *time.Time `form:"to,omitempty" json:"to,omitempty"`
 }
 
 // WorkloadOptimizationAPIGetInstallCmdParams defines parameters for WorkloadOptimizationAPIGetInstallCmd.

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -1017,6 +1017,9 @@ type ClientInterface interface {
 	// WorkloadOptimizationAPIGetWorkload request
 	WorkloadOptimizationAPIGetWorkload(ctx context.Context, clusterId string, workloadId string, params *WorkloadOptimizationAPIGetWorkloadParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// WorkloadOptimizationAPIGetWorkloadGPUMetrics request
+	WorkloadOptimizationAPIGetWorkloadGPUMetrics(ctx context.Context, clusterId string, workloadId string, params *WorkloadOptimizationAPIGetWorkloadGPUMetricsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// WorkloadOptimizationAPIGetWorkloadNativeVpaSpec request
 	WorkloadOptimizationAPIGetWorkloadNativeVpaSpec(ctx context.Context, clusterId string, workloadId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -5097,6 +5100,18 @@ func (c *Client) WorkloadOptimizationAPIMigrateClusterToHPAV2(ctx context.Contex
 
 func (c *Client) WorkloadOptimizationAPIGetWorkload(ctx context.Context, clusterId string, workloadId string, params *WorkloadOptimizationAPIGetWorkloadParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewWorkloadOptimizationAPIGetWorkloadRequest(c.Server, clusterId, workloadId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) WorkloadOptimizationAPIGetWorkloadGPUMetrics(ctx context.Context, clusterId string, workloadId string, params *WorkloadOptimizationAPIGetWorkloadGPUMetricsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewWorkloadOptimizationAPIGetWorkloadGPUMetricsRequest(c.Server, clusterId, workloadId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -11465,22 +11480,6 @@ func NewExternalClusterAPIGetConnectAndEnableCASTAICmdRequest(server string, par
 
 		}
 
-		if params.GcpSaImpersonate != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "gcpSaImpersonate", runtime.ParamLocationQuery, *params.GcpSaImpersonate); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
 		if params.InstallNetflowExporter != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "installNetflowExporter", runtime.ParamLocationQuery, *params.InstallNetflowExporter); err != nil {
@@ -12571,6 +12570,22 @@ func NewExternalClusterAPITriggerHibernateClusterRequest(server string, clusterI
 		if params.Mode != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "mode", runtime.ParamLocationQuery, *params.Mode); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.StopControlPlane != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "stopControlPlane", runtime.ParamLocationQuery, *params.StopControlPlane); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -20947,6 +20962,85 @@ func NewWorkloadOptimizationAPIGetWorkloadRequest(server string, clusterId strin
 	return req, nil
 }
 
+// NewWorkloadOptimizationAPIGetWorkloadGPUMetricsRequest generates requests for WorkloadOptimizationAPIGetWorkloadGPUMetrics
+func NewWorkloadOptimizationAPIGetWorkloadGPUMetricsRequest(server string, clusterId string, workloadId string, params *WorkloadOptimizationAPIGetWorkloadGPUMetricsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "clusterId", runtime.ParamLocationPath, clusterId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "workloadId", runtime.ParamLocationPath, workloadId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/workload-autoscaling/clusters/%s/workloads/%s/gpu-metrics", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.From != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "from", runtime.ParamLocationQuery, *params.From); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.To != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "to", runtime.ParamLocationQuery, *params.To); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewWorkloadOptimizationAPIGetWorkloadNativeVpaSpecRequest generates requests for WorkloadOptimizationAPIGetWorkloadNativeVpaSpec
 func NewWorkloadOptimizationAPIGetWorkloadNativeVpaSpecRequest(server string, clusterId string, workloadId string) (*http.Request, error) {
 	var err error
@@ -22849,6 +22943,9 @@ type ClientWithResponsesInterface interface {
 
 	// WorkloadOptimizationAPIGetWorkload request
 	WorkloadOptimizationAPIGetWorkloadWithResponse(ctx context.Context, clusterId string, workloadId string, params *WorkloadOptimizationAPIGetWorkloadParams) (*WorkloadOptimizationAPIGetWorkloadResponse, error)
+
+	// WorkloadOptimizationAPIGetWorkloadGPUMetrics request
+	WorkloadOptimizationAPIGetWorkloadGPUMetricsWithResponse(ctx context.Context, clusterId string, workloadId string, params *WorkloadOptimizationAPIGetWorkloadGPUMetricsParams) (*WorkloadOptimizationAPIGetWorkloadGPUMetricsResponse, error)
 
 	// WorkloadOptimizationAPIGetWorkloadNativeVpaSpec request
 	WorkloadOptimizationAPIGetWorkloadNativeVpaSpecWithResponse(ctx context.Context, clusterId string, workloadId string) (*WorkloadOptimizationAPIGetWorkloadNativeVpaSpecResponse, error)
@@ -30493,6 +30590,36 @@ func (r WorkloadOptimizationAPIGetWorkloadResponse) GetBody() []byte {
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
+type WorkloadOptimizationAPIGetWorkloadGPUMetricsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *WorkloadoptimizationV1GetWorkloadGPUMetricsResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r WorkloadOptimizationAPIGetWorkloadGPUMetricsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r WorkloadOptimizationAPIGetWorkloadGPUMetricsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r WorkloadOptimizationAPIGetWorkloadGPUMetricsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
 type WorkloadOptimizationAPIGetWorkloadNativeVpaSpecResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -33829,6 +33956,15 @@ func (c *ClientWithResponses) WorkloadOptimizationAPIGetWorkloadWithResponse(ctx
 		return nil, err
 	}
 	return ParseWorkloadOptimizationAPIGetWorkloadResponse(rsp)
+}
+
+// WorkloadOptimizationAPIGetWorkloadGPUMetricsWithResponse request returning *WorkloadOptimizationAPIGetWorkloadGPUMetricsResponse
+func (c *ClientWithResponses) WorkloadOptimizationAPIGetWorkloadGPUMetricsWithResponse(ctx context.Context, clusterId string, workloadId string, params *WorkloadOptimizationAPIGetWorkloadGPUMetricsParams) (*WorkloadOptimizationAPIGetWorkloadGPUMetricsResponse, error) {
+	rsp, err := c.WorkloadOptimizationAPIGetWorkloadGPUMetrics(ctx, clusterId, workloadId, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseWorkloadOptimizationAPIGetWorkloadGPUMetricsResponse(rsp)
 }
 
 // WorkloadOptimizationAPIGetWorkloadNativeVpaSpecWithResponse request returning *WorkloadOptimizationAPIGetWorkloadNativeVpaSpecResponse
@@ -40511,6 +40647,32 @@ func ParseWorkloadOptimizationAPIGetWorkloadResponse(rsp *http.Response) (*Workl
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest WorkloadoptimizationV1GetWorkloadResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseWorkloadOptimizationAPIGetWorkloadGPUMetricsResponse parses an HTTP response from a WorkloadOptimizationAPIGetWorkloadGPUMetricsWithResponse call
+func ParseWorkloadOptimizationAPIGetWorkloadGPUMetricsResponse(rsp *http.Response) (*WorkloadOptimizationAPIGetWorkloadGPUMetricsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &WorkloadOptimizationAPIGetWorkloadGPUMetricsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest WorkloadoptimizationV1GetWorkloadGPUMetricsResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/castai/sdk/cluster_autoscaler/api.gen.go
+++ b/castai/sdk/cluster_autoscaler/api.gen.go
@@ -37,6 +37,12 @@ type ClusterAssignments struct {
 	Items []ClusterAssignment `json:"items"`
 }
 
+// ComboMutationParams Parameters for combo mutation.
+type ComboMutationParams struct {
+	// Mutations Sub-mutations in this combo.
+	Mutations *[]Mutation `json:"mutations,omitempty"`
+}
+
 // GPUConfig GPUConfig describes instance GPU configuration.
 //
 //	Required while provisioning GCP N1 instance types with GPU.
@@ -131,6 +137,57 @@ type ListHibernationSchedulesResponse struct {
 	TotalCount *int32 `json:"totalCount,omitempty"`
 }
 
+// MaxPodsMutationParams Parameters for max pods mutation.
+type MaxPodsMutationParams struct {
+	// NewMaxPods New max pods value.
+	NewMaxPods *int32 `json:"newMaxPods,omitempty"`
+
+	// RemoveFormula Whether to remove the formula.
+	RemoveFormula *bool `json:"removeFormula,omitempty"`
+
+	// TemplateName Template name.
+	TemplateName *string `json:"templateName,omitempty"`
+}
+
+// MinCpuMutationParams Parameters for min CPU mutation.
+type MinCpuMutationParams struct {
+	// NewMinCpu New minimum CPU value.
+	NewMinCpu *int32 `json:"newMinCpu,omitempty"`
+
+	// TemplateName Template name.
+	TemplateName *string `json:"templateName,omitempty"`
+}
+
+// Mutation A single mutation applied to a rebalancing plan.
+type Mutation struct {
+	// AffectedSubjects Affected subjects (e.g. node names).
+	AffectedSubjects *[]string `json:"affectedSubjects,omitempty"`
+
+	// Category Mutation category.
+	Category *string `json:"category,omitempty"`
+
+	// Combo Combo mutation parameters.
+	Combo *ComboMutationParams `json:"combo,omitempty"`
+
+	// Description Mutation description.
+	Description *string `json:"description,omitempty"`
+
+	// Hash Stable fingerprint of the mutation's identity (name, category, subjects, params).
+	Hash *string `json:"hash,omitempty"`
+
+	// MaxPods Max pods mutation parameters.
+	MaxPods *MaxPodsMutationParams `json:"maxPods,omitempty"`
+
+	// MinCpu Min CPU mutation parameters.
+	MinCpu *MinCpuMutationParams `json:"minCpu,omitempty"`
+
+	// Name Mutation name.
+	Name *string `json:"name,omitempty"`
+
+	// RemoveTopology Remove topology mutation parameters.
+	RemoveTopology *RemoveTopologyMutationParams `json:"removeTopology,omitempty"`
+}
+
 // NodeAffinity NodeAffinity provides control over the assignment of individual nodes to dedicated host instances.
 type NodeAffinity struct {
 	// Affinity THe affinity rules required for choosing the group.
@@ -212,6 +269,15 @@ type RaidConfig struct {
 	// ChunkSizeKb Specify the RAID0 chunk size in kilobytes, this parameter affects the read/write in the disk array and must be tailored
 	//  for the type of data written by the workloads in the node. If not provided it will default to 64KB.
 	ChunkSizeKb *int32 `json:"chunkSizeKb,omitempty"`
+}
+
+// RemoveTopologyMutationParams Parameters for remove topology mutation.
+type RemoveTopologyMutationParams struct {
+	// OwnerKind Owner kind (e.g. Deployment, StatefulSet).
+	OwnerKind *string `json:"ownerKind,omitempty"`
+
+	// OwnerName Owner name (e.g. Deployment or StatefulSet name).
+	OwnerName *string `json:"ownerName,omitempty"`
 }
 
 // ResumeConfig Resume configuration

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -6615,6 +6615,26 @@ func (mr *MockClientInterfaceMockRecorder) WorkloadOptimizationAPIGetWorkloadFil
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetWorkloadFilters", reflect.TypeOf((*MockClientInterface)(nil).WorkloadOptimizationAPIGetWorkloadFilters), varargs...)
 }
 
+// WorkloadOptimizationAPIGetWorkloadGPUMetrics mocks base method.
+func (m *MockClientInterface) WorkloadOptimizationAPIGetWorkloadGPUMetrics(ctx context.Context, clusterId, workloadId string, params *sdk.WorkloadOptimizationAPIGetWorkloadGPUMetricsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, clusterId, workloadId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIGetWorkloadGPUMetrics", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadOptimizationAPIGetWorkloadGPUMetrics indicates an expected call of WorkloadOptimizationAPIGetWorkloadGPUMetrics.
+func (mr *MockClientInterfaceMockRecorder) WorkloadOptimizationAPIGetWorkloadGPUMetrics(ctx, clusterId, workloadId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, clusterId, workloadId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetWorkloadGPUMetrics", reflect.TypeOf((*MockClientInterface)(nil).WorkloadOptimizationAPIGetWorkloadGPUMetrics), varargs...)
+}
+
 // WorkloadOptimizationAPIGetWorkloadNativeVpaSpec mocks base method.
 func (m *MockClientInterface) WorkloadOptimizationAPIGetWorkloadNativeVpaSpec(ctx context.Context, clusterId, workloadId string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -18586,6 +18606,41 @@ func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIGetWorkloadFil
 func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIGetWorkloadFiltersWithResponse(ctx, clusterId, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetWorkloadFiltersWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIGetWorkloadFiltersWithResponse), ctx, clusterId, params)
+}
+
+// WorkloadOptimizationAPIGetWorkloadGPUMetrics mocks base method.
+func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIGetWorkloadGPUMetrics(ctx context.Context, clusterId, workloadId string, params *sdk.WorkloadOptimizationAPIGetWorkloadGPUMetricsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, clusterId, workloadId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIGetWorkloadGPUMetrics", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadOptimizationAPIGetWorkloadGPUMetrics indicates an expected call of WorkloadOptimizationAPIGetWorkloadGPUMetrics.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIGetWorkloadGPUMetrics(ctx, clusterId, workloadId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, clusterId, workloadId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetWorkloadGPUMetrics", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIGetWorkloadGPUMetrics), varargs...)
+}
+
+// WorkloadOptimizationAPIGetWorkloadGPUMetricsWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIGetWorkloadGPUMetricsWithResponse(ctx context.Context, clusterId, workloadId string, params *sdk.WorkloadOptimizationAPIGetWorkloadGPUMetricsParams) (*sdk.WorkloadOptimizationAPIGetWorkloadGPUMetricsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIGetWorkloadGPUMetricsWithResponse", ctx, clusterId, workloadId, params)
+	ret0, _ := ret[0].(*sdk.WorkloadOptimizationAPIGetWorkloadGPUMetricsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadOptimizationAPIGetWorkloadGPUMetricsWithResponse indicates an expected call of WorkloadOptimizationAPIGetWorkloadGPUMetricsWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIGetWorkloadGPUMetricsWithResponse(ctx, clusterId, workloadId, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetWorkloadGPUMetricsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIGetWorkloadGPUMetricsWithResponse), ctx, clusterId, workloadId, params)
 }
 
 // WorkloadOptimizationAPIGetWorkloadNativeVpaSpec mocks base method.

--- a/docs/resources/edge_location.md
+++ b/docs/resources/edge_location.md
@@ -130,7 +130,17 @@ Optional:
 
 Optional:
 
+- `cni` (Attributes) CNI (kube-router) configuration for the edge cluster. (see [below for nested schema](#nestedatt--networking--cni))
 - `tunneled_cidrs` (List of String) List of destination CIDR blocks whose traffic should be routed through the main cluster instead of directly from the edge cluster.
+
+<a id="nestedatt--networking--cni"></a>
+### Nested Schema for `networking.cni`
+
+Optional:
+
+- `overlay` (String) Overlay mode for kube-router pod-to-pod traffic. Valid values: OVERLAY_UNSPECIFIED, OVERLAY_OFF, OVERLAY_SUBNET, OVERLAY_FULL.
+- `overlay_encap` (String) Encapsulation protocol used by the overlay. Valid values: OVERLAY_ENCAP_UNSPECIFIED, OVERLAY_ENCAP_IPIP, OVERLAY_ENCAP_FOU.
+
 
 
 <a id="nestedatt--oci"></a>

--- a/examples/omni-custom-edgelocation/README.md
+++ b/examples/omni-custom-edgelocation/README.md
@@ -1,0 +1,62 @@
+# Omni Custom Edge Location
+
+Creates a CAST AI Omni custom edge location using the `castai_edge_location` resource with the `custom` cloud provider.
+
+Custom edge locations don't provision cloud infrastructure — the edge cluster runs on existing nodes in your environment.
+
+## Usage
+
+```hcl
+module "omni_custom_edge_location" {
+  source = "./omni-custom-edgelocation"
+
+  castai_api_token   = var.castai_api_token
+  organization_id    = var.organization_id
+  cluster_id         = var.cluster_id
+  edge_location_name = "my-custom-edge"
+  description        = "My custom edge location"
+  control_plane_mode = "DEDICATED"
+
+  tunneled_cidrs    = ["10.0.0.0/8"]
+  cni_overlay       = "OVERLAY_FULL"
+  cni_overlay_encap = "OVERLAY_ENCAP_IPIP"
+}
+```
+
+## Prerequisites
+
+- Terraform >= 1.x
+- CAST AI provider >= 8.2.0
+- A CAST AI Omni cluster already onboarded
+- Valid CAST AI API key
+
+## Inputs
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `castai_api_token` | CAST AI API token | `string` | — |
+| `organization_id` | CAST AI Organization ID | `string` | — |
+| `cluster_id` | Omni cluster ID | `string` | — |
+| `edge_location_name` | Name of the edge location | `string` | — |
+| `description` | Description of the edge location | `string` | `"Custom edge location onboarded by Terraform"` |
+| `control_plane_mode` | Control plane mode | `string` | `"DEDICATED"` |
+| `tunneled_cidrs` | CIDRs routed through main cluster | `list(string)` | `[]` |
+| `cni_overlay` | CNI overlay mode | `string` | `"OVERLAY_FULL"` |
+| `cni_overlay_encap` | CNI encapsulation protocol | `string` | `"OVERLAY_ENCAP_IPIP"` |
+
+## CNI Values
+
+| `cni_overlay` | `cni_overlay_encap` |
+|---------------|---------------------|
+| `OVERLAY_UNSPECIFIED` | `OVERLAY_ENCAP_UNSPECIFIED` |
+| `OVERLAY_OFF` | `OVERLAY_ENCAP_IPIP` |
+| `OVERLAY_SUBNET` | `OVERLAY_ENCAP_FOU` |
+| `OVERLAY_FULL` | |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `edge_location_id` | ID of the created edge location |
+| `edge_location_name` | Name of the edge location |
+| `credentials_revision` | Revision number for credentials |

--- a/examples/omni-custom-edgelocation/main.tf
+++ b/examples/omni-custom-edgelocation/main.tf
@@ -1,0 +1,41 @@
+provider "castai" {
+  api_token = var.castai_api_token
+}
+
+resource "castai_edge_location" "this1" {
+  name               = "customedgelocation01"
+  cluster_id         = var.cluster_id
+  organization_id    = var.organization_id
+  description        = var.description
+  region             = var.region
+  control_plane_mode = "SHARED"
+
+  custom = {}
+
+  networking = {
+    tunneled_cidrs = var.tunneled_cidrs
+
+    cni = {
+      overlay       = "OVERLAY_FULL"
+      overlay_encap = "OVERLAY_ENCAP_FOU"
+    }
+  }
+}
+
+resource "castai_edge_location" "this2" {
+  name               = "customedgelocation02"
+  cluster_id         = var.cluster_id
+  organization_id    = var.organization_id
+  description        = var.description
+  region             = var.region
+  control_plane_mode = "SHARED"
+
+  custom = {}
+
+  networking = {
+    tunneled_cidrs = ["10.0.0.0/8"]
+    cni = {
+      overlay = "OVERLAY_OFF"
+    }
+  }
+}

--- a/examples/omni-custom-edgelocation/outputs.tf
+++ b/examples/omni-custom-edgelocation/outputs.tf
@@ -1,0 +1,14 @@
+output "edge_location_id" {
+  description = "ID of the created edge location"
+  value       = castai_edge_location.this3.id
+}
+
+output "edge_location_name" {
+  description = "Name of the edge location"
+  value       = castai_edge_location.this3.name
+}
+
+output "credentials_revision" {
+  description = "Revision number incremented each time credentials change"
+  value       = castai_edge_location.this3.credentials_revision
+}

--- a/examples/omni-custom-edgelocation/variables.tf
+++ b/examples/omni-custom-edgelocation/variables.tf
@@ -1,0 +1,71 @@
+variable "castai_api_token" {
+  description = "Your CAST AI API token"
+  type        = string
+  sensitive   = true
+}
+
+variable "organization_id" {
+  description = "Your CAST AI Organization ID"
+  type        = string
+}
+
+variable "cluster_id" {
+  description = "CAST AI Omni cluster ID"
+  type        = string
+}
+
+variable "region" {
+  description = "Region where the edge location is deployed. Can be omitted for custom cloud provider."
+  type        = string
+  default     = null
+}
+
+variable "edge_location_name" {
+  description = "Name of the edge location. Must be unique and relatively short (max 30 chars for GCP service account compatibility)."
+  type        = string
+}
+
+variable "description" {
+  description = "Description of the edge location"
+  type        = string
+  default     = "Custom edge location onboarded by Terraform"
+}
+
+variable "control_plane_mode" {
+  description = "Control plane mode for the edge location. Valid values: DEDICATED, SHARED."
+  type        = string
+  default     = "SHARED"
+
+  validation {
+    condition     = contains(["DEDICATED", "SHARED"], var.control_plane_mode)
+    error_message = "control_plane_mode must be DEDICATED or SHARED."
+  }
+}
+
+variable "tunneled_cidrs" {
+  description = "List of destination CIDR blocks whose traffic should be routed through the main cluster."
+  type        = list(string)
+  default     = []
+}
+
+variable "cni_overlay" {
+  description = "Overlay mode for kube-router pod-to-pod traffic. Valid: OVERLAY_UNSPECIFIED, OVERLAY_OFF, OVERLAY_SUBNET, OVERLAY_FULL."
+  type        = string
+  default     = "OVERLAY_FULL"
+
+  validation {
+    condition     = contains(["OVERLAY_UNSPECIFIED", "OVERLAY_OFF", "OVERLAY_SUBNET", "OVERLAY_FULL"], var.cni_overlay)
+    error_message = "cni_overlay must be OVERLAY_UNSPECIFIED, OVERLAY_OFF, OVERLAY_SUBNET, or OVERLAY_FULL."
+  }
+}
+
+variable "cni_overlay_encap" {
+  description = "Encapsulation protocol used by the overlay. Valid: OVERLAY_ENCAP_UNSPECIFIED, OVERLAY_ENCAP_IPIP, OVERLAY_ENCAP_FOU."
+  type        = string
+  default     = "OVERLAY_ENCAP_IPIP"
+
+  validation {
+    condition     = contains(["OVERLAY_ENCAP_UNSPECIFIED", "OVERLAY_ENCAP_IPIP", "OVERLAY_ENCAP_FOU"], var.cni_overlay_encap)
+    error_message = "cni_overlay_encap must be OVERLAY_ENCAP_UNSPECIFIED, OVERLAY_ENCAP_IPIP, or OVERLAY_ENCAP_FOU."
+  }
+}

--- a/examples/omni-custom-edgelocation/versions.tf
+++ b/examples/omni-custom-edgelocation/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    castai = {
+      source  = "castai/castai"
+      version = ">= 8.2.0"
+    }
+  }
+}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for configuring CNI (kube-router) overlay settings on `castai_edge_location` resources and introduces a new example module for custom edge locations. Also regenerates the CAST AI SDK to include latest API additions.

### Why
Edge clusters need configurable pod-to-pod overlay modes and encapsulation protocols for different network topologies.

### Key changes
- `castai/resource_edge_location.go`
  - Added `cni` nested block under `networking` with `overlay` and `overlay_encap` attributes, including Terraform validators for allowed values.
  - Added `cniModel` and updated `networkingModel` equality checks.
  - Updated `Read`, `edgeClusterSpecUpdate`, `toEdgeClusterSpec`, and added `toCNI` to map CNI configuration to the Omni API.
  - `Read` logic only syncs CNI state when it already exists in Terraform state to avoid perpetual drift.
- `docs/resources/edge_location.md`
  - Documented new `networking.cni`, `networking.cni.overlay`, and `networking.cni.overlay_encap` arguments.
- `examples/omni-custom-edgelocation/`
  - Added complete example module demonstrating a custom edge location with CNI configuration.
- `castai/sdk/*`
  - Regenerated SDK to add workload GPU metrics APIs, cluster autoscaler mutation types, `IsOpsPilot` scaling policy field, `stop_control_plane` hibernate parameter, and removed deprecated `gcp_sa_impersonate` parameter.

### Impact
No breaking changes. The `cni` block is optional. Existing edge locations without CNI configuration will not show drift.