### PR TITLE
chore: live subnets

### DIFF
--- a/examples/eks/eks_cluster_live_migration/module/castai/castai.tf
+++ b/examples/eks/eks_cluster_live_migration/module/castai/castai.tf
@@ -28,7 +28,7 @@ module "castai-eks-cluster" {
     }
 
     live = {
-      subnets              = [var.subnets[0]] // Set single subnet 
+      subnets              = length(var.subnets) > 0 ? [var.subnets[0]] : [] // Set single subnet 
       instance_profile_arn = var.castai-eks-role-iam_instance_profile_arn
       security_groups      = var.security_groups
 

--- a/examples/eks/eks_cluster_live_migration/module/castai/castai.tf
+++ b/examples/eks/eks_cluster_live_migration/module/castai/castai.tf
@@ -28,7 +28,7 @@ module "castai-eks-cluster" {
     }
 
     live = {
-      subnets              = var.subnets
+      subnets              = [var.subnets[0]] // Set single subnet 
       instance_profile_arn = var.castai-eks-role-iam_instance_profile_arn
       security_groups      = var.security_groups
 

--- a/examples/eks/eks_cluster_live_migration/vpc.tf
+++ b/examples/eks/eks_cluster_live_migration/vpc.tf
@@ -9,8 +9,8 @@ module "vpc" {
   cidr = "10.0.0.0/16"
 
   azs             = data.aws_availability_zones.available.names
-  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets  = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  private_subnets = ["10.0.0.0/20", "10.0.16.0/20", "10.0.32.0/20"]
+  public_subnets  = ["10.0.48.0/20", "10.0.64.0/20", "10.0.80.0/20"]
 
   enable_nat_gateway     = true
   single_nat_gateway     = true


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Updates the EKS live migration example to configure live migration nodes with a single subnet and expands the example VPC subnets from `/24` to `/20`.

### Why
Live migration is constrained to a single subnet, and larger subnets prevent IP exhaustion in the example environment.

### Key changes
- `castai.tf`: Changed `live.subnets` from `var.subnets` to `[var.subnets[0]]`, selecting only the first subnet for live migration.
- `vpc.tf`: Updated `private_subnets` and `public_subnets` to use `/20` CIDR blocks instead of `/24`, increasing available IP addresses within the `10.0.0.0/16` VPC.