### PR TITLE
feat: add cpus_per_gpu and min_gpus_per_node to node template dedicated_node_affinity

### DIFF
--- a/castai/resource_node_template.go
+++ b/castai/resource_node_template.go
@@ -73,6 +73,8 @@ const (
 	FieldNodeTemplateAffinityKeyName                          = "key"
 	FieldNodeTemplateAffinityOperatorName                     = "operator"
 	FieldNodeTemplateAffinityValuesName                       = "values"
+	FieldNodeTemplateCpusPerGpu                               = "cpus_per_gpu"
+	FieldNodeTemplateMinGpusPerNode                           = "min_gpus_per_node"
 	FieldNodeTemplateBurstableInstances                       = "burstable_instances"
 	FieldNodeTemplateCustomerSpecific                         = "customer_specific"
 	FieldNodeTemplateCPUManufacturers                         = "cpu_manufacturers"
@@ -553,6 +555,16 @@ func resourceNodeTemplate() *schema.Resource {
 												},
 											},
 										},
+									},
+									FieldNodeTemplateCpusPerGpu: {
+										Optional:    true,
+										Type:        schema.TypeInt,
+										Description: "Number of CPUs per GPU on the node.",
+									},
+									FieldNodeTemplateMinGpusPerNode: {
+										Optional:    true,
+										Type:        schema.TypeInt,
+										Description: "Minimal number of GPUs per node.",
 									},
 								},
 							},
@@ -1225,6 +1237,13 @@ func flattenNodeAffinity(affinities []sdk.NodetemplatesV1TemplateConstraintsDedi
 
 		result[FieldNodeTemplateName] = lo.FromPtr(item.Name)
 		result[FieldNodeTemplateAzName] = lo.FromPtr(item.AzName)
+
+		if item.CpusPerGpu != nil {
+			result[FieldNodeTemplateCpusPerGpu] = lo.FromPtr(item.CpusPerGpu)
+		}
+		if item.MinGpusPerNode != nil {
+			result[FieldNodeTemplateMinGpusPerNode] = lo.FromPtr(item.MinGpusPerNode)
+		}
 
 		if item.Affinity != nil && len(*item.Affinity) > 0 {
 			result[FieldNodeTemplateAffinityName] = lo.Map(*item.Affinity, func(affinity sdk.K8sSelectorV1KubernetesNodeAffinity, index int) map[string]any {
@@ -2027,6 +2046,12 @@ func toTemplateConstraintsNodeAffinity(o map[string]any) *sdk.NodetemplatesV1Tem
 			}
 			return out
 		}))
+	}
+	if v, ok := o[FieldNodeTemplateCpusPerGpu].(int); ok && v != 0 {
+		out.CpusPerGpu = toPtr(int32(v))
+	}
+	if v, ok := o[FieldNodeTemplateMinGpusPerNode].(int); ok && v != 0 {
+		out.MinGpusPerNode = toPtr(int32(v))
 	}
 
 	return &out

--- a/castai/resource_node_template_test.go
+++ b/castai/resource_node_template_test.go
@@ -114,7 +114,9 @@ func TestNodeTemplateResourceReadContext(t *testing.T) {
 							"operator": "In",	
 							"values": ["foo"]
 						  }
-						]
+						],
+						"cpusPerGpu": 4,
+              			"minGpusPerNode": 2
 					}
 				  ],
 				  "cpuManufacturers": ["INTEL", "AMD"],
@@ -229,8 +231,10 @@ constraints.0.dedicated_node_affinity.0.affinity.0.operator = In
 constraints.0.dedicated_node_affinity.0.affinity.0.values.# = 1
 constraints.0.dedicated_node_affinity.0.affinity.0.values.0 = foo
 constraints.0.dedicated_node_affinity.0.az_name = eu-central-1a
+constraints.0.dedicated_node_affinity.0.cpus_per_gpu = 4
 constraints.0.dedicated_node_affinity.0.instance_types.# = 1
 constraints.0.dedicated_node_affinity.0.instance_types.0 = m5.24xlarge
+constraints.0.dedicated_node_affinity.0.min_gpus_per_node = 2
 constraints.0.dedicated_node_affinity.0.name = foo
 constraints.0.on_demand = true
 constraints.0.os.# = 1
@@ -293,9 +297,11 @@ func Test_flattenNodeAffinity(t *testing.T) {
 					Operator: sdk.K8sSelectorV1Operator(op),
 					Values:   []string{"linux"},
 				}},
-				AzName:        lo.ToPtr("us-central1-c"),
-				InstanceTypes: &[]string{"e2"},
-				Name:          lo.ToPtr("linux-only"),
+				AzName:         lo.ToPtr("us-central1-c"),
+				InstanceTypes:  &[]string{"e2"},
+				Name:           lo.ToPtr("linux-only"),
+				CpusPerGpu:     lo.ToPtr(int32(4)),
+				MinGpusPerNode: lo.ToPtr(int32(2)),
 			},
 		}
 	}
@@ -303,9 +309,11 @@ func Test_flattenNodeAffinity(t *testing.T) {
 	makeMappedNodeAffinityWithOperator := func(op string) []map[string]any {
 		wantNA := []map[string]any{
 			{
-				FieldNodeTemplateInstanceTypes: []string{"e2"},
-				FieldNodeTemplateAzName:        "us-central1-c",
-				FieldNodeTemplateName:          "linux-only",
+				FieldNodeTemplateInstanceTypes:  []string{"e2"},
+				FieldNodeTemplateAzName:         "us-central1-c",
+				FieldNodeTemplateName:           "linux-only",
+				FieldNodeTemplateCpusPerGpu:     int32(4),
+				FieldNodeTemplateMinGpusPerNode: int32(2),
 				FieldNodeTemplateAffinityName: []map[string]any{
 					{
 						FieldNodeTemplateAffinityKeyName:      "kubernetes.io/os",
@@ -363,6 +371,54 @@ func Test_flattenNodeAffinity(t *testing.T) {
 			if tc.wantErr {
 				r.Error(err)
 			}
+		})
+	}
+}
+
+func Test_toTemplateConstraintsDedicatedAffinity(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]any
+		want  *sdk.NodetemplatesV1TemplateConstraintsDedicatedNodeAffinity
+	}{
+		{
+			name: "full map",
+			input: map[string]any{
+				FieldNodeTemplateName:           "test",
+				FieldNodeTemplateAzName:         "us-central1-c",
+				FieldNodeTemplateInstanceTypes:  []any{"e2"},
+				FieldNodeTemplateCpusPerGpu:     4,
+				FieldNodeTemplateMinGpusPerNode: 2,
+			},
+			want: &sdk.NodetemplatesV1TemplateConstraintsDedicatedNodeAffinity{
+				Name:           lo.ToPtr("test"),
+				AzName:         lo.ToPtr("us-central1-c"),
+				InstanceTypes:  &[]string{"e2"},
+				CpusPerGpu:     lo.ToPtr(int32(4)),
+				MinGpusPerNode: lo.ToPtr(int32(2)),
+			},
+		},
+		{
+			name:  "nil map returns nil",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name: "partial map without new fields",
+			input: map[string]any{
+				FieldNodeTemplateName: "test",
+			},
+			want: &sdk.NodetemplatesV1TemplateConstraintsDedicatedNodeAffinity{
+				Name: lo.ToPtr("test"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			got := toTemplateConstraintsNodeAffinity(tc.input)
+			r.Equal(tc.want, got)
 		})
 	}
 }

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -1411,26 +1411,6 @@ const (
 	WorkloadOptimizationAPIGetWorkloadFiltersParamsManagementOptionsUNDEFINED WorkloadOptimizationAPIGetWorkloadFiltersParamsManagementOptions = "UNDEFINED"
 )
 
-// Defines values for WorkloadOptimizationAPIGetInstallCmdParamsCmePresets.
-const (
-	WorkloadOptimizationAPIGetInstallCmdParamsCmePresetsCODAHALE      WorkloadOptimizationAPIGetInstallCmdParamsCmePresets = "CODAHALE"
-	WorkloadOptimizationAPIGetInstallCmdParamsCmePresetsDROPWIZARD    WorkloadOptimizationAPIGetInstallCmdParamsCmePresets = "DROPWIZARD"
-	WorkloadOptimizationAPIGetInstallCmdParamsCmePresetsINVALID       WorkloadOptimizationAPIGetInstallCmdParamsCmePresets = "INVALID"
-	WorkloadOptimizationAPIGetInstallCmdParamsCmePresetsMICROMETER    WorkloadOptimizationAPIGetInstallCmdParamsCmePresets = "MICROMETER"
-	WorkloadOptimizationAPIGetInstallCmdParamsCmePresetsOTELJAVAAGENT WorkloadOptimizationAPIGetInstallCmdParamsCmePresets = "OTEL_JAVA_AGENT"
-	WorkloadOptimizationAPIGetInstallCmdParamsCmePresetsSDKPROMETHEUS WorkloadOptimizationAPIGetInstallCmdParamsCmePresets = "SDK_PROMETHEUS"
-)
-
-// Defines values for WorkloadOptimizationAPIGetInstallScriptParamsCmePresets.
-const (
-	WorkloadOptimizationAPIGetInstallScriptParamsCmePresetsCODAHALE      WorkloadOptimizationAPIGetInstallScriptParamsCmePresets = "CODAHALE"
-	WorkloadOptimizationAPIGetInstallScriptParamsCmePresetsDROPWIZARD    WorkloadOptimizationAPIGetInstallScriptParamsCmePresets = "DROPWIZARD"
-	WorkloadOptimizationAPIGetInstallScriptParamsCmePresetsINVALID       WorkloadOptimizationAPIGetInstallScriptParamsCmePresets = "INVALID"
-	WorkloadOptimizationAPIGetInstallScriptParamsCmePresetsMICROMETER    WorkloadOptimizationAPIGetInstallScriptParamsCmePresets = "MICROMETER"
-	WorkloadOptimizationAPIGetInstallScriptParamsCmePresetsOTELJAVAAGENT WorkloadOptimizationAPIGetInstallScriptParamsCmePresets = "OTEL_JAVA_AGENT"
-	WorkloadOptimizationAPIGetInstallScriptParamsCmePresetsSDKPROMETHEUS WorkloadOptimizationAPIGetInstallScriptParamsCmePresets = "SDK_PROMETHEUS"
-)
-
 // Defines values for WorkloadOptimizationAPIListClusterHPAsParamsManagementOptions.
 const (
 	WorkloadOptimizationAPIListClusterHPAsParamsManagementOptionsMANAGED   WorkloadOptimizationAPIListClusterHPAsParamsManagementOptions = "MANAGED"
@@ -9281,11 +9261,6 @@ type WorkloadoptimizationV1GetHPAV2MigrationEligibilityResponse struct {
 //   - NONE: No workloads eligible for migration - banner should not be shown
 type WorkloadoptimizationV1GetHPAV2MigrationEligibilityResponseMigrationStatus string
 
-// WorkloadoptimizationV1GetInstallCmdResponse defines model for workloadoptimization.v1.GetInstallCmdResponse.
-type WorkloadoptimizationV1GetInstallCmdResponse struct {
-	Script string `json:"script"`
-}
-
 // WorkloadoptimizationV1GetOrganizationAgentStatusesResponse defines model for workloadoptimization.v1.GetOrganizationAgentStatusesResponse.
 type WorkloadoptimizationV1GetOrganizationAgentStatusesResponse struct {
 	ClusterAgentStatuses []WorkloadoptimizationV1GetAgentStatusResponse `json:"clusterAgentStatuses"`
@@ -12598,25 +12573,6 @@ type WorkloadOptimizationAPIGetWorkloadGPUMetricsParams struct {
 	From *time.Time `form:"from,omitempty" json:"from,omitempty"`
 	To   *time.Time `form:"to,omitempty" json:"to,omitempty"`
 }
-
-// WorkloadOptimizationAPIGetInstallCmdParams defines parameters for WorkloadOptimizationAPIGetInstallCmd.
-type WorkloadOptimizationAPIGetInstallCmdParams struct {
-	ClusterId  string                                                  `form:"clusterId" json:"clusterId"`
-	CmeDsUrl   *string                                                 `form:"cmeDsUrl,omitempty" json:"cmeDsUrl,omitempty"`
-	CmePresets *[]WorkloadOptimizationAPIGetInstallCmdParamsCmePresets `form:"cmePresets,omitempty" json:"cmePresets,omitempty"`
-}
-
-// WorkloadOptimizationAPIGetInstallCmdParamsCmePresets defines parameters for WorkloadOptimizationAPIGetInstallCmd.
-type WorkloadOptimizationAPIGetInstallCmdParamsCmePresets string
-
-// WorkloadOptimizationAPIGetInstallScriptParams defines parameters for WorkloadOptimizationAPIGetInstallScript.
-type WorkloadOptimizationAPIGetInstallScriptParams struct {
-	CmeDsUrl   *string                                                    `form:"cmeDsUrl,omitempty" json:"cmeDsUrl,omitempty"`
-	CmePresets *[]WorkloadOptimizationAPIGetInstallScriptParamsCmePresets `form:"cmePresets,omitempty" json:"cmePresets,omitempty"`
-}
-
-// WorkloadOptimizationAPIGetInstallScriptParamsCmePresets defines parameters for WorkloadOptimizationAPIGetInstallScript.
-type WorkloadOptimizationAPIGetInstallScriptParamsCmePresets string
 
 // InventoryAPIListZonesParams defines parameters for InventoryAPIListZones.
 type InventoryAPIListZonesParams struct {

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -1023,12 +1023,6 @@ type ClientInterface interface {
 	// WorkloadOptimizationAPIGetOrganizationAgentStatuses request
 	WorkloadOptimizationAPIGetOrganizationAgentStatuses(ctx context.Context, organizationId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// WorkloadOptimizationAPIGetInstallCmd request
-	WorkloadOptimizationAPIGetInstallCmd(ctx context.Context, params *WorkloadOptimizationAPIGetInstallCmdParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// WorkloadOptimizationAPIGetInstallScript request
-	WorkloadOptimizationAPIGetInstallScript(ctx context.Context, params *WorkloadOptimizationAPIGetInstallScriptParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
 	// InventoryAPIListZones request
 	InventoryAPIListZones(ctx context.Context, params *InventoryAPIListZonesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -5110,30 +5104,6 @@ func (c *Client) WorkloadOptimizationAPIResetSystemOverrides(ctx context.Context
 
 func (c *Client) WorkloadOptimizationAPIGetOrganizationAgentStatuses(ctx context.Context, organizationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewWorkloadOptimizationAPIGetOrganizationAgentStatusesRequest(c.Server, organizationId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) WorkloadOptimizationAPIGetInstallCmd(ctx context.Context, params *WorkloadOptimizationAPIGetInstallCmdParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewWorkloadOptimizationAPIGetInstallCmdRequest(c.Server, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) WorkloadOptimizationAPIGetInstallScript(ctx context.Context, params *WorkloadOptimizationAPIGetInstallScriptParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewWorkloadOptimizationAPIGetInstallScriptRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -20988,148 +20958,6 @@ func NewWorkloadOptimizationAPIGetOrganizationAgentStatusesRequest(server string
 	return req, nil
 }
 
-// NewWorkloadOptimizationAPIGetInstallCmdRequest generates requests for WorkloadOptimizationAPIGetInstallCmd
-func NewWorkloadOptimizationAPIGetInstallCmdRequest(server string, params *WorkloadOptimizationAPIGetInstallCmdParams) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/v1/workload-autoscaling/scripts/workload-autoscaler-install")
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "clusterId", runtime.ParamLocationQuery, params.ClusterId); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-		if params.CmeDsUrl != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cmeDsUrl", runtime.ParamLocationQuery, *params.CmeDsUrl); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.CmePresets != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cmePresets", runtime.ParamLocationQuery, *params.CmePresets); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewWorkloadOptimizationAPIGetInstallScriptRequest generates requests for WorkloadOptimizationAPIGetInstallScript
-func NewWorkloadOptimizationAPIGetInstallScriptRequest(server string, params *WorkloadOptimizationAPIGetInstallScriptParams) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/v1/workload-autoscaling/scripts/workload-autoscaler-install.sh")
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.CmeDsUrl != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cmeDsUrl", runtime.ParamLocationQuery, *params.CmeDsUrl); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.CmePresets != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cmePresets", runtime.ParamLocationQuery, *params.CmePresets); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
 // NewInventoryAPIListZonesRequest generates requests for InventoryAPIListZones
 func NewInventoryAPIListZonesRequest(server string, params *InventoryAPIListZonesParams) (*http.Request, error) {
 	var err error
@@ -22685,12 +22513,6 @@ type ClientWithResponsesInterface interface {
 
 	// WorkloadOptimizationAPIGetOrganizationAgentStatuses request
 	WorkloadOptimizationAPIGetOrganizationAgentStatusesWithResponse(ctx context.Context, organizationId string) (*WorkloadOptimizationAPIGetOrganizationAgentStatusesResponse, error)
-
-	// WorkloadOptimizationAPIGetInstallCmd request
-	WorkloadOptimizationAPIGetInstallCmdWithResponse(ctx context.Context, params *WorkloadOptimizationAPIGetInstallCmdParams) (*WorkloadOptimizationAPIGetInstallCmdResponse, error)
-
-	// WorkloadOptimizationAPIGetInstallScript request
-	WorkloadOptimizationAPIGetInstallScriptWithResponse(ctx context.Context, params *WorkloadOptimizationAPIGetInstallScriptParams) (*WorkloadOptimizationAPIGetInstallScriptResponse, error)
 
 	// InventoryAPIListZones request
 	InventoryAPIListZonesWithResponse(ctx context.Context, params *InventoryAPIListZonesParams) (*InventoryAPIListZonesResponse, error)
@@ -30372,65 +30194,6 @@ func (r WorkloadOptimizationAPIGetOrganizationAgentStatusesResponse) GetBody() [
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
-type WorkloadOptimizationAPIGetInstallCmdResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *WorkloadoptimizationV1GetInstallCmdResponse
-}
-
-// Status returns HTTPResponse.Status
-func (r WorkloadOptimizationAPIGetInstallCmdResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r WorkloadOptimizationAPIGetInstallCmdResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
-// Body returns body of byte array
-func (r WorkloadOptimizationAPIGetInstallCmdResponse) GetBody() []byte {
-	return r.Body
-}
-
-// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
-
-type WorkloadOptimizationAPIGetInstallScriptResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-}
-
-// Status returns HTTPResponse.Status
-func (r WorkloadOptimizationAPIGetInstallScriptResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r WorkloadOptimizationAPIGetInstallScriptResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
-// Body returns body of byte array
-func (r WorkloadOptimizationAPIGetInstallScriptResponse) GetBody() []byte {
-	return r.Body
-}
-
-// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
-
 type InventoryAPIListZonesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -33576,24 +33339,6 @@ func (c *ClientWithResponses) WorkloadOptimizationAPIGetOrganizationAgentStatuse
 		return nil, err
 	}
 	return ParseWorkloadOptimizationAPIGetOrganizationAgentStatusesResponse(rsp)
-}
-
-// WorkloadOptimizationAPIGetInstallCmdWithResponse request returning *WorkloadOptimizationAPIGetInstallCmdResponse
-func (c *ClientWithResponses) WorkloadOptimizationAPIGetInstallCmdWithResponse(ctx context.Context, params *WorkloadOptimizationAPIGetInstallCmdParams) (*WorkloadOptimizationAPIGetInstallCmdResponse, error) {
-	rsp, err := c.WorkloadOptimizationAPIGetInstallCmd(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-	return ParseWorkloadOptimizationAPIGetInstallCmdResponse(rsp)
-}
-
-// WorkloadOptimizationAPIGetInstallScriptWithResponse request returning *WorkloadOptimizationAPIGetInstallScriptResponse
-func (c *ClientWithResponses) WorkloadOptimizationAPIGetInstallScriptWithResponse(ctx context.Context, params *WorkloadOptimizationAPIGetInstallScriptParams) (*WorkloadOptimizationAPIGetInstallScriptResponse, error) {
-	rsp, err := c.WorkloadOptimizationAPIGetInstallScript(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-	return ParseWorkloadOptimizationAPIGetInstallScriptResponse(rsp)
 }
 
 // InventoryAPIListZonesWithResponse request returning *InventoryAPIListZonesResponse
@@ -40262,48 +40007,6 @@ func ParseWorkloadOptimizationAPIGetOrganizationAgentStatusesResponse(rsp *http.
 		}
 		response.JSON200 = &dest
 
-	}
-
-	return response, nil
-}
-
-// ParseWorkloadOptimizationAPIGetInstallCmdResponse parses an HTTP response from a WorkloadOptimizationAPIGetInstallCmdWithResponse call
-func ParseWorkloadOptimizationAPIGetInstallCmdResponse(rsp *http.Response) (*WorkloadOptimizationAPIGetInstallCmdResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &WorkloadOptimizationAPIGetInstallCmdResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest WorkloadoptimizationV1GetInstallCmdResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseWorkloadOptimizationAPIGetInstallScriptResponse parses an HTTP response from a WorkloadOptimizationAPIGetInstallScriptWithResponse call
-func ParseWorkloadOptimizationAPIGetInstallScriptResponse(rsp *http.Response) (*WorkloadOptimizationAPIGetInstallScriptResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &WorkloadOptimizationAPIGetInstallScriptResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
 	}
 
 	return response, nil

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -6355,46 +6355,6 @@ func (mr *MockClientInterfaceMockRecorder) WorkloadOptimizationAPIGetHPAV2Migrat
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetHPAV2MigrationEligibility", reflect.TypeOf((*MockClientInterface)(nil).WorkloadOptimizationAPIGetHPAV2MigrationEligibility), varargs...)
 }
 
-// WorkloadOptimizationAPIGetInstallCmd mocks base method.
-func (m *MockClientInterface) WorkloadOptimizationAPIGetInstallCmd(ctx context.Context, params *sdk.WorkloadOptimizationAPIGetInstallCmdParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, params}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIGetInstallCmd", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WorkloadOptimizationAPIGetInstallCmd indicates an expected call of WorkloadOptimizationAPIGetInstallCmd.
-func (mr *MockClientInterfaceMockRecorder) WorkloadOptimizationAPIGetInstallCmd(ctx, params interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, params}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetInstallCmd", reflect.TypeOf((*MockClientInterface)(nil).WorkloadOptimizationAPIGetInstallCmd), varargs...)
-}
-
-// WorkloadOptimizationAPIGetInstallScript mocks base method.
-func (m *MockClientInterface) WorkloadOptimizationAPIGetInstallScript(ctx context.Context, params *sdk.WorkloadOptimizationAPIGetInstallScriptParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, params}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIGetInstallScript", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WorkloadOptimizationAPIGetInstallScript indicates an expected call of WorkloadOptimizationAPIGetInstallScript.
-func (mr *MockClientInterfaceMockRecorder) WorkloadOptimizationAPIGetInstallScript(ctx, params interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, params}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetInstallScript", reflect.TypeOf((*MockClientInterface)(nil).WorkloadOptimizationAPIGetInstallScript), varargs...)
-}
-
 // WorkloadOptimizationAPIGetOrganizationAgentStatuses mocks base method.
 func (m *MockClientInterface) WorkloadOptimizationAPIGetOrganizationAgentStatuses(ctx context.Context, organizationId string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -18066,76 +18026,6 @@ func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIGetHPAV2Migrat
 func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIGetHPAV2MigrationEligibilityWithResponse(ctx, clusterId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetHPAV2MigrationEligibilityWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIGetHPAV2MigrationEligibilityWithResponse), ctx, clusterId)
-}
-
-// WorkloadOptimizationAPIGetInstallCmd mocks base method.
-func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIGetInstallCmd(ctx context.Context, params *sdk.WorkloadOptimizationAPIGetInstallCmdParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, params}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIGetInstallCmd", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WorkloadOptimizationAPIGetInstallCmd indicates an expected call of WorkloadOptimizationAPIGetInstallCmd.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIGetInstallCmd(ctx, params interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, params}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetInstallCmd", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIGetInstallCmd), varargs...)
-}
-
-// WorkloadOptimizationAPIGetInstallCmdWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIGetInstallCmdWithResponse(ctx context.Context, params *sdk.WorkloadOptimizationAPIGetInstallCmdParams) (*sdk.WorkloadOptimizationAPIGetInstallCmdResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIGetInstallCmdWithResponse", ctx, params)
-	ret0, _ := ret[0].(*sdk.WorkloadOptimizationAPIGetInstallCmdResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WorkloadOptimizationAPIGetInstallCmdWithResponse indicates an expected call of WorkloadOptimizationAPIGetInstallCmdWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIGetInstallCmdWithResponse(ctx, params interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetInstallCmdWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIGetInstallCmdWithResponse), ctx, params)
-}
-
-// WorkloadOptimizationAPIGetInstallScript mocks base method.
-func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIGetInstallScript(ctx context.Context, params *sdk.WorkloadOptimizationAPIGetInstallScriptParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, params}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIGetInstallScript", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WorkloadOptimizationAPIGetInstallScript indicates an expected call of WorkloadOptimizationAPIGetInstallScript.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIGetInstallScript(ctx, params interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, params}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetInstallScript", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIGetInstallScript), varargs...)
-}
-
-// WorkloadOptimizationAPIGetInstallScriptWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) WorkloadOptimizationAPIGetInstallScriptWithResponse(ctx context.Context, params *sdk.WorkloadOptimizationAPIGetInstallScriptParams) (*sdk.WorkloadOptimizationAPIGetInstallScriptResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WorkloadOptimizationAPIGetInstallScriptWithResponse", ctx, params)
-	ret0, _ := ret[0].(*sdk.WorkloadOptimizationAPIGetInstallScriptResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WorkloadOptimizationAPIGetInstallScriptWithResponse indicates an expected call of WorkloadOptimizationAPIGetInstallScriptWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) WorkloadOptimizationAPIGetInstallScriptWithResponse(ctx, params interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadOptimizationAPIGetInstallScriptWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).WorkloadOptimizationAPIGetInstallScriptWithResponse), ctx, params)
 }
 
 // WorkloadOptimizationAPIGetOrganizationAgentStatuses mocks base method.

--- a/castai/sdk/organization_management/api.gen.go
+++ b/castai/sdk/organization_management/api.gen.go
@@ -291,6 +291,33 @@ type BatchCreateEnterpriseRoleBindingsResponse struct {
 	RoleBindings *[]RoleBinding `json:"roleBindings,omitempty"`
 }
 
+// BatchCreateEnterpriseServiceAccountsRequest Request message for batch creating service accounts in an enterprise.
+type BatchCreateEnterpriseServiceAccountsRequest struct {
+	// EnterpriseId ID of the enterprise organization.
+	EnterpriseId string `json:"enterpriseId"`
+
+	// Requests List of service accounts to create. Maximum 100 per request.
+	Requests []BatchCreateEnterpriseServiceAccountsRequestServiceAccountRequest `json:"requests"`
+}
+
+// BatchCreateEnterpriseServiceAccountsRequestServiceAccountRequest ServiceAccountRequest is a single service account to create.
+type BatchCreateEnterpriseServiceAccountsRequestServiceAccountRequest struct {
+	// Description Description of the service account.
+	Description *string `json:"description,omitempty"`
+
+	// Name Name of the service account.
+	Name string `json:"name"`
+
+	// OrganizationId Organization ID — must be the enterprise itself or a direct child (deleted_at IS NULL).
+	OrganizationId string `json:"organizationId"`
+}
+
+// BatchCreateEnterpriseServiceAccountsResponse Response message for batch creating service accounts in an enterprise.
+type BatchCreateEnterpriseServiceAccountsResponse struct {
+	// Items ListEnterpriseServiceAccountsResponse contains the list of service accounts in the enterprise organization
+	Items *[]ListEnterpriseServiceAccountsResponseServiceAccount `json:"items,omitempty"`
+}
+
 // BatchDeleteEnterpriseGroupsRequest Request message for batch deleting enterprise groups
 type BatchDeleteEnterpriseGroupsRequest struct {
 	// EnterpriseId Required field that identifies the enterprise.
@@ -1441,6 +1468,9 @@ type EnterpriseAPIBatchDeleteEnterpriseRoleBindingsJSONRequestBody = BatchDelete
 
 // EnterpriseAPIBatchUpdateEnterpriseRoleBindingsJSONRequestBody defines body for EnterpriseAPIBatchUpdateEnterpriseRoleBindings for application/json ContentType.
 type EnterpriseAPIBatchUpdateEnterpriseRoleBindingsJSONRequestBody = BatchUpdateEnterpriseRoleBindingsRequest
+
+// EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody defines body for EnterpriseAPIBatchCreateEnterpriseServiceAccounts for application/json ContentType.
+type EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody = BatchCreateEnterpriseServiceAccountsRequest
 
 // EnterpriseAPIAddUserToChildOrganizationJSONRequestBody defines body for EnterpriseAPIAddUserToChildOrganization for application/json ContentType.
 type EnterpriseAPIAddUserToChildOrganizationJSONRequestBody = AddUserToChildOrganizationRequest

--- a/castai/sdk/organization_management/client.gen.go
+++ b/castai/sdk/organization_management/client.gen.go
@@ -151,6 +151,11 @@ type ClientInterface interface {
 	// EnterpriseAPIListEnterpriseServiceAccounts request
 	EnterpriseAPIListEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, params *EnterpriseAPIListEnterpriseServiceAccountsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody request with any body
+	EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody(ctx context.Context, enterpriseId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	EnterpriseAPIBatchCreateEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// EnterpriseAPIAddUserToChildOrganizationWithBody request with any body
 	EnterpriseAPIAddUserToChildOrganizationWithBody(ctx context.Context, enterpriseId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -428,6 +433,30 @@ func (c *Client) EnterpriseAPIBatchUpdateEnterpriseRoleBindings(ctx context.Cont
 
 func (c *Client) EnterpriseAPIListEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, params *EnterpriseAPIListEnterpriseServiceAccountsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewEnterpriseAPIListEnterpriseServiceAccountsRequest(c.Server, enterpriseId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody(ctx context.Context, enterpriseId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEnterpriseAPIBatchCreateEnterpriseServiceAccountsRequestWithBody(c.Server, enterpriseId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EnterpriseAPIBatchCreateEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEnterpriseAPIBatchCreateEnterpriseServiceAccountsRequest(c.Server, enterpriseId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1624,6 +1653,53 @@ func NewEnterpriseAPIListEnterpriseServiceAccountsRequest(server string, enterpr
 	return req, nil
 }
 
+// NewEnterpriseAPIBatchCreateEnterpriseServiceAccountsRequest calls the generic EnterpriseAPIBatchCreateEnterpriseServiceAccounts builder with application/json body
+func NewEnterpriseAPIBatchCreateEnterpriseServiceAccountsRequest(server string, enterpriseId string, body EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEnterpriseAPIBatchCreateEnterpriseServiceAccountsRequestWithBody(server, enterpriseId, "application/json", bodyReader)
+}
+
+// NewEnterpriseAPIBatchCreateEnterpriseServiceAccountsRequestWithBody generates requests for EnterpriseAPIBatchCreateEnterpriseServiceAccounts with any type of body
+func NewEnterpriseAPIBatchCreateEnterpriseServiceAccountsRequestWithBody(server string, enterpriseId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "enterpriseId", runtime.ParamLocationPath, enterpriseId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/organization-management/v1/enterprises/%s/service-accounts:batchCreate", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewEnterpriseAPIAddUserToChildOrganizationRequest calls the generic EnterpriseAPIAddUserToChildOrganization builder with application/json body
 func NewEnterpriseAPIAddUserToChildOrganizationRequest(server string, enterpriseId string, body EnterpriseAPIAddUserToChildOrganizationJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -1822,6 +1898,11 @@ type ClientWithResponsesInterface interface {
 
 	// EnterpriseAPIListEnterpriseServiceAccounts request
 	EnterpriseAPIListEnterpriseServiceAccountsWithResponse(ctx context.Context, enterpriseId string, params *EnterpriseAPIListEnterpriseServiceAccountsParams) (*EnterpriseAPIListEnterpriseServiceAccountsResponse, error)
+
+	// EnterpriseAPIBatchCreateEnterpriseServiceAccounts request  with any body
+	EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBodyWithResponse(ctx context.Context, enterpriseId string, contentType string, body io.Reader) (*EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse, error)
+
+	EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithResponse(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody) (*EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse, error)
 
 	// EnterpriseAPIAddUserToChildOrganization request  with any body
 	EnterpriseAPIAddUserToChildOrganizationWithBodyWithResponse(ctx context.Context, enterpriseId string, contentType string, body io.Reader) (*EnterpriseAPIAddUserToChildOrganizationResponse, error)
@@ -2305,6 +2386,37 @@ func (r EnterpriseAPIListEnterpriseServiceAccountsResponse) GetBody() []byte {
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
+type EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *BatchCreateEnterpriseServiceAccountsResponse
+	JSONDefault  *Status
+}
+
+// Status returns HTTPResponse.Status
+func (r EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
 type EnterpriseAPIAddUserToChildOrganizationResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -2564,6 +2676,23 @@ func (c *ClientWithResponses) EnterpriseAPIListEnterpriseServiceAccountsWithResp
 		return nil, err
 	}
 	return ParseEnterpriseAPIListEnterpriseServiceAccountsResponse(rsp)
+}
+
+// EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBodyWithResponse request with arbitrary body returning *EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse
+func (c *ClientWithResponses) EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBodyWithResponse(ctx context.Context, enterpriseId string, contentType string, body io.Reader) (*EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse, error) {
+	rsp, err := c.EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody(ctx, enterpriseId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse(rsp)
+}
+
+func (c *ClientWithResponses) EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithResponse(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody) (*EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse, error) {
+	rsp, err := c.EnterpriseAPIBatchCreateEnterpriseServiceAccounts(ctx, enterpriseId, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse(rsp)
 }
 
 // EnterpriseAPIAddUserToChildOrganizationWithBodyWithResponse request with arbitrary body returning *EnterpriseAPIAddUserToChildOrganizationResponse
@@ -3057,6 +3186,39 @@ func ParseEnterpriseAPIListEnterpriseServiceAccountsResponse(rsp *http.Response)
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ListEnterpriseServiceAccountsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest Status
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse parses an HTTP response from a EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithResponse call
+func ParseEnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse(rsp *http.Response) (*EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest BatchCreateEnterpriseServiceAccountsResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/castai/sdk/organization_management/mock/client.go
+++ b/castai/sdk/organization_management/mock/client.go
@@ -195,6 +195,46 @@ func (mr *MockClientInterfaceMockRecorder) EnterpriseAPIBatchCreateEnterpriseRol
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchCreateEnterpriseRoleBindingsWithBody", reflect.TypeOf((*MockClientInterface)(nil).EnterpriseAPIBatchCreateEnterpriseRoleBindingsWithBody), varargs...)
 }
 
+// EnterpriseAPIBatchCreateEnterpriseServiceAccounts mocks base method.
+func (m *MockClientInterface) EnterpriseAPIBatchCreateEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body organization_management.EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchCreateEnterpriseServiceAccounts", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchCreateEnterpriseServiceAccounts indicates an expected call of EnterpriseAPIBatchCreateEnterpriseServiceAccounts.
+func (mr *MockClientInterfaceMockRecorder) EnterpriseAPIBatchCreateEnterpriseServiceAccounts(ctx, enterpriseId, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchCreateEnterpriseServiceAccounts", reflect.TypeOf((*MockClientInterface)(nil).EnterpriseAPIBatchCreateEnterpriseServiceAccounts), varargs...)
+}
+
+// EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody mocks base method.
+func (m *MockClientInterface) EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody(ctx context.Context, enterpriseId, contentType string, body io.Reader, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody indicates an expected call of EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody.
+func (mr *MockClientInterfaceMockRecorder) EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody(ctx, enterpriseId, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody", reflect.TypeOf((*MockClientInterface)(nil).EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody), varargs...)
+}
+
 // EnterpriseAPIBatchDeleteEnterpriseGroups mocks base method.
 func (m *MockClientInterface) EnterpriseAPIBatchDeleteEnterpriseGroups(ctx context.Context, enterpriseId string, body organization_management.EnterpriseAPIBatchDeleteEnterpriseGroupsJSONRequestBody, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -846,6 +886,76 @@ func (m *MockClientWithResponsesInterface) EnterpriseAPIBatchCreateEnterpriseRol
 func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIBatchCreateEnterpriseRoleBindingsWithResponse(ctx, enterpriseId, body interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchCreateEnterpriseRoleBindingsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIBatchCreateEnterpriseRoleBindingsWithResponse), ctx, enterpriseId, body)
+}
+
+// EnterpriseAPIBatchCreateEnterpriseServiceAccounts mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIBatchCreateEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body organization_management.EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchCreateEnterpriseServiceAccounts", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchCreateEnterpriseServiceAccounts indicates an expected call of EnterpriseAPIBatchCreateEnterpriseServiceAccounts.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIBatchCreateEnterpriseServiceAccounts(ctx, enterpriseId, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchCreateEnterpriseServiceAccounts", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIBatchCreateEnterpriseServiceAccounts), varargs...)
+}
+
+// EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody(ctx context.Context, enterpriseId, contentType string, body io.Reader, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody indicates an expected call of EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody(ctx, enterpriseId, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody), varargs...)
+}
+
+// EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBodyWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBodyWithResponse(ctx context.Context, enterpriseId, contentType string, body io.Reader) (*organization_management.EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBodyWithResponse", ctx, enterpriseId, contentType, body)
+	ret0, _ := ret[0].(*organization_management.EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBodyWithResponse indicates an expected call of EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBodyWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBodyWithResponse(ctx, enterpriseId, contentType, body interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBodyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBodyWithResponse), ctx, enterpriseId, contentType, body)
+}
+
+// EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithResponse(ctx context.Context, enterpriseId string, body organization_management.EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody) (*organization_management.EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithResponse", ctx, enterpriseId, body)
+	ret0, _ := ret[0].(*organization_management.EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithResponse indicates an expected call of EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithResponse(ctx, enterpriseId, body interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithResponse), ctx, enterpriseId, body)
 }
 
 // EnterpriseAPIBatchDeleteEnterpriseGroups mocks base method.

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -181,6 +181,8 @@ Required:
 Optional:
 
 - `affinity` (Block List) (see [below for nested schema](#nestedblock--constraints--dedicated_node_affinity--affinity))
+- `cpus_per_gpu` (Number) Number of CPUs per GPU on the node.
+- `min_gpus_per_node` (Number) Minimal number of GPUs per node.
 
 <a id="nestedblock--constraints--dedicated_node_affinity--affinity"></a>
 ### Nested Schema for `constraints.dedicated_node_affinity.affinity`


### PR DESCRIPTION
### What changed
Adds `cpus_per_gpu` and `min_gpus_per_node` optional fields to the `dedicated_node_affinity` block of the `castai_node_template` resource, allowing users to configure CPUs-to-GPU ratios and minimum GPU counts per node.

---
### Kimchi Summary
### What changed
Adds optional `cpus_per_gpu` and `min_gpus_per_node` arguments to the `dedicated_node_affinity` block of the `castai_node_template` resource to support sole-tenant GPU node configuration. Also regenerates the CAST AI SDK client from the latest API specifications.

### Why
Exposes new GPU scheduling controls so Terraform-managed clusters can enforce CPU-to-GPU ratios and minimum GPU counts when pinning workloads to dedicated nodes.

### Key changes
- `castai/resource_node_template.go`: Introduces `cpus_per_gpu` and `min_gpus_per_node` schema fields inside `dedicated_node_affinity`; updates `flattenNodeAffinity` and `toTemplateConstraintsNodeAffinity` to read and write the new values.
- `castai/resource_node_template_test.go`: Expands `TestNodeTemplateResourceReadContext`, `Test_flattenNodeAffinity`, and adds `Test_toTemplateConstraintsDedicatedAffinity` to cover the new fields.
- `docs/resources/node_template.md`: Documents `cpus_per_gpu` and `min_gpus_per_node` under the `constraints.dedicated_node_affinity` nested schema.
- `castai/sdk/*`: Regenerates SDK bindings; removes obsolete workload-optimization install script endpoints and adds enterprise service-account batch creation endpoints.

### Impact
No breaking changes. The new Terraform arguments are optional. SDK additions and removals only affect generated code not currently consumed by provider resources.