### PR TITLE
fix: live security groups

### DIFF
--- a/examples/eks/eks_cluster_live_migration/eks.tf
+++ b/examples/eks/eks_cluster_live_migration/eks.tf
@@ -78,6 +78,22 @@ module "eks" {
     }
   }
 
+  node_security_group_additional_rules = {
+    # Match eksctl default behaviour: allow the control plane to reach all workload TCP ports on nodes
+    # (ports 1025-65535). This covers any admission webhook on any port (e.g. castai-live on 9091,
+    # Istio on 15017/15012, etc.) without needing to enumerate each one individually.
+    # See: https://github.com/eksctl-io/eksctl/blob/main/pkg/cfn/builder/nodegroup.go
+    #      ControlPlaneNodeGroupEgressRules / makeNodeIngressRules
+    ingress_cluster_all_workload_ports = {
+      description                   = "Cluster API to node workload TCP ports (kubelet and webhooks)"
+      protocol                      = "tcp"
+      from_port                     = 1025
+      to_port                       = 65535
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
+  }
+
 }
 
 module "ebs_csi_irsa_role" {


### PR DESCRIPTION
overwise node communication is blocked, causing all webhooks to be unavailable

---
### Kimchi Summary
### What changed
Added a security group rule to the EKS live migration example that allows the control plane to reach node workload TCP ports 1025–65535.

### Why
Ensures admission webhooks on non-standard ports (e.g., `castai-live` on 9091, Istio on 15017/15012) are reachable without enumerating each port individually, aligning with default `eksctl` behavior.

### Key changes
- `examples/eks/eks_cluster_live_migration/eks.tf`: added `node_security_group_additional_rules` block containing an `ingress_cluster_all_workload_ports` rule that permits ingress from the cluster security group to TCP ports 1025–65535.