### PR TITLE
fix: live set gp2 as default storage class

### DIFF
--- a/examples/eks/eks_cluster_live_migration/eks.tf
+++ b/examples/eks/eks_cluster_live_migration/eks.tf
@@ -95,6 +95,22 @@ module "ebs_csi_irsa_role" {
   }
 }
 
+# Mark the EKS-created gp2 StorageClass as the cluster default.
+# EKS ships gp2 without the default annotation, so PVCs without an explicit
+# storageClassName would fail. We patch it here rather than creating a new SC.
+resource "kubernetes_annotations" "gp2_default_storage_class" {
+  api_version = "storage.k8s.io/v1"
+  kind        = "StorageClass"
+  metadata {
+    name = "gp2"
+  }
+  annotations = {
+    "storageclass.kubernetes.io/is-default-class" = "true"
+  }
+
+  depends_on = [module.eks]
+}
+
 # Example additional security group.
 resource "aws_security_group" "additional" {
   name_prefix = "${var.cluster_name}-additional"

--- a/examples/eks/eks_cluster_live_migration/eks.tf
+++ b/examples/eks/eks_cluster_live_migration/eks.tf
@@ -95,6 +95,14 @@ module "ebs_csi_irsa_role" {
   }
 }
 
+# The gp2 StorageClass is created by the EKS control plane / aws-ebs-csi-driver addon
+# asynchronously after the EKS module completes. A short sleep gives the addon time to
+# reconcile before we attempt to patch the annotation.
+resource "time_sleep" "wait_for_gp2" {
+  create_duration = "30s"
+  depends_on      = [module.eks]
+}
+
 # Mark the EKS-created gp2 StorageClass as the cluster default.
 # EKS ships gp2 without the default annotation, so PVCs without an explicit
 # storageClassName would fail. We patch it here rather than creating a new SC.
@@ -108,7 +116,7 @@ resource "kubernetes_annotations" "gp2_default_storage_class" {
     "storageclass.kubernetes.io/is-default-class" = "true"
   }
 
-  depends_on = [module.eks]
+  depends_on = [time_sleep.wait_for_gp2]
 }
 
 # Example additional security group.

--- a/examples/eks/eks_cluster_live_migration/versions.tf
+++ b/examples/eks/eks_cluster_live_migration/versions.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9"
+    }
   }
   required_version = ">= 1.3.2"
 }


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
The EKS live migration example now waits for the `aws-ebs-csi-driver` addon to reconcile, then patches the EKS-created `gp2` StorageClass with the default annotation. This allows PVCs without an explicit `storageClassName` to provision volumes successfully.

### Why
EKS creates the `gp2` StorageClass asynchronously after cluster creation and does not mark it as the default storage class. Without this annotation, workloads that rely on a default StorageClass fail to bind persistent volume claims.

### Key changes
- `examples/eks/eks_cluster_live_migration/eks.tf`: Added `time_sleep.wait_for_gp2` to pause 30 seconds after `module.eks` completes, allowing the addon to create the `gp2` StorageClass; added `kubernetes_annotations.gp2_default_storage_class` to apply the `storageclass.kubernetes.io/is-default-class` annotation to `gp2`.
- `examples/eks/eks_cluster_live_migration/versions.tf`: Added the `hashicorp/time` provider with version constraint `~> 0.9`.