### PR TITLE
feat: various small improvements around GKE impersonation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ examples/**/.terraform/
 examples/**/terraform.d/
 examples/**/crash.log
 examples/**/.terraformrc
+examples/**/.tofurc
 examples/**/*.tfstate
 examples/**/*.tfstate.lock.info
 examples/**/*.tfstate.backup

--- a/castai/resource_aks_cluster.go
+++ b/castai/resource_aks_cluster.go
@@ -273,7 +273,7 @@ func updateAKSClusterSettings(ctx context.Context, data *schema.ResourceData, cl
 		FieldAKSNoProxyDestinations,
 		FieldClusterCredentialsId,
 	) {
-		log.Printf("[INFO] Nothing to update in cluster setttings.")
+		log.Printf("[INFO] Nothing to update in cluster settings.")
 		return nil
 	}
 

--- a/castai/resource_eks_cluster.go
+++ b/castai/resource_eks_cluster.go
@@ -195,7 +195,7 @@ func updateClusterSettings(ctx context.Context, data *schema.ResourceData, clien
 		FieldEKSClusterAssumeRoleArn,
 		FieldClusterCredentialsId,
 	) {
-		log.Printf("[INFO] Nothing to update in cluster setttings.")
+		log.Printf("[INFO] Nothing to update in cluster settings.")
 		return nil
 	}
 

--- a/castai/resource_gke_cluster.go
+++ b/castai/resource_gke_cluster.go
@@ -199,7 +199,7 @@ func updateGKEClusterSettings(ctx context.Context, data *schema.ResourceData, cl
 		FieldGKEClusterCredentials,
 		FieldClusterCredentialsId,
 	) {
-		log.Printf("[INFO] Nothing to update in cluster setttings.")
+		log.Printf("[INFO] Nothing to update in cluster settings.")
 		return nil
 	}
 

--- a/castai/resource_gke_cluster_id.go
+++ b/castai/resource_gke_cluster_id.go
@@ -71,7 +71,6 @@ func resourceGKEClusterId() *schema.Resource {
 			},
 			FieldGKECastSA: {
 				Type:        schema.TypeString,
-				Optional:    true,
 				Computed:    true,
 				Description: "Service account email in cast project",
 			},

--- a/castai/resource_gke_cluster_id.go
+++ b/castai/resource_gke_cluster_id.go
@@ -134,6 +134,9 @@ func resourceCastaiGKEClusterIdCreate(ctx context.Context, data *schema.Resource
 		if err != nil {
 			return diag.FromErr(err)
 		}
+		if err := sdk.StatusOk(resp); err != nil {
+			return diag.FromErr(err)
+		}
 		if resp.JSON200 == nil || resp.JSON200.ServiceAccount == nil {
 			return diag.FromErr(fmt.Errorf("service account not returned"))
 		}

--- a/docs/resources/gke_cluster_id.md
+++ b/docs/resources/gke_cluster_id.md
@@ -23,12 +23,12 @@ GKE cluster resource allows connecting an existing GKE cluster to CAST AI.
 
 ### Optional
 
-- `cast_service_account` (String) Service account email in cast project
 - `client_service_account` (String) Service account email in client project
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
+- `cast_service_account` (String) Service account email in cast project
 - `cluster_token` (String, Sensitive) CAST.AI agent cluster token
 - `id` (String) The ID of this resource.
 - `organization_id` (String) CAST AI organization ID

--- a/examples/gke/gke_impersonate/castai.tf
+++ b/examples/gke/gke_impersonate/castai.tf
@@ -6,7 +6,7 @@ locals {
 # Configure GKE cluster connection.
 module "iam-impersonate" {
   source             = "castai/iam-impersonate/gke"
-  version            = "1.0.0"
+  version            = "~> 1.1"
   service_account_id = local.service_account_id
   cluster_region     = var.cluster_region
   cluster_name       = var.cluster_name

--- a/examples/gke/gke_impersonate/gke.tf
+++ b/examples/gke/gke_impersonate/gke.tf
@@ -1,6 +1,6 @@
 module "gke" {
   source                     = "terraform-google-modules/kubernetes-engine/google"
-  version                    = "24.1.0"
+  version                    = "44.2.0"
   project_id                 = var.project_id
   name                       = var.cluster_name
   region                     = var.cluster_region
@@ -14,6 +14,7 @@ module "gke" {
   horizontal_pod_autoscaling = true
   filestore_csi_driver       = false
   create_service_account     = false
+  deletion_protection        = false
   service_account            = module.iam-impersonate.client_service_account_email
 
   node_pools = [

--- a/examples/gke/gke_impersonate/variables.tf
+++ b/examples/gke/gke_impersonate/variables.tf
@@ -12,6 +12,7 @@ variable "cluster_region" {
 variable "cluster_zones" {
   type        = list(string)
   description = "The zones to create the cluster."
+  default     = []
 }
 
 variable "project_id" {

--- a/examples/gke/gke_impersonate/vpc.tf
+++ b/examples/gke/gke_impersonate/vpc.tf
@@ -6,7 +6,7 @@ locals {
 
 module "vpc" {
   source       = "terraform-google-modules/network/google"
-  version      = "6.0.0"
+  version      = "18.1.1"
   project_id   = var.project_id
   network_name = var.cluster_name
   subnets = [


### PR DESCRIPTION
The only functional change is making the `castai_gke_cluster_id.cast_service_account` field read-only. It was always meant to be read-only and setting it should have had no effect. We're only using it as an output to return the Cast AI service account created for impersonation.

If someone has previously set this field for any reason (it shouldn't have made a difference) then they'll get a similar error:

```
╷                                                                                                                                                                                                                                       
│ Error: Value for unconfigurable attribute                                                                                                                                                                                             
│                                                                                                                                                                                                                                       
│   with module.iam-impersonate.castai_gke_cluster_id.cluster_id,                                                                                                                                                                       
│   on .terraform/modules/iam-impersonate/main.tf line 52, in resource "castai_gke_cluster_id" "cluster_id":                                                                                                                            
│   52:   cast_service_account = "to-be-computed"                                                                                                                                                                                       
│                                                                                                                                                                                                                                       
│ Can't configure a value for "cast_service_account": its value will be decided automatically based on the result of applying this configuration.
```

The solution would be to just remove the attribute from the configuration.

## Proof of Work

I've successfully connected a GKE cluster using the example that is being changed.