### PR TITLE
fix: omni edgelocation networking support for unspecified values

### DIFF
--- a/castai/resource_edge_location.go
+++ b/castai/resource_edge_location.go
@@ -688,9 +688,21 @@ func (r *edgeLocationResource) Read(ctx context.Context, req resource.ReadReques
 				state.Networking.TunneledCIDRs = cidrs
 			}
 			if state.Networking.CNI != nil && apiNet.Cni != nil {
+				overlay := types.StringPointerValue((*string)(apiNet.Cni.Overlay))
+				overlayEncap := types.StringPointerValue((*string)(apiNet.Cni.OverlayEncap))
+
+				// Treat UNSPECIFIED values from the API as null when the user hasn't
+				// explicitly set them, to avoid perpetual diffs.
+				if state.Networking.CNI.Overlay.IsNull() && overlay.ValueString() == string(omni.OVERLAYUNSPECIFIED) {
+					overlay = types.StringNull()
+				}
+				if state.Networking.CNI.OverlayEncap.IsNull() && overlayEncap.ValueString() == string(omni.OVERLAYENCAPUNSPECIFIED) {
+					overlayEncap = types.StringNull()
+				}
+
 				state.Networking.CNI = &cniModel{
-					Overlay:      types.StringPointerValue((*string)(apiNet.Cni.Overlay)),
-					OverlayEncap: types.StringPointerValue((*string)(apiNet.Cni.OverlayEncap)),
+					Overlay:      overlay,
+					OverlayEncap: overlayEncap,
 				}
 			}
 		}

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -11671,8 +11671,8 @@ type DboAPIListDatabaseComponentsParams struct {
 	EndTime *time.Time `form:"endTime,omitempty" json:"endTime,omitempty"`
 }
 
-// DboAPIListDatabaseInstancesParams defines parameters for DboAPIListDatabaseInstances.
-type DboAPIListDatabaseInstancesParams struct {
+// DboAPIListDatabaseInstancesLegacyParams defines parameters for DboAPIListDatabaseInstancesLegacy.
+type DboAPIListDatabaseInstancesLegacyParams struct {
 	// StartTime Start of period.
 	StartTime *time.Time `form:"startTime,omitempty" json:"startTime,omitempty"`
 

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -286,8 +286,8 @@ type ClientInterface interface {
 	// DboAPIListDatabaseComponents request
 	DboAPIListDatabaseComponents(ctx context.Context, params *DboAPIListDatabaseComponentsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DboAPIListDatabaseInstances request
-	DboAPIListDatabaseInstances(ctx context.Context, params *DboAPIListDatabaseInstancesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// DboAPIListDatabaseInstancesLegacy request
+	DboAPIListDatabaseInstancesLegacy(ctx context.Context, params *DboAPIListDatabaseInstancesLegacyParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DboAPIGetDatabaseInstance request
 	DboAPIGetDatabaseInstance(ctx context.Context, instanceId string, params *DboAPIGetDatabaseInstanceParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1906,8 +1906,8 @@ func (c *Client) DboAPIListDatabaseComponents(ctx context.Context, params *DboAP
 	return c.Client.Do(req)
 }
 
-func (c *Client) DboAPIListDatabaseInstances(ctx context.Context, params *DboAPIListDatabaseInstancesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDboAPIListDatabaseInstancesRequest(c.Server, params)
+func (c *Client) DboAPIListDatabaseInstancesLegacy(ctx context.Context, params *DboAPIListDatabaseInstancesLegacyParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDboAPIListDatabaseInstancesLegacyRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -9300,8 +9300,8 @@ func NewDboAPIListDatabaseComponentsRequest(server string, params *DboAPIListDat
 	return req, nil
 }
 
-// NewDboAPIListDatabaseInstancesRequest generates requests for DboAPIListDatabaseInstances
-func NewDboAPIListDatabaseInstancesRequest(server string, params *DboAPIListDatabaseInstancesParams) (*http.Request, error) {
+// NewDboAPIListDatabaseInstancesLegacyRequest generates requests for DboAPIListDatabaseInstancesLegacy
+func NewDboAPIListDatabaseInstancesLegacyRequest(server string, params *DboAPIListDatabaseInstancesLegacyParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -22213,8 +22213,8 @@ type ClientWithResponsesInterface interface {
 	// DboAPIListDatabaseComponents request
 	DboAPIListDatabaseComponentsWithResponse(ctx context.Context, params *DboAPIListDatabaseComponentsParams) (*DboAPIListDatabaseComponentsResponse, error)
 
-	// DboAPIListDatabaseInstances request
-	DboAPIListDatabaseInstancesWithResponse(ctx context.Context, params *DboAPIListDatabaseInstancesParams) (*DboAPIListDatabaseInstancesResponse, error)
+	// DboAPIListDatabaseInstancesLegacy request
+	DboAPIListDatabaseInstancesLegacyWithResponse(ctx context.Context, params *DboAPIListDatabaseInstancesLegacyParams) (*DboAPIListDatabaseInstancesLegacyResponse, error)
 
 	// DboAPIGetDatabaseInstance request
 	DboAPIGetDatabaseInstanceWithResponse(ctx context.Context, instanceId string, params *DboAPIGetDatabaseInstanceParams) (*DboAPIGetDatabaseInstanceResponse, error)
@@ -24681,14 +24681,14 @@ func (r DboAPIListDatabaseComponentsResponse) GetBody() []byte {
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
-type DboAPIListDatabaseInstancesResponse struct {
+type DboAPIListDatabaseInstancesLegacyResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *DboV1ListDatabaseInstancesResponse
 }
 
 // Status returns HTTPResponse.Status
-func (r DboAPIListDatabaseInstancesResponse) Status() string {
+func (r DboAPIListDatabaseInstancesLegacyResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -24696,7 +24696,7 @@ func (r DboAPIListDatabaseInstancesResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r DboAPIListDatabaseInstancesResponse) StatusCode() int {
+func (r DboAPIListDatabaseInstancesLegacyResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -24705,7 +24705,7 @@ func (r DboAPIListDatabaseInstancesResponse) StatusCode() int {
 
 // TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 // Body returns body of byte array
-func (r DboAPIListDatabaseInstancesResponse) GetBody() []byte {
+func (r DboAPIListDatabaseInstancesLegacyResponse) GetBody() []byte {
 	return r.Body
 }
 
@@ -31625,13 +31625,13 @@ func (c *ClientWithResponses) DboAPIListDatabaseComponentsWithResponse(ctx conte
 	return ParseDboAPIListDatabaseComponentsResponse(rsp)
 }
 
-// DboAPIListDatabaseInstancesWithResponse request returning *DboAPIListDatabaseInstancesResponse
-func (c *ClientWithResponses) DboAPIListDatabaseInstancesWithResponse(ctx context.Context, params *DboAPIListDatabaseInstancesParams) (*DboAPIListDatabaseInstancesResponse, error) {
-	rsp, err := c.DboAPIListDatabaseInstances(ctx, params)
+// DboAPIListDatabaseInstancesLegacyWithResponse request returning *DboAPIListDatabaseInstancesLegacyResponse
+func (c *ClientWithResponses) DboAPIListDatabaseInstancesLegacyWithResponse(ctx context.Context, params *DboAPIListDatabaseInstancesLegacyParams) (*DboAPIListDatabaseInstancesLegacyResponse, error) {
+	rsp, err := c.DboAPIListDatabaseInstancesLegacy(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	return ParseDboAPIListDatabaseInstancesResponse(rsp)
+	return ParseDboAPIListDatabaseInstancesLegacyResponse(rsp)
 }
 
 // DboAPIGetDatabaseInstanceWithResponse request returning *DboAPIGetDatabaseInstanceResponse
@@ -35554,15 +35554,15 @@ func ParseDboAPIListDatabaseComponentsResponse(rsp *http.Response) (*DboAPIListD
 	return response, nil
 }
 
-// ParseDboAPIListDatabaseInstancesResponse parses an HTTP response from a DboAPIListDatabaseInstancesWithResponse call
-func ParseDboAPIListDatabaseInstancesResponse(rsp *http.Response) (*DboAPIListDatabaseInstancesResponse, error) {
+// ParseDboAPIListDatabaseInstancesLegacyResponse parses an HTTP response from a DboAPIListDatabaseInstancesLegacyWithResponse call
+func ParseDboAPIListDatabaseInstancesLegacyResponse(rsp *http.Response) (*DboAPIListDatabaseInstancesLegacyResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &DboAPIListDatabaseInstancesResponse{
+	response := &DboAPIListDatabaseInstancesLegacyResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -1915,24 +1915,24 @@ func (mr *MockClientInterfaceMockRecorder) DboAPIListDatabaseComponents(ctx, par
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIListDatabaseComponents", reflect.TypeOf((*MockClientInterface)(nil).DboAPIListDatabaseComponents), varargs...)
 }
 
-// DboAPIListDatabaseInstances mocks base method.
-func (m *MockClientInterface) DboAPIListDatabaseInstances(ctx context.Context, params *sdk.DboAPIListDatabaseInstancesParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+// DboAPIListDatabaseInstancesLegacy mocks base method.
+func (m *MockClientInterface) DboAPIListDatabaseInstancesLegacy(ctx context.Context, params *sdk.DboAPIListDatabaseInstancesLegacyParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, params}
 	for _, a := range reqEditors {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "DboAPIListDatabaseInstances", varargs...)
+	ret := m.ctrl.Call(m, "DboAPIListDatabaseInstancesLegacy", varargs...)
 	ret0, _ := ret[0].(*http.Response)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DboAPIListDatabaseInstances indicates an expected call of DboAPIListDatabaseInstances.
-func (mr *MockClientInterfaceMockRecorder) DboAPIListDatabaseInstances(ctx, params interface{}, reqEditors ...interface{}) *gomock.Call {
+// DboAPIListDatabaseInstancesLegacy indicates an expected call of DboAPIListDatabaseInstancesLegacy.
+func (mr *MockClientInterfaceMockRecorder) DboAPIListDatabaseInstancesLegacy(ctx, params interface{}, reqEditors ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, params}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIListDatabaseInstances", reflect.TypeOf((*MockClientInterface)(nil).DboAPIListDatabaseInstances), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIListDatabaseInstancesLegacy", reflect.TypeOf((*MockClientInterface)(nil).DboAPIListDatabaseInstancesLegacy), varargs...)
 }
 
 // DboAPIUpdateCacheConfiguration mocks base method.
@@ -10398,39 +10398,39 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIListDatabaseCompon
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIListDatabaseComponentsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIListDatabaseComponentsWithResponse), ctx, params)
 }
 
-// DboAPIListDatabaseInstances mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPIListDatabaseInstances(ctx context.Context, params *sdk.DboAPIListDatabaseInstancesParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+// DboAPIListDatabaseInstancesLegacy mocks base method.
+func (m *MockClientWithResponsesInterface) DboAPIListDatabaseInstancesLegacy(ctx context.Context, params *sdk.DboAPIListDatabaseInstancesLegacyParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, params}
 	for _, a := range reqEditors {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "DboAPIListDatabaseInstances", varargs...)
+	ret := m.ctrl.Call(m, "DboAPIListDatabaseInstancesLegacy", varargs...)
 	ret0, _ := ret[0].(*http.Response)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DboAPIListDatabaseInstances indicates an expected call of DboAPIListDatabaseInstances.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIListDatabaseInstances(ctx, params interface{}, reqEditors ...interface{}) *gomock.Call {
+// DboAPIListDatabaseInstancesLegacy indicates an expected call of DboAPIListDatabaseInstancesLegacy.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIListDatabaseInstancesLegacy(ctx, params interface{}, reqEditors ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, params}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIListDatabaseInstances", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIListDatabaseInstances), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIListDatabaseInstancesLegacy", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIListDatabaseInstancesLegacy), varargs...)
 }
 
-// DboAPIListDatabaseInstancesWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPIListDatabaseInstancesWithResponse(ctx context.Context, params *sdk.DboAPIListDatabaseInstancesParams) (*sdk.DboAPIListDatabaseInstancesResponse, error) {
+// DboAPIListDatabaseInstancesLegacyWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) DboAPIListDatabaseInstancesLegacyWithResponse(ctx context.Context, params *sdk.DboAPIListDatabaseInstancesLegacyParams) (*sdk.DboAPIListDatabaseInstancesLegacyResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DboAPIListDatabaseInstancesWithResponse", ctx, params)
-	ret0, _ := ret[0].(*sdk.DboAPIListDatabaseInstancesResponse)
+	ret := m.ctrl.Call(m, "DboAPIListDatabaseInstancesLegacyWithResponse", ctx, params)
+	ret0, _ := ret[0].(*sdk.DboAPIListDatabaseInstancesLegacyResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DboAPIListDatabaseInstancesWithResponse indicates an expected call of DboAPIListDatabaseInstancesWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIListDatabaseInstancesWithResponse(ctx, params interface{}) *gomock.Call {
+// DboAPIListDatabaseInstancesLegacyWithResponse indicates an expected call of DboAPIListDatabaseInstancesLegacyWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIListDatabaseInstancesLegacyWithResponse(ctx, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIListDatabaseInstancesWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIListDatabaseInstancesWithResponse), ctx, params)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIListDatabaseInstancesLegacyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIListDatabaseInstancesLegacyWithResponse), ctx, params)
 }
 
 // DboAPIUpdateCacheConfiguration mocks base method.

--- a/examples/omni-custom-edgelocation/main.tf
+++ b/examples/omni-custom-edgelocation/main.tf
@@ -8,7 +8,7 @@ resource "castai_edge_location" "this" {
   organization_id    = var.organization_id
   description        = var.description
   region             = var.region
-  control_plane_mode = var.control_plane_mode
+  control_plane_mode = "SHARED"
 
   custom = {}
 

--- a/examples/omni-custom-edgelocation/main.tf
+++ b/examples/omni-custom-edgelocation/main.tf
@@ -2,13 +2,13 @@ provider "castai" {
   api_token = var.castai_api_token
 }
 
-resource "castai_edge_location" "this1" {
-  name               = "customedgelocation01"
+resource "castai_edge_location" "this" {
+  name               = var.edge_location_name
   cluster_id         = var.cluster_id
   organization_id    = var.organization_id
   description        = var.description
   region             = var.region
-  control_plane_mode = "SHARED"
+  control_plane_mode = var.control_plane_mode
 
   custom = {}
 
@@ -16,26 +16,9 @@ resource "castai_edge_location" "this1" {
     tunneled_cidrs = var.tunneled_cidrs
 
     cni = {
-      overlay       = "OVERLAY_FULL"
-      overlay_encap = "OVERLAY_ENCAP_FOU"
+      overlay       = var.cni_overlay
+      overlay_encap = var.cni_overlay_encap
     }
   }
 }
 
-resource "castai_edge_location" "this2" {
-  name               = "customedgelocation02"
-  cluster_id         = var.cluster_id
-  organization_id    = var.organization_id
-  description        = var.description
-  region             = var.region
-  control_plane_mode = "SHARED"
-
-  custom = {}
-
-  networking = {
-    tunneled_cidrs = ["10.0.0.0/8"]
-    cni = {
-      overlay = "OVERLAY_OFF"
-    }
-  }
-}

--- a/examples/omni-custom-edgelocation/outputs.tf
+++ b/examples/omni-custom-edgelocation/outputs.tf
@@ -1,14 +1,14 @@
 output "edge_location_id" {
   description = "ID of the created edge location"
-  value       = castai_edge_location.this3.id
+  value       = castai_edge_location.this.id
 }
 
 output "edge_location_name" {
   description = "Name of the edge location"
-  value       = castai_edge_location.this3.name
+  value       = castai_edge_location.this.name
 }
 
 output "credentials_revision" {
   description = "Revision number incremented each time credentials change"
-  value       = castai_edge_location.this3.credentials_revision
+  value       = castai_edge_location.this.credentials_revision
 }

--- a/examples/omni-custom-edgelocation/variables.tf
+++ b/examples/omni-custom-edgelocation/variables.tf
@@ -31,17 +31,6 @@ variable "description" {
   default     = "Custom edge location onboarded by Terraform"
 }
 
-variable "control_plane_mode" {
-  description = "Control plane mode for the edge location. Valid values: DEDICATED, SHARED."
-  type        = string
-  default     = "SHARED"
-
-  validation {
-    condition     = contains(["DEDICATED", "SHARED"], var.control_plane_mode)
-    error_message = "control_plane_mode must be DEDICATED or SHARED."
-  }
-}
-
 variable "tunneled_cidrs" {
   description = "List of destination CIDR blocks whose traffic should be routed through the main cluster."
   type        = list(string)
@@ -62,7 +51,7 @@ variable "cni_overlay" {
 variable "cni_overlay_encap" {
   description = "Encapsulation protocol used by the overlay. Valid: OVERLAY_ENCAP_UNSPECIFIED, OVERLAY_ENCAP_IPIP, OVERLAY_ENCAP_FOU."
   type        = string
-  default     = "OVERLAY_ENCAP_IPIP"
+  default     = "OVERLAY_ENCAP_FOU"
 
   validation {
     condition     = contains(["OVERLAY_ENCAP_UNSPECIFIED", "OVERLAY_ENCAP_IPIP", "OVERLAY_ENCAP_FOU"], var.cni_overlay_encap)


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Fixes perpetual diffs in the `castai_edge_location` resource by treating unset CNI fields as `null` when the API returns `UNSPECIFIED`. Also regenerates the internal SDK to adopt renamed legacy database instance endpoints and cleans up the custom edge location example.

### Why
Optional `overlay` and `overlay_encap` values that default to `UNSPECIFIED` in the API were being persisted in Terraform state as explicit strings, causing a non-empty diff on every plan. The example code also referenced a non-existent resource in its outputs.

### Key changes
- `castai/resource_edge_location.go`: In `Read`, maps `OVERLAY_UNSPECIFIED` and `OVERLAY_ENCAP_UNSPECIFIED` to `types.StringNull()` when the corresponding state field is not set, eliminating spurious diffs.
- `castai/sdk/api.gen.go`, `castai/sdk/client.gen.go`, `castai/sdk/mock/client.go`: Renamed generated types, methods, and response structs from `DboAPIListDatabaseInstances*` to `DboAPIListDatabaseInstancesLegacy*`.
- `examples/omni-custom-edgelocation/main.tf`: Consolidated two hardcoded resources into a single parameterized `castai_edge_location.this` resource.
- `examples/omni-custom-edgelocation/outputs.tf`: Corrected invalid `castai_edge_location.this3` references to `castai_edge_location.this`.
- `examples/omni-custom-edgelocation/variables.tf`: Removed the unused `control_plane_mode` variable and updated the default `cni_overlay_encap` value to `OVERLAY_ENCAP_FOU`.