### PR TITLE
fix: Deprecate aggressive_mode

### DIFF
--- a/castai/resource_edge_configuration_default_test.go
+++ b/castai/resource_edge_configuration_default_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccCloudAgnostic_ResourceEdgeConfigurationDefault(t *testing.T) {
 	rName := fmt.Sprintf("%v-edgecfg-%v", ResourcePrefix, acctest.RandString(8))
-	clusterName := "omni-tf-acc-gcp"
+	clusterName := "omni-tf-acc-gcp-dflt"
 	resourceName := "castai_edge_configuration_default.test"
 
 	resource.Test(t, resource.TestCase{

--- a/castai/resource_edge_configuration_test.go
+++ b/castai/resource_edge_configuration_test.go
@@ -70,7 +70,7 @@ func TestAccCloudAgnostic_ResourceEdgeConfigurationGCP(t *testing.T) {
 
 func TestAccCloudAgnostic_ResourceEdgeConfigurationAWS(t *testing.T) {
 	rName := fmt.Sprintf("%v-edgecfg-%v", ResourcePrefix, acctest.RandString(8))
-	clusterName := "omni-tf-acc-aws"
+	clusterName := "omni-tf-acc-aws-cfg"
 	resourceName := "castai_edge_configuration.test"
 
 	resource.Test(t, resource.TestCase{
@@ -126,7 +126,7 @@ func TestAccCloudAgnostic_ResourceEdgeConfigurationAWS(t *testing.T) {
 
 func TestAccCloudAgnostic_ResourceEdgeConfigurationOCI(t *testing.T) {
 	rName := fmt.Sprintf("%v-edgecfg-%v", ResourcePrefix, acctest.RandString(8))
-	clusterName := "test-oci-cluster"
+	clusterName := "test-oci-cluster-cfg"
 	resourceName := "castai_edge_configuration.test"
 
 	resource.Test(t, resource.TestCase{

--- a/castai/resource_edge_location_test.go
+++ b/castai/resource_edge_location_test.go
@@ -113,7 +113,7 @@ resource "castai_edge_location" "test" {
 func TestAccCloudAgnostic_ResourceEdgeLocationAWSImpersonation(t *testing.T) {
 	rName := fmt.Sprintf("%v-edge-loc-%v", ResourcePrefix, acctest.RandString(8))
 	resourceName := "castai_edge_location.test"
-	clusterName := "omni-tf-acc-aws"
+	clusterName := "omni-tf-acc-aws-imp"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/castai/resource_rebalancing_schedule.go
+++ b/castai/resource_rebalancing_schedule.go
@@ -122,7 +122,7 @@ func resourceRebalancingSchedule() *schema.Resource {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Description: "Deprecated: Use aggressive_mode_config instead. When enabled, rebalancing considers all problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic.",
-							Deprecated:  "Use aggressive_mode_config instead.",
+							Deprecated:  "Use aggressive_mode_config instead and set every value to true to replicate the behaviour of this deprecated field.",
 						},
 						"aggressive_mode_config": {
 							Type:     schema.TypeList,
@@ -347,7 +347,7 @@ func stateToSchedule(d *schema.ResourceData) (*sdk.ScheduledrebalancingV1Rebalan
 			}
 		}
 
-		aggresiveMode := readOptionalValue[bool](launchConfigurationData, "aggressive_mode")
+		aggressiveMode := readOptionalValue[bool](launchConfigurationData, "aggressive_mode")
 
 		var aggressiveModeConfig *sdk.ScheduledrebalancingV1AggressiveModeConfig
 		aggressiveModeConfigSection := launchConfigurationData["aggressive_mode_config"].([]any)
@@ -368,7 +368,7 @@ func stateToSchedule(d *schema.ResourceData) (*sdk.ScheduledrebalancingV1Rebalan
 				MinNodes:              readOptionalNumber[int, int32](launchConfigurationData, "rebalancing_min_nodes"),
 				KeepDrainTimeoutNodes: keepDrainTimeoutNodes,
 				ExecutionConditions:   executionConditions,
-				AggressiveMode:        aggresiveMode,
+				AggressiveMode:        aggressiveMode,
 				AggressiveModeConfig:  aggressiveModeConfig,
 			},
 			Selector:                     selector,

--- a/castai/resource_rebalancing_schedule.go
+++ b/castai/resource_rebalancing_schedule.go
@@ -400,7 +400,7 @@ func scheduleToState(schedule *sdk.ScheduledrebalancingV1RebalancingSchedule, d 
 	if schedule.LaunchConfiguration.RebalancingOptions != nil {
 		launchConfig["rebalancing_min_nodes"] = schedule.LaunchConfiguration.RebalancingOptions.MinNodes
 		launchConfig["keep_drain_timeout_nodes"] = schedule.LaunchConfiguration.RebalancingOptions.KeepDrainTimeoutNodes
-		launchConfig["aggressive_mode"] = schedule.LaunchConfiguration.RebalancingOptions.AggressiveMode
+		launchConfig["aggressive_mode"] = schedule.LaunchConfiguration.RebalancingOptions.AggressiveMode //nolint:staticcheck // AggressiveMode is deprecated but still supported for backwards compatibility
 		launchConfig["target_node_selection_algorithm"] = schedule.LaunchConfiguration.TargetNodeSelectionAlgorithm
 		if schedule.LaunchConfiguration.RebalancingOptions.AggressiveModeConfig != nil {
 			launchConfig["aggressive_mode_config"] = []map[string]any{

--- a/castai/resource_rebalancing_schedule.go
+++ b/castai/resource_rebalancing_schedule.go
@@ -122,7 +122,7 @@ func resourceRebalancingSchedule() *schema.Resource {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Description: "Deprecated: Use aggressive_mode_config instead. When enabled, rebalancing considers all problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic.",
-							Deprecated:  "Use aggressive_mode_config instead and set every value to true to replicate the behaviour of this deprecated field.",
+							Deprecated:  "For equivalent behaviour use aggresive_mode_config = {ignore_local_persistent_volumes = true, ignore_problem_job_pods = true, ignore_problem_removal_disabled_pods = true, ignore_problem_pods_without_controller = true}",
 						},
 						"aggressive_mode_config": {
 							Type:     schema.TypeList,

--- a/castai/resource_rebalancing_schedule.go
+++ b/castai/resource_rebalancing_schedule.go
@@ -121,7 +121,8 @@ func resourceRebalancingSchedule() *schema.Resource {
 						"aggressive_mode": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Description: "When enabled, rebalancing considers all problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic.",
+							Description: "Deprecated: Use aggressive_mode_config instead. When enabled, rebalancing considers all problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic.",
+							Deprecated:  "Use aggressive_mode_config instead.",
 						},
 						"aggressive_mode_config": {
 							Type:     schema.TypeList,

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -1158,6 +1158,14 @@ const (
 	DboAPIGetCacheQueriesParamsSortOrderDesc DboAPIGetCacheQueriesParamsSortOrder = "desc"
 )
 
+// Defines values for ExternalClusterAPIGetConnectAndEnableCASTAICmdParamsOnboardingPath.
+const (
+	ONBOARDINGPATHCASTCTL     ExternalClusterAPIGetConnectAndEnableCASTAICmdParamsOnboardingPath = "ONBOARDING_PATH_CASTCTL"
+	ONBOARDINGPATHHELM        ExternalClusterAPIGetConnectAndEnableCASTAICmdParamsOnboardingPath = "ONBOARDING_PATH_HELM"
+	ONBOARDINGPATHSCRIPT      ExternalClusterAPIGetConnectAndEnableCASTAICmdParamsOnboardingPath = "ONBOARDING_PATH_SCRIPT"
+	ONBOARDINGPATHUNSPECIFIED ExternalClusterAPIGetConnectAndEnableCASTAICmdParamsOnboardingPath = "ONBOARDING_PATH_UNSPECIFIED"
+)
+
 // Defines values for ExternalClusterAPIGetCredentialsScriptParamsKentParams.
 const (
 	EnableRebalancing                ExternalClusterAPIGetCredentialsScriptParamsKentParams = "enable_rebalancing"
@@ -2199,6 +2207,18 @@ type CastaiInventoryV1beta1DiscountPricing struct {
 // $4. Same if discount value is "-1", the final price will be $6.
 type CastaiInventoryV1beta1DiscountPricingType string
 
+// CastaiInventoryV1beta1EnaQueueInfo EnaQueueInfo describes ENA queue capabilities for an AWS instance type.
+type CastaiInventoryV1beta1EnaQueueInfo struct {
+	// DefaultQueueCountPerInterface Default number of ENA queues per network interface.
+	DefaultQueueCountPerInterface *int32 `json:"defaultQueueCountPerInterface,omitempty"`
+
+	// MaximumQueueCount Maximum total number of ENA queues across all interfaces on the instance.
+	MaximumQueueCount *int32 `json:"maximumQueueCount,omitempty"`
+
+	// MaximumQueueCountPerInterface Maximum number of ENA queues configurable per network interface.
+	MaximumQueueCountPerInterface *int32 `json:"maximumQueueCountPerInterface,omitempty"`
+}
+
 // CastaiInventoryV1beta1GCPCommitmentImport defines model for castai.inventory.v1beta1.GCPCommitmentImport.
 type CastaiInventoryV1beta1GCPCommitmentImport struct {
 	AutoRenew         *bool                                `json:"autoRenew,omitempty"`
@@ -2620,6 +2640,9 @@ type CastaiInventoryV1beta1NetworkInfo struct {
 
 	// EfaSupported Indicates if the AWS instance type supports EFA (Elastic Fabric Adapter).
 	EfaSupported *bool `json:"efaSupported,omitempty"`
+
+	// EnaQueueInfo EnaQueueInfo describes ENA queue capabilities for an AWS instance type.
+	EnaQueueInfo *CastaiInventoryV1beta1EnaQueueInfo `json:"enaQueueInfo,omitempty"`
 
 	// EncryptionInTransitSupported Indicates whether the instance type automatically encrypts in-transit traffic between instances. AWS only.
 	EncryptionInTransitSupported *bool `json:"encryptionInTransitSupported"`
@@ -3947,6 +3970,9 @@ type CastaiUsersV1beta1User struct {
 
 // CastaiUsersV1beta1UserOrganization UserOrganization describes organization user belongs to.
 type CastaiUsersV1beta1UserOrganization struct {
+	// BlockEscalatedPrivilege Whether the organization blocks escalated privileges for Cast AI members.
+	BlockEscalatedPrivilege *bool `json:"blockEscalatedPrivilege,omitempty"`
+
 	// ChildOrderId The order id of child org in enterprise by created_at - if the org is a child org.
 	ChildOrderId *int32 `json:"childOrderId"`
 
@@ -4969,9 +4995,6 @@ type DboV1DeleteAccountParams struct {
 	AccountId string `json:"accountId"`
 }
 
-// DboV1DeleteAccountResponse defines model for dbo.v1.DeleteAccountResponse.
-type DboV1DeleteAccountResponse = map[string]interface{}
-
 // DboV1DeleteCacheConfigurationResponse defines model for dbo.v1.DeleteCacheConfigurationResponse.
 type DboV1DeleteCacheConfigurationResponse = map[string]interface{}
 
@@ -4981,15 +5004,15 @@ type DboV1DeleteCacheGroupResponse = map[string]interface{}
 // DboV1DeleteCacheTTLResponse defines model for dbo.v1.DeleteCacheTTLResponse.
 type DboV1DeleteCacheTTLResponse = map[string]interface{}
 
-// DboV1DeleteLogicalDatabaseResponse defines model for dbo.v1.DeleteLogicalDatabaseResponse.
-type DboV1DeleteLogicalDatabaseResponse = map[string]interface{}
-
 // DboV1DeployCacheParams defines model for dbo.v1.DeployCacheParams.
 type DboV1DeployCacheParams struct {
 	CacheGroupId         string  `json:"cacheGroupId"`
 	HelmChartValues      *string `json:"helmChartValues,omitempty"`
 	ManualExecuteCommand *string `json:"manualExecuteCommand,omitempty"`
 	PoolingEnabled       *bool   `json:"poolingEnabled"`
+
+	// ProtocolType ProtocolType specifies the protocol type used by the database.
+	ProtocolType *DboV1CacheGroupProtocolType `json:"protocolType,omitempty"`
 }
 
 // DboV1DeployDBAgentParams defines model for dbo.v1.DeployDBAgentParams.
@@ -5135,20 +5158,6 @@ type DboV1ListCacheTTLsResponse struct {
 type DboV1ListDatabaseComponentsResponse struct {
 	Components []DboV1DatabaseComponent `json:"components"`
 	Summary    DboV1OrganizationSummary `json:"summary"`
-}
-
-// DboV1ListDatabaseInstancesResponse defines model for dbo.v1.ListDatabaseInstancesResponse.
-type DboV1ListDatabaseInstancesResponse struct {
-	Instances []DboV1DatabaseInstance  `json:"instances"`
-	Summary   DboV1OrganizationSummary `json:"summary"`
-}
-
-// DboV1LogicalDatabase defines model for dbo.v1.LogicalDatabase.
-type DboV1LogicalDatabase struct {
-	Id *string `json:"id,omitempty"`
-
-	// Name Name of the logical database.
-	Name string `json:"name"`
 }
 
 // DboV1OperationalMetricsSummary defines model for dbo.v1.OperationalMetricsSummary.
@@ -7566,10 +7575,20 @@ type NodetemplatesV1TemplateConstraintsCustomPriority struct {
 // NodetemplatesV1TemplateConstraintsDedicatedNodeAffinity defines model for nodetemplates.v1.TemplateConstraints.DedicatedNodeAffinity.
 type NodetemplatesV1TemplateConstraintsDedicatedNodeAffinity struct {
 	// Affinity The affinity rules required for choosing the node.
-	Affinity      *[]K8sSelectorV1KubernetesNodeAffinity `json:"affinity,omitempty"`
-	AzName        *string                                `json:"azName,omitempty"`
-	InstanceTypes *[]string                              `json:"instanceTypes,omitempty"`
-	Name          *string                                `json:"name,omitempty"`
+	Affinity *[]K8sSelectorV1KubernetesNodeAffinity `json:"affinity,omitempty"`
+	AzName   *string                                `json:"azName,omitempty"`
+
+	// CpusPerGpu Target number of CPUs to allocate per GPU on this dedicated/sole-tenant node group.
+	// This allows configuring nodes in the way that when all GPUs are in use, all CPUs are also utilized, maximizing resource efficiency.
+	// For a node with N GPUs and M CPUs, set cpus_per_gpu = M / N.
+	// If not set, no ratio-based sizing is applied.
+	CpusPerGpu    *int32    `json:"cpusPerGpu"`
+	InstanceTypes *[]string `json:"instanceTypes,omitempty"`
+
+	// MinGpusPerNode Minimum number of GPUs per node for this dedicated/sole-tenant node group.
+	// If not set, no minimum GPU count filtering is applied.
+	MinGpusPerNode *int32  `json:"minGpusPerNode"`
+	Name           *string `json:"name,omitempty"`
 }
 
 // NodetemplatesV1TemplateConstraintsGPUConstraints defines model for nodetemplates.v1.TemplateConstraints.GPUConstraints.
@@ -8721,6 +8740,8 @@ type WorkloadoptimizationV1ConstraintsV2Strategy struct {
 
 // WorkloadoptimizationV1Container defines model for workloadoptimization.v1.Container.
 type WorkloadoptimizationV1Container struct {
+	FirstSeenResources *WorkloadoptimizationV1Resources `json:"firstSeenResources,omitempty"`
+
 	// Name Name of the container.
 	Name              string                           `json:"name"`
 	OriginalResources *WorkloadoptimizationV1Resources `json:"originalResources,omitempty"`
@@ -9656,10 +9677,11 @@ type WorkloadoptimizationV1HPAState struct {
 
 // WorkloadoptimizationV1HPATargetWorkloadContainer HPATargetWorkloadContainer mirrors Container.
 type WorkloadoptimizationV1HPATargetWorkloadContainer struct {
-	Name              string                           `json:"name"`
-	OriginalResources *WorkloadoptimizationV1Resources `json:"originalResources,omitempty"`
-	Recommendation    *WorkloadoptimizationV1Resources `json:"recommendation,omitempty"`
-	Resources         *WorkloadoptimizationV1Resources `json:"resources,omitempty"`
+	FirstSeenResources *WorkloadoptimizationV1Resources `json:"firstSeenResources,omitempty"`
+	Name               string                           `json:"name"`
+	OriginalResources  *WorkloadoptimizationV1Resources `json:"originalResources,omitempty"`
+	Recommendation     *WorkloadoptimizationV1Resources `json:"recommendation,omitempty"`
+	Resources          *WorkloadoptimizationV1Resources `json:"resources,omitempty"`
 
 	// Runtime Defines the application runtime.
 	Runtime *WorkloadoptimizationV1Runtime `json:"runtime,omitempty"`
@@ -11671,15 +11693,6 @@ type DboAPIListDatabaseComponentsParams struct {
 	EndTime *time.Time `form:"endTime,omitempty" json:"endTime,omitempty"`
 }
 
-// DboAPIListDatabaseInstancesLegacyParams defines parameters for DboAPIListDatabaseInstancesLegacy.
-type DboAPIListDatabaseInstancesLegacyParams struct {
-	// StartTime Start of period.
-	StartTime *time.Time `form:"startTime,omitempty" json:"startTime,omitempty"`
-
-	// EndTime End of period.
-	EndTime *time.Time `form:"endTime,omitempty" json:"endTime,omitempty"`
-}
-
 // DboAPIGetDatabaseInstanceParams defines parameters for DboAPIGetDatabaseInstance.
 type DboAPIGetDatabaseInstanceParams struct {
 	// StartTime Start of period.
@@ -11687,18 +11700,6 @@ type DboAPIGetDatabaseInstanceParams struct {
 
 	// EndTime End of period.
 	EndTime *time.Time `form:"endTime,omitempty" json:"endTime,omitempty"`
-}
-
-// DboAPIGetDatabaseInstanceCachePerformanceParams defines parameters for DboAPIGetDatabaseInstanceCachePerformance.
-type DboAPIGetDatabaseInstanceCachePerformanceParams struct {
-	// StartTime Start of period.
-	StartTime time.Time `form:"startTime" json:"startTime"`
-
-	// EndTime End of period.
-	EndTime time.Time `form:"endTime" json:"endTime"`
-
-	// StepSeconds Aggregate items in specified interval steps.
-	StepSeconds int64 `form:"stepSeconds" json:"stepSeconds"`
 }
 
 // DboAPIGetDatabaseInstanceInfrastructureMetricsParams defines parameters for DboAPIGetDatabaseInstanceInfrastructureMetrics.
@@ -11711,14 +11712,6 @@ type DboAPIGetDatabaseInstanceInfrastructureMetricsParams struct {
 
 	// StepSeconds Aggregate items in specified interval steps.
 	StepSeconds int64 `form:"stepSeconds" json:"stepSeconds"`
-}
-
-// DboAPICreateLogicalDatabasesJSONBody defines parameters for DboAPICreateLogicalDatabases.
-type DboAPICreateLogicalDatabasesJSONBody = []DboV1LogicalDatabase
-
-// DboAPICreateLogicalDatabasesParams defines parameters for DboAPICreateLogicalDatabases.
-type DboAPICreateLogicalDatabasesParams struct {
-	CreateCacheConfigurations *bool `form:"createCacheConfigurations,omitempty" json:"createCacheConfigurations,omitempty"`
 }
 
 // InventoryAPIListInstanceTypeNamesParams defines parameters for InventoryAPIListInstanceTypeNames.
@@ -11813,8 +11806,16 @@ type ExternalClusterAPIGetConnectAndEnableCASTAICmdParams struct {
 	UseUmbrella *bool `form:"useUmbrella,omitempty" json:"useUmbrella,omitempty"`
 
 	// UseCastctl Whether to use castctl to connect a cluster.
+	// Deprecated. Use onboarding_path=ONBOARDING_PATH_CASTCTL.
 	UseCastctl *bool `form:"useCastctl,omitempty" json:"useCastctl,omitempty"`
+
+	// OnboardingPath Installation method (script, helm, castctl, …).
+	// Defaults to ONBOARDING_PATH_SCRIPT for backward compatibility.
+	OnboardingPath *ExternalClusterAPIGetConnectAndEnableCASTAICmdParamsOnboardingPath `form:"onboardingPath,omitempty" json:"onboardingPath,omitempty"`
 }
+
+// ExternalClusterAPIGetConnectAndEnableCASTAICmdParamsOnboardingPath defines parameters for ExternalClusterAPIGetConnectAndEnableCASTAICmd.
+type ExternalClusterAPIGetConnectAndEnableCASTAICmdParamsOnboardingPath string
 
 // ExternalClusterAPIGetCredentialsScriptParams defines parameters for ExternalClusterAPIGetCredentialsScript.
 type ExternalClusterAPIGetCredentialsScriptParams struct {
@@ -12691,9 +12692,6 @@ type DboAPIUpdateCacheGroupJSONRequestBody = DboV1CacheGroup
 
 // DboAPIExchangeCacheStateJSONRequestBody defines body for DboAPIExchangeCacheState for application/json ContentType.
 type DboAPIExchangeCacheStateJSONRequestBody = DboV1ProxyState
-
-// DboAPICreateLogicalDatabasesJSONRequestBody defines body for DboAPICreateLogicalDatabases for application/json ContentType.
-type DboAPICreateLogicalDatabasesJSONRequestBody = DboAPICreateLogicalDatabasesJSONBody
 
 // DboAPICreateRegistrationJSONRequestBody defines body for DboAPICreateRegistration for application/json ContentType.
 type DboAPICreateRegistrationJSONRequestBody = DboV1Registration

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -3417,6 +3417,18 @@ type CastaiServiceaccountsV1beta1GetServiceAccountResponse struct {
 	ServiceAccount CastaiServiceaccountsV1beta1ServiceAccount `json:"serviceAccount"`
 }
 
+// CastaiServiceaccountsV1beta1ListServiceAccountKeysResponse ListServiceAccountKeysResponse is the response for listing service account keys.
+type CastaiServiceaccountsV1beta1ListServiceAccountKeysResponse struct {
+	// Keys Keys is the list of service account keys.
+	Keys *[]CastaiServiceaccountsV1beta1ServiceAccountKey `json:"keys,omitempty"`
+
+	// NextPage Page defines how many and which fields should be returned.
+	NextPage CastaiPaginationV1beta1Page `json:"nextPage"`
+
+	// TotalCount TotalCount is the total number of keys in the dataset.
+	TotalCount *string `json:"totalCount,omitempty"`
+}
+
 // CastaiServiceaccountsV1beta1ListServiceAccountsResponse ListServiceAccountsResponse is the response for listing service accounts.
 type CastaiServiceaccountsV1beta1ListServiceAccountsResponse struct {
 	// NextPage Page defines how many and which fields should be returned.
@@ -3446,7 +3458,8 @@ type CastaiServiceaccountsV1beta1ServiceAccount struct {
 	// Id ID is the unique identifier of the service account.
 	Id *string `json:"id,omitempty"`
 
-	// Keys Keys is the list of keys associated with the service account.
+	// Keys Deprecated: Use ListServiceAccountKeys endpoint instead. This field is kept for backward compatibility.
+	// Deprecated:
 	Keys *[]CastaiServiceaccountsV1beta1ServiceAccountKey `json:"keys,omitempty"`
 
 	// ManagedBy Method used to create role binding, eg.: console, terraform.
@@ -8482,6 +8495,10 @@ type ScheduledrebalancingV1RebalancingJob struct {
 // ScheduledrebalancingV1RebalancingOptions defines model for scheduledrebalancing.v1.RebalancingOptions.
 type ScheduledrebalancingV1RebalancingOptions struct {
 	// AggressiveMode When enabled will also consider rebalancing problematic pods (pods without controller, job pods, pods with removal-disabled annotation).
+	//
+	// Deprecated: use AggressiveModeConfig instead.
+	// If set to true, this overrides all settings in AggressiveModeConfig to true.
+	// Deprecated:
 	AggressiveMode       *bool                                       `json:"aggressiveMode"`
 	AggressiveModeConfig *ScheduledrebalancingV1AggressiveModeConfig `json:"aggressiveModeConfig,omitempty"`
 
@@ -12028,6 +12045,15 @@ type ServiceAccountsAPIDeleteServiceAccountsParams struct {
 
 // ServiceAccountsAPIListServiceAccountsParams defines parameters for ServiceAccountsAPIListServiceAccounts.
 type ServiceAccountsAPIListServiceAccountsParams struct {
+	PageLimit *string `form:"page.limit,omitempty" json:"page.limit,omitempty"`
+
+	// PageCursor Cursor that defines token indicating where to start the next page.
+	// Empty value indicates to start from beginning of the dataset.
+	PageCursor *string `form:"page.cursor,omitempty" json:"page.cursor,omitempty"`
+}
+
+// ServiceAccountsAPIListServiceAccountKeysParams defines parameters for ServiceAccountsAPIListServiceAccountKeys.
+type ServiceAccountsAPIListServiceAccountKeysParams struct {
 	PageLimit *string `form:"page.limit,omitempty" json:"page.limit,omitempty"`
 
 	// PageCursor Cursor that defines token indicating where to start the next page.

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -182,9 +182,6 @@ type ClientInterface interface {
 	// DboAPIListAccounts request
 	DboAPIListAccounts(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DboAPIDeleteAccount request
-	DboAPIDeleteAccount(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
-
 	// DboAPIListCacheGroups request
 	DboAPIListCacheGroups(ctx context.Context, params *DboAPIListCacheGroupsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -286,25 +283,11 @@ type ClientInterface interface {
 	// DboAPIListDatabaseComponents request
 	DboAPIListDatabaseComponents(ctx context.Context, params *DboAPIListDatabaseComponentsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DboAPIListDatabaseInstancesLegacy request
-	DboAPIListDatabaseInstancesLegacy(ctx context.Context, params *DboAPIListDatabaseInstancesLegacyParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
 	// DboAPIGetDatabaseInstance request
 	DboAPIGetDatabaseInstance(ctx context.Context, instanceId string, params *DboAPIGetDatabaseInstanceParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DboAPIGetDatabaseInstanceCachePerformance request
-	DboAPIGetDatabaseInstanceCachePerformance(ctx context.Context, instanceId string, params *DboAPIGetDatabaseInstanceCachePerformanceParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
 	// DboAPIGetDatabaseInstanceInfrastructureMetrics request
 	DboAPIGetDatabaseInstanceInfrastructureMetrics(ctx context.Context, instanceId string, params *DboAPIGetDatabaseInstanceInfrastructureMetricsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// DboAPIDeleteLogicalDatabase request
-	DboAPIDeleteLogicalDatabase(ctx context.Context, instanceId string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// DboAPICreateLogicalDatabasesWithBody request with any body
-	DboAPICreateLogicalDatabasesWithBody(ctx context.Context, instanceId string, params *DboAPICreateLogicalDatabasesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	DboAPICreateLogicalDatabases(ctx context.Context, instanceId string, params *DboAPICreateLogicalDatabasesParams, body DboAPICreateLogicalDatabasesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DboAPICreateRegistrationWithBody request with any body
 	DboAPICreateRegistrationWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1462,18 +1445,6 @@ func (c *Client) DboAPIListAccounts(ctx context.Context, reqEditors ...RequestEd
 	return c.Client.Do(req)
 }
 
-func (c *Client) DboAPIDeleteAccount(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDboAPIDeleteAccountRequest(c.Server, id)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
 func (c *Client) DboAPIListCacheGroups(ctx context.Context, params *DboAPIListCacheGroupsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewDboAPIListCacheGroupsRequest(c.Server, params)
 	if err != nil {
@@ -1906,18 +1877,6 @@ func (c *Client) DboAPIListDatabaseComponents(ctx context.Context, params *DboAP
 	return c.Client.Do(req)
 }
 
-func (c *Client) DboAPIListDatabaseInstancesLegacy(ctx context.Context, params *DboAPIListDatabaseInstancesLegacyParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDboAPIListDatabaseInstancesLegacyRequest(c.Server, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
 func (c *Client) DboAPIGetDatabaseInstance(ctx context.Context, instanceId string, params *DboAPIGetDatabaseInstanceParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewDboAPIGetDatabaseInstanceRequest(c.Server, instanceId, params)
 	if err != nil {
@@ -1930,56 +1889,8 @@ func (c *Client) DboAPIGetDatabaseInstance(ctx context.Context, instanceId strin
 	return c.Client.Do(req)
 }
 
-func (c *Client) DboAPIGetDatabaseInstanceCachePerformance(ctx context.Context, instanceId string, params *DboAPIGetDatabaseInstanceCachePerformanceParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDboAPIGetDatabaseInstanceCachePerformanceRequest(c.Server, instanceId, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
 func (c *Client) DboAPIGetDatabaseInstanceInfrastructureMetrics(ctx context.Context, instanceId string, params *DboAPIGetDatabaseInstanceInfrastructureMetricsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewDboAPIGetDatabaseInstanceInfrastructureMetricsRequest(c.Server, instanceId, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) DboAPIDeleteLogicalDatabase(ctx context.Context, instanceId string, name string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDboAPIDeleteLogicalDatabaseRequest(c.Server, instanceId, name)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) DboAPICreateLogicalDatabasesWithBody(ctx context.Context, instanceId string, params *DboAPICreateLogicalDatabasesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDboAPICreateLogicalDatabasesRequestWithBody(c.Server, instanceId, params, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) DboAPICreateLogicalDatabases(ctx context.Context, instanceId string, params *DboAPICreateLogicalDatabasesParams, body DboAPICreateLogicalDatabasesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDboAPICreateLogicalDatabasesRequest(c.Server, instanceId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -7162,40 +7073,6 @@ func NewDboAPIListAccountsRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
-// NewDboAPIDeleteAccountRequest generates requests for DboAPIDeleteAccount
-func NewDboAPIDeleteAccountRequest(server string, id string) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/v1/dbo/accounts/%s", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
 // NewDboAPIListCacheGroupsRequest generates requests for DboAPIListCacheGroups
 func NewDboAPIListCacheGroupsRequest(server string, params *DboAPIListCacheGroupsParams) (*http.Request, error) {
 	var err error
@@ -9300,71 +9177,6 @@ func NewDboAPIListDatabaseComponentsRequest(server string, params *DboAPIListDat
 	return req, nil
 }
 
-// NewDboAPIListDatabaseInstancesLegacyRequest generates requests for DboAPIListDatabaseInstancesLegacy
-func NewDboAPIListDatabaseInstancesLegacyRequest(server string, params *DboAPIListDatabaseInstancesLegacyParams) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/v1/dbo/db-instances")
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.StartTime != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "startTime", runtime.ParamLocationQuery, *params.StartTime); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.EndTime != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "endTime", runtime.ParamLocationQuery, *params.EndTime); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
 // NewDboAPIGetDatabaseInstanceRequest generates requests for DboAPIGetDatabaseInstance
 func NewDboAPIGetDatabaseInstanceRequest(server string, instanceId string, params *DboAPIGetDatabaseInstanceParams) (*http.Request, error) {
 	var err error
@@ -9424,82 +9236,6 @@ func NewDboAPIGetDatabaseInstanceRequest(server string, instanceId string, param
 				}
 			}
 
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewDboAPIGetDatabaseInstanceCachePerformanceRequest generates requests for DboAPIGetDatabaseInstanceCachePerformance
-func NewDboAPIGetDatabaseInstanceCachePerformanceRequest(server string, instanceId string, params *DboAPIGetDatabaseInstanceCachePerformanceParams) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "instanceId", runtime.ParamLocationPath, instanceId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/v1/dbo/db-instances/%s/cache-performance", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "startTime", runtime.ParamLocationQuery, params.StartTime); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "endTime", runtime.ParamLocationQuery, params.EndTime); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "stepSeconds", runtime.ParamLocationQuery, params.StepSeconds); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -9585,116 +9321,6 @@ func NewDboAPIGetDatabaseInstanceInfrastructureMetricsRequest(server string, ins
 	if err != nil {
 		return nil, err
 	}
-
-	return req, nil
-}
-
-// NewDboAPIDeleteLogicalDatabaseRequest generates requests for DboAPIDeleteLogicalDatabase
-func NewDboAPIDeleteLogicalDatabaseRequest(server string, instanceId string, name string) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "instanceId", runtime.ParamLocationPath, instanceId)
-	if err != nil {
-		return nil, err
-	}
-
-	var pathParam1 string
-
-	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/v1/dbo/db-instances/%s/logical-db/%s", pathParam0, pathParam1)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewDboAPICreateLogicalDatabasesRequest calls the generic DboAPICreateLogicalDatabases builder with application/json body
-func NewDboAPICreateLogicalDatabasesRequest(server string, instanceId string, params *DboAPICreateLogicalDatabasesParams, body DboAPICreateLogicalDatabasesJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewDboAPICreateLogicalDatabasesRequestWithBody(server, instanceId, params, "application/json", bodyReader)
-}
-
-// NewDboAPICreateLogicalDatabasesRequestWithBody generates requests for DboAPICreateLogicalDatabases with any type of body
-func NewDboAPICreateLogicalDatabasesRequestWithBody(server string, instanceId string, params *DboAPICreateLogicalDatabasesParams, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "instanceId", runtime.ParamLocationPath, instanceId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/v1/dbo/db-instances/%s/logical-dbs", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.CreateCacheConfigurations != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "createCacheConfigurations", runtime.ParamLocationQuery, *params.CreateCacheConfigurations); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -11611,6 +11237,22 @@ func NewExternalClusterAPIGetConnectAndEnableCASTAICmdRequest(server string, par
 		if params.UseCastctl != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "useCastctl", runtime.ParamLocationQuery, *params.UseCastctl); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.OnboardingPath != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "onboardingPath", runtime.ParamLocationQuery, *params.OnboardingPath); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -22109,9 +21751,6 @@ type ClientWithResponsesInterface interface {
 	// DboAPIListAccounts request
 	DboAPIListAccountsWithResponse(ctx context.Context) (*DboAPIListAccountsResponse, error)
 
-	// DboAPIDeleteAccount request
-	DboAPIDeleteAccountWithResponse(ctx context.Context, id string) (*DboAPIDeleteAccountResponse, error)
-
 	// DboAPIListCacheGroups request
 	DboAPIListCacheGroupsWithResponse(ctx context.Context, params *DboAPIListCacheGroupsParams) (*DboAPIListCacheGroupsResponse, error)
 
@@ -22213,25 +21852,11 @@ type ClientWithResponsesInterface interface {
 	// DboAPIListDatabaseComponents request
 	DboAPIListDatabaseComponentsWithResponse(ctx context.Context, params *DboAPIListDatabaseComponentsParams) (*DboAPIListDatabaseComponentsResponse, error)
 
-	// DboAPIListDatabaseInstancesLegacy request
-	DboAPIListDatabaseInstancesLegacyWithResponse(ctx context.Context, params *DboAPIListDatabaseInstancesLegacyParams) (*DboAPIListDatabaseInstancesLegacyResponse, error)
-
 	// DboAPIGetDatabaseInstance request
 	DboAPIGetDatabaseInstanceWithResponse(ctx context.Context, instanceId string, params *DboAPIGetDatabaseInstanceParams) (*DboAPIGetDatabaseInstanceResponse, error)
 
-	// DboAPIGetDatabaseInstanceCachePerformance request
-	DboAPIGetDatabaseInstanceCachePerformanceWithResponse(ctx context.Context, instanceId string, params *DboAPIGetDatabaseInstanceCachePerformanceParams) (*DboAPIGetDatabaseInstanceCachePerformanceResponse, error)
-
 	// DboAPIGetDatabaseInstanceInfrastructureMetrics request
 	DboAPIGetDatabaseInstanceInfrastructureMetricsWithResponse(ctx context.Context, instanceId string, params *DboAPIGetDatabaseInstanceInfrastructureMetricsParams) (*DboAPIGetDatabaseInstanceInfrastructureMetricsResponse, error)
-
-	// DboAPIDeleteLogicalDatabase request
-	DboAPIDeleteLogicalDatabaseWithResponse(ctx context.Context, instanceId string, name string) (*DboAPIDeleteLogicalDatabaseResponse, error)
-
-	// DboAPICreateLogicalDatabases request  with any body
-	DboAPICreateLogicalDatabasesWithBodyWithResponse(ctx context.Context, instanceId string, params *DboAPICreateLogicalDatabasesParams, contentType string, body io.Reader) (*DboAPICreateLogicalDatabasesResponse, error)
-
-	DboAPICreateLogicalDatabasesWithResponse(ctx context.Context, instanceId string, params *DboAPICreateLogicalDatabasesParams, body DboAPICreateLogicalDatabasesJSONRequestBody) (*DboAPICreateLogicalDatabasesResponse, error)
 
 	// DboAPICreateRegistration request  with any body
 	DboAPICreateRegistrationWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*DboAPICreateRegistrationResponse, error)
@@ -23781,36 +23406,6 @@ func (r DboAPIListAccountsResponse) GetBody() []byte {
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
-type DboAPIDeleteAccountResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *DboV1DeleteAccountResponse
-}
-
-// Status returns HTTPResponse.Status
-func (r DboAPIDeleteAccountResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r DboAPIDeleteAccountResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
-// Body returns body of byte array
-func (r DboAPIDeleteAccountResponse) GetBody() []byte {
-	return r.Body
-}
-
-// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
-
 type DboAPIListCacheGroupsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -24681,36 +24276,6 @@ func (r DboAPIListDatabaseComponentsResponse) GetBody() []byte {
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
-type DboAPIListDatabaseInstancesLegacyResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *DboV1ListDatabaseInstancesResponse
-}
-
-// Status returns HTTPResponse.Status
-func (r DboAPIListDatabaseInstancesLegacyResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r DboAPIListDatabaseInstancesLegacyResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
-// Body returns body of byte array
-func (r DboAPIListDatabaseInstancesLegacyResponse) GetBody() []byte {
-	return r.Body
-}
-
-// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
-
 type DboAPIGetDatabaseInstanceResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -24741,36 +24306,6 @@ func (r DboAPIGetDatabaseInstanceResponse) GetBody() []byte {
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
-type DboAPIGetDatabaseInstanceCachePerformanceResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *[]DboV1CachePerformanceTimeseries
-}
-
-// Status returns HTTPResponse.Status
-func (r DboAPIGetDatabaseInstanceCachePerformanceResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r DboAPIGetDatabaseInstanceCachePerformanceResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
-// Body returns body of byte array
-func (r DboAPIGetDatabaseInstanceCachePerformanceResponse) GetBody() []byte {
-	return r.Body
-}
-
-// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
-
 type DboAPIGetDatabaseInstanceInfrastructureMetricsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -24796,66 +24331,6 @@ func (r DboAPIGetDatabaseInstanceInfrastructureMetricsResponse) StatusCode() int
 // TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 // Body returns body of byte array
 func (r DboAPIGetDatabaseInstanceInfrastructureMetricsResponse) GetBody() []byte {
-	return r.Body
-}
-
-// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
-
-type DboAPIDeleteLogicalDatabaseResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *DboV1DeleteLogicalDatabaseResponse
-}
-
-// Status returns HTTPResponse.Status
-func (r DboAPIDeleteLogicalDatabaseResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r DboAPIDeleteLogicalDatabaseResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
-// Body returns body of byte array
-func (r DboAPIDeleteLogicalDatabaseResponse) GetBody() []byte {
-	return r.Body
-}
-
-// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
-
-type DboAPICreateLogicalDatabasesResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *[]DboV1LogicalDatabase
-}
-
-// Status returns HTTPResponse.Status
-func (r DboAPICreateLogicalDatabasesResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r DboAPICreateLogicalDatabasesResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
-// Body returns body of byte array
-func (r DboAPICreateLogicalDatabasesResponse) GetBody() []byte {
 	return r.Body
 }
 
@@ -31299,15 +30774,6 @@ func (c *ClientWithResponses) DboAPIListAccountsWithResponse(ctx context.Context
 	return ParseDboAPIListAccountsResponse(rsp)
 }
 
-// DboAPIDeleteAccountWithResponse request returning *DboAPIDeleteAccountResponse
-func (c *ClientWithResponses) DboAPIDeleteAccountWithResponse(ctx context.Context, id string) (*DboAPIDeleteAccountResponse, error) {
-	rsp, err := c.DboAPIDeleteAccount(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDboAPIDeleteAccountResponse(rsp)
-}
-
 // DboAPIListCacheGroupsWithResponse request returning *DboAPIListCacheGroupsResponse
 func (c *ClientWithResponses) DboAPIListCacheGroupsWithResponse(ctx context.Context, params *DboAPIListCacheGroupsParams) (*DboAPIListCacheGroupsResponse, error) {
 	rsp, err := c.DboAPIListCacheGroups(ctx, params)
@@ -31625,15 +31091,6 @@ func (c *ClientWithResponses) DboAPIListDatabaseComponentsWithResponse(ctx conte
 	return ParseDboAPIListDatabaseComponentsResponse(rsp)
 }
 
-// DboAPIListDatabaseInstancesLegacyWithResponse request returning *DboAPIListDatabaseInstancesLegacyResponse
-func (c *ClientWithResponses) DboAPIListDatabaseInstancesLegacyWithResponse(ctx context.Context, params *DboAPIListDatabaseInstancesLegacyParams) (*DboAPIListDatabaseInstancesLegacyResponse, error) {
-	rsp, err := c.DboAPIListDatabaseInstancesLegacy(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDboAPIListDatabaseInstancesLegacyResponse(rsp)
-}
-
 // DboAPIGetDatabaseInstanceWithResponse request returning *DboAPIGetDatabaseInstanceResponse
 func (c *ClientWithResponses) DboAPIGetDatabaseInstanceWithResponse(ctx context.Context, instanceId string, params *DboAPIGetDatabaseInstanceParams) (*DboAPIGetDatabaseInstanceResponse, error) {
 	rsp, err := c.DboAPIGetDatabaseInstance(ctx, instanceId, params)
@@ -31643,15 +31100,6 @@ func (c *ClientWithResponses) DboAPIGetDatabaseInstanceWithResponse(ctx context.
 	return ParseDboAPIGetDatabaseInstanceResponse(rsp)
 }
 
-// DboAPIGetDatabaseInstanceCachePerformanceWithResponse request returning *DboAPIGetDatabaseInstanceCachePerformanceResponse
-func (c *ClientWithResponses) DboAPIGetDatabaseInstanceCachePerformanceWithResponse(ctx context.Context, instanceId string, params *DboAPIGetDatabaseInstanceCachePerformanceParams) (*DboAPIGetDatabaseInstanceCachePerformanceResponse, error) {
-	rsp, err := c.DboAPIGetDatabaseInstanceCachePerformance(ctx, instanceId, params)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDboAPIGetDatabaseInstanceCachePerformanceResponse(rsp)
-}
-
 // DboAPIGetDatabaseInstanceInfrastructureMetricsWithResponse request returning *DboAPIGetDatabaseInstanceInfrastructureMetricsResponse
 func (c *ClientWithResponses) DboAPIGetDatabaseInstanceInfrastructureMetricsWithResponse(ctx context.Context, instanceId string, params *DboAPIGetDatabaseInstanceInfrastructureMetricsParams) (*DboAPIGetDatabaseInstanceInfrastructureMetricsResponse, error) {
 	rsp, err := c.DboAPIGetDatabaseInstanceInfrastructureMetrics(ctx, instanceId, params)
@@ -31659,32 +31107,6 @@ func (c *ClientWithResponses) DboAPIGetDatabaseInstanceInfrastructureMetricsWith
 		return nil, err
 	}
 	return ParseDboAPIGetDatabaseInstanceInfrastructureMetricsResponse(rsp)
-}
-
-// DboAPIDeleteLogicalDatabaseWithResponse request returning *DboAPIDeleteLogicalDatabaseResponse
-func (c *ClientWithResponses) DboAPIDeleteLogicalDatabaseWithResponse(ctx context.Context, instanceId string, name string) (*DboAPIDeleteLogicalDatabaseResponse, error) {
-	rsp, err := c.DboAPIDeleteLogicalDatabase(ctx, instanceId, name)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDboAPIDeleteLogicalDatabaseResponse(rsp)
-}
-
-// DboAPICreateLogicalDatabasesWithBodyWithResponse request with arbitrary body returning *DboAPICreateLogicalDatabasesResponse
-func (c *ClientWithResponses) DboAPICreateLogicalDatabasesWithBodyWithResponse(ctx context.Context, instanceId string, params *DboAPICreateLogicalDatabasesParams, contentType string, body io.Reader) (*DboAPICreateLogicalDatabasesResponse, error) {
-	rsp, err := c.DboAPICreateLogicalDatabasesWithBody(ctx, instanceId, params, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDboAPICreateLogicalDatabasesResponse(rsp)
-}
-
-func (c *ClientWithResponses) DboAPICreateLogicalDatabasesWithResponse(ctx context.Context, instanceId string, params *DboAPICreateLogicalDatabasesParams, body DboAPICreateLogicalDatabasesJSONRequestBody) (*DboAPICreateLogicalDatabasesResponse, error) {
-	rsp, err := c.DboAPICreateLogicalDatabases(ctx, instanceId, params, body)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDboAPICreateLogicalDatabasesResponse(rsp)
 }
 
 // DboAPICreateRegistrationWithBodyWithResponse request with arbitrary body returning *DboAPICreateRegistrationResponse
@@ -34774,32 +34196,6 @@ func ParseDboAPIListAccountsResponse(rsp *http.Response) (*DboAPIListAccountsRes
 	return response, nil
 }
 
-// ParseDboAPIDeleteAccountResponse parses an HTTP response from a DboAPIDeleteAccountWithResponse call
-func ParseDboAPIDeleteAccountResponse(rsp *http.Response) (*DboAPIDeleteAccountResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &DboAPIDeleteAccountResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest DboV1DeleteAccountResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
 // ParseDboAPIListCacheGroupsResponse parses an HTTP response from a DboAPIListCacheGroupsWithResponse call
 func ParseDboAPIListCacheGroupsResponse(rsp *http.Response) (*DboAPIListCacheGroupsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -35554,32 +34950,6 @@ func ParseDboAPIListDatabaseComponentsResponse(rsp *http.Response) (*DboAPIListD
 	return response, nil
 }
 
-// ParseDboAPIListDatabaseInstancesLegacyResponse parses an HTTP response from a DboAPIListDatabaseInstancesLegacyWithResponse call
-func ParseDboAPIListDatabaseInstancesLegacyResponse(rsp *http.Response) (*DboAPIListDatabaseInstancesLegacyResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &DboAPIListDatabaseInstancesLegacyResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest DboV1ListDatabaseInstancesResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
 // ParseDboAPIGetDatabaseInstanceResponse parses an HTTP response from a DboAPIGetDatabaseInstanceWithResponse call
 func ParseDboAPIGetDatabaseInstanceResponse(rsp *http.Response) (*DboAPIGetDatabaseInstanceResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -35606,32 +34976,6 @@ func ParseDboAPIGetDatabaseInstanceResponse(rsp *http.Response) (*DboAPIGetDatab
 	return response, nil
 }
 
-// ParseDboAPIGetDatabaseInstanceCachePerformanceResponse parses an HTTP response from a DboAPIGetDatabaseInstanceCachePerformanceWithResponse call
-func ParseDboAPIGetDatabaseInstanceCachePerformanceResponse(rsp *http.Response) (*DboAPIGetDatabaseInstanceCachePerformanceResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &DboAPIGetDatabaseInstanceCachePerformanceResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []DboV1CachePerformanceTimeseries
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
 // ParseDboAPIGetDatabaseInstanceInfrastructureMetricsResponse parses an HTTP response from a DboAPIGetDatabaseInstanceInfrastructureMetricsWithResponse call
 func ParseDboAPIGetDatabaseInstanceInfrastructureMetricsResponse(rsp *http.Response) (*DboAPIGetDatabaseInstanceInfrastructureMetricsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -35648,58 +34992,6 @@ func ParseDboAPIGetDatabaseInstanceInfrastructureMetricsResponse(rsp *http.Respo
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest []DboV1InstanceMetrics
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseDboAPIDeleteLogicalDatabaseResponse parses an HTTP response from a DboAPIDeleteLogicalDatabaseWithResponse call
-func ParseDboAPIDeleteLogicalDatabaseResponse(rsp *http.Response) (*DboAPIDeleteLogicalDatabaseResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &DboAPIDeleteLogicalDatabaseResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest DboV1DeleteLogicalDatabaseResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseDboAPICreateLogicalDatabasesResponse parses an HTTP response from a DboAPICreateLogicalDatabasesWithResponse call
-func ParseDboAPICreateLogicalDatabasesResponse(rsp *http.Response) (*DboAPICreateLogicalDatabasesResponse, error) {
-	bodyBytes, err := ioutil.ReadAll(rsp.Body)
-	defer rsp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &DboAPICreateLogicalDatabasesResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []DboV1LogicalDatabase
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -662,6 +662,9 @@ type ClientInterface interface {
 
 	ServiceAccountsAPIUpdateServiceAccount(ctx context.Context, organizationId string, serviceAccountId string, body ServiceAccountsAPIUpdateServiceAccountJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ServiceAccountsAPIListServiceAccountKeys request
+	ServiceAccountsAPIListServiceAccountKeys(ctx context.Context, organizationId string, serviceAccountId string, params *ServiceAccountsAPIListServiceAccountKeysParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ServiceAccountsAPICreateServiceAccountKeyWithBody request with any body
 	ServiceAccountsAPICreateServiceAccountKeyWithBody(ctx context.Context, organizationId string, serviceAccountId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -3535,6 +3538,18 @@ func (c *Client) ServiceAccountsAPIUpdateServiceAccountWithBody(ctx context.Cont
 
 func (c *Client) ServiceAccountsAPIUpdateServiceAccount(ctx context.Context, organizationId string, serviceAccountId string, body ServiceAccountsAPIUpdateServiceAccountJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewServiceAccountsAPIUpdateServiceAccountRequest(c.Server, organizationId, serviceAccountId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ServiceAccountsAPIListServiceAccountKeys(ctx context.Context, organizationId string, serviceAccountId string, params *ServiceAccountsAPIListServiceAccountKeysParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewServiceAccountsAPIListServiceAccountKeysRequest(c.Server, organizationId, serviceAccountId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -14604,6 +14619,85 @@ func NewServiceAccountsAPIUpdateServiceAccountRequestWithBody(server string, org
 	return req, nil
 }
 
+// NewServiceAccountsAPIListServiceAccountKeysRequest generates requests for ServiceAccountsAPIListServiceAccountKeys
+func NewServiceAccountsAPIListServiceAccountKeysRequest(server string, organizationId string, serviceAccountId string, params *ServiceAccountsAPIListServiceAccountKeysParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "organizationId", runtime.ParamLocationPath, organizationId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "serviceAccountId", runtime.ParamLocationPath, serviceAccountId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/organizations/%s/service-accounts/%s/keys", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PageLimit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.limit", runtime.ParamLocationQuery, *params.PageLimit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PageCursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.cursor", runtime.ParamLocationQuery, *params.PageCursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewServiceAccountsAPICreateServiceAccountKeyRequest calls the generic ServiceAccountsAPICreateServiceAccountKey builder with application/json body
 func NewServiceAccountsAPICreateServiceAccountKeyRequest(server string, organizationId string, serviceAccountId string, body ServiceAccountsAPICreateServiceAccountKeyJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -22231,6 +22325,9 @@ type ClientWithResponsesInterface interface {
 
 	ServiceAccountsAPIUpdateServiceAccountWithResponse(ctx context.Context, organizationId string, serviceAccountId string, body ServiceAccountsAPIUpdateServiceAccountJSONRequestBody) (*ServiceAccountsAPIUpdateServiceAccountResponse, error)
 
+	// ServiceAccountsAPIListServiceAccountKeys request
+	ServiceAccountsAPIListServiceAccountKeysWithResponse(ctx context.Context, organizationId string, serviceAccountId string, params *ServiceAccountsAPIListServiceAccountKeysParams) (*ServiceAccountsAPIListServiceAccountKeysResponse, error)
+
 	// ServiceAccountsAPICreateServiceAccountKey request  with any body
 	ServiceAccountsAPICreateServiceAccountKeyWithBodyWithResponse(ctx context.Context, organizationId string, serviceAccountId string, contentType string, body io.Reader) (*ServiceAccountsAPICreateServiceAccountKeyResponse, error)
 
@@ -27307,6 +27404,36 @@ func (r ServiceAccountsAPIUpdateServiceAccountResponse) GetBody() []byte {
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
+type ServiceAccountsAPIListServiceAccountKeysResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CastaiServiceaccountsV1beta1ListServiceAccountKeysResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ServiceAccountsAPIListServiceAccountKeysResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ServiceAccountsAPIListServiceAccountKeysResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r ServiceAccountsAPIListServiceAccountKeysResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
 type ServiceAccountsAPICreateServiceAccountKeyResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -32302,6 +32429,15 @@ func (c *ClientWithResponses) ServiceAccountsAPIUpdateServiceAccountWithResponse
 		return nil, err
 	}
 	return ParseServiceAccountsAPIUpdateServiceAccountResponse(rsp)
+}
+
+// ServiceAccountsAPIListServiceAccountKeysWithResponse request returning *ServiceAccountsAPIListServiceAccountKeysResponse
+func (c *ClientWithResponses) ServiceAccountsAPIListServiceAccountKeysWithResponse(ctx context.Context, organizationId string, serviceAccountId string, params *ServiceAccountsAPIListServiceAccountKeysParams) (*ServiceAccountsAPIListServiceAccountKeysResponse, error) {
+	rsp, err := c.ServiceAccountsAPIListServiceAccountKeys(ctx, organizationId, serviceAccountId, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseServiceAccountsAPIListServiceAccountKeysResponse(rsp)
 }
 
 // ServiceAccountsAPICreateServiceAccountKeyWithBodyWithResponse request with arbitrary body returning *ServiceAccountsAPICreateServiceAccountKeyResponse
@@ -37570,6 +37706,32 @@ func ParseServiceAccountsAPIUpdateServiceAccountResponse(rsp *http.Response) (*S
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest CastaiServiceaccountsV1beta1UpdateServiceAccountResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseServiceAccountsAPIListServiceAccountKeysResponse parses an HTTP response from a ServiceAccountsAPIListServiceAccountKeysWithResponse call
+func ParseServiceAccountsAPIListServiceAccountKeysResponse(rsp *http.Response) (*ServiceAccountsAPIListServiceAccountKeysResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ServiceAccountsAPIListServiceAccountKeysResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CastaiServiceaccountsV1beta1ListServiceAccountKeysResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -5575,6 +5575,26 @@ func (mr *MockClientInterfaceMockRecorder) ServiceAccountsAPIGetServiceAccountKe
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAccountsAPIGetServiceAccountKey", reflect.TypeOf((*MockClientInterface)(nil).ServiceAccountsAPIGetServiceAccountKey), varargs...)
 }
 
+// ServiceAccountsAPIListServiceAccountKeys mocks base method.
+func (m *MockClientInterface) ServiceAccountsAPIListServiceAccountKeys(ctx context.Context, organizationId, serviceAccountId string, params *sdk.ServiceAccountsAPIListServiceAccountKeysParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, serviceAccountId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ServiceAccountsAPIListServiceAccountKeys", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceAccountsAPIListServiceAccountKeys indicates an expected call of ServiceAccountsAPIListServiceAccountKeys.
+func (mr *MockClientInterfaceMockRecorder) ServiceAccountsAPIListServiceAccountKeys(ctx, organizationId, serviceAccountId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, serviceAccountId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAccountsAPIListServiceAccountKeys", reflect.TypeOf((*MockClientInterface)(nil).ServiceAccountsAPIListServiceAccountKeys), varargs...)
+}
+
 // ServiceAccountsAPIListServiceAccounts mocks base method.
 func (m *MockClientInterface) ServiceAccountsAPIListServiceAccounts(ctx context.Context, organizationId string, params *sdk.ServiceAccountsAPIListServiceAccountsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -16681,6 +16701,41 @@ func (m *MockClientWithResponsesInterface) ServiceAccountsAPIGetServiceAccountWi
 func (mr *MockClientWithResponsesInterfaceMockRecorder) ServiceAccountsAPIGetServiceAccountWithResponse(ctx, organizationId, serviceAccountId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAccountsAPIGetServiceAccountWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ServiceAccountsAPIGetServiceAccountWithResponse), ctx, organizationId, serviceAccountId)
+}
+
+// ServiceAccountsAPIListServiceAccountKeys mocks base method.
+func (m *MockClientWithResponsesInterface) ServiceAccountsAPIListServiceAccountKeys(ctx context.Context, organizationId, serviceAccountId string, params *sdk.ServiceAccountsAPIListServiceAccountKeysParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, serviceAccountId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ServiceAccountsAPIListServiceAccountKeys", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceAccountsAPIListServiceAccountKeys indicates an expected call of ServiceAccountsAPIListServiceAccountKeys.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) ServiceAccountsAPIListServiceAccountKeys(ctx, organizationId, serviceAccountId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, serviceAccountId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAccountsAPIListServiceAccountKeys", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ServiceAccountsAPIListServiceAccountKeys), varargs...)
+}
+
+// ServiceAccountsAPIListServiceAccountKeysWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) ServiceAccountsAPIListServiceAccountKeysWithResponse(ctx context.Context, organizationId, serviceAccountId string, params *sdk.ServiceAccountsAPIListServiceAccountKeysParams) (*sdk.ServiceAccountsAPIListServiceAccountKeysResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceAccountsAPIListServiceAccountKeysWithResponse", ctx, organizationId, serviceAccountId, params)
+	ret0, _ := ret[0].(*sdk.ServiceAccountsAPIListServiceAccountKeysResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceAccountsAPIListServiceAccountKeysWithResponse indicates an expected call of ServiceAccountsAPIListServiceAccountKeysWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) ServiceAccountsAPIListServiceAccountKeysWithResponse(ctx, organizationId, serviceAccountId, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAccountsAPIListServiceAccountKeysWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ServiceAccountsAPIListServiceAccountKeysWithResponse), ctx, organizationId, serviceAccountId, params)
 }
 
 // ServiceAccountsAPIListServiceAccounts mocks base method.

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -1175,46 +1175,6 @@ func (mr *MockClientInterfaceMockRecorder) DboAPICreateCacheTTLWithBody(ctx, gro
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPICreateCacheTTLWithBody", reflect.TypeOf((*MockClientInterface)(nil).DboAPICreateCacheTTLWithBody), varargs...)
 }
 
-// DboAPICreateLogicalDatabases mocks base method.
-func (m *MockClientInterface) DboAPICreateLogicalDatabases(ctx context.Context, instanceId string, params *sdk.DboAPICreateLogicalDatabasesParams, body sdk.DboAPICreateLogicalDatabasesJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, instanceId, params, body}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DboAPICreateLogicalDatabases", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPICreateLogicalDatabases indicates an expected call of DboAPICreateLogicalDatabases.
-func (mr *MockClientInterfaceMockRecorder) DboAPICreateLogicalDatabases(ctx, instanceId, params, body interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, instanceId, params, body}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPICreateLogicalDatabases", reflect.TypeOf((*MockClientInterface)(nil).DboAPICreateLogicalDatabases), varargs...)
-}
-
-// DboAPICreateLogicalDatabasesWithBody mocks base method.
-func (m *MockClientInterface) DboAPICreateLogicalDatabasesWithBody(ctx context.Context, instanceId string, params *sdk.DboAPICreateLogicalDatabasesParams, contentType string, body io.Reader, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, instanceId, params, contentType, body}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DboAPICreateLogicalDatabasesWithBody", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPICreateLogicalDatabasesWithBody indicates an expected call of DboAPICreateLogicalDatabasesWithBody.
-func (mr *MockClientInterfaceMockRecorder) DboAPICreateLogicalDatabasesWithBody(ctx, instanceId, params, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, instanceId, params, contentType, body}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPICreateLogicalDatabasesWithBody", reflect.TypeOf((*MockClientInterface)(nil).DboAPICreateLogicalDatabasesWithBody), varargs...)
-}
-
 // DboAPICreateRegistration mocks base method.
 func (m *MockClientInterface) DboAPICreateRegistration(ctx context.Context, body sdk.DboAPICreateRegistrationJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -1295,26 +1255,6 @@ func (mr *MockClientInterfaceMockRecorder) DboAPICreateRegistrationWithBody(ctx,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPICreateRegistrationWithBody", reflect.TypeOf((*MockClientInterface)(nil).DboAPICreateRegistrationWithBody), varargs...)
 }
 
-// DboAPIDeleteAccount mocks base method.
-func (m *MockClientInterface) DboAPIDeleteAccount(ctx context.Context, id string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, id}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DboAPIDeleteAccount", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPIDeleteAccount indicates an expected call of DboAPIDeleteAccount.
-func (mr *MockClientInterfaceMockRecorder) DboAPIDeleteAccount(ctx, id interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, id}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIDeleteAccount", reflect.TypeOf((*MockClientInterface)(nil).DboAPIDeleteAccount), varargs...)
-}
-
 // DboAPIDeleteCacheConfiguration mocks base method.
 func (m *MockClientInterface) DboAPIDeleteCacheConfiguration(ctx context.Context, groupId, id string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -1373,26 +1313,6 @@ func (mr *MockClientInterfaceMockRecorder) DboAPIDeleteCacheTTL(ctx, groupId, ca
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, groupId, cacheId, id}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIDeleteCacheTTL", reflect.TypeOf((*MockClientInterface)(nil).DboAPIDeleteCacheTTL), varargs...)
-}
-
-// DboAPIDeleteLogicalDatabase mocks base method.
-func (m *MockClientInterface) DboAPIDeleteLogicalDatabase(ctx context.Context, instanceId, name string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, instanceId, name}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DboAPIDeleteLogicalDatabase", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPIDeleteLogicalDatabase indicates an expected call of DboAPIDeleteLogicalDatabase.
-func (mr *MockClientInterfaceMockRecorder) DboAPIDeleteLogicalDatabase(ctx, instanceId, name interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, instanceId, name}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIDeleteLogicalDatabase", reflect.TypeOf((*MockClientInterface)(nil).DboAPIDeleteLogicalDatabase), varargs...)
 }
 
 // DboAPIExchangeCacheState mocks base method.
@@ -1735,26 +1655,6 @@ func (mr *MockClientInterfaceMockRecorder) DboAPIGetDatabaseInstance(ctx, instan
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIGetDatabaseInstance", reflect.TypeOf((*MockClientInterface)(nil).DboAPIGetDatabaseInstance), varargs...)
 }
 
-// DboAPIGetDatabaseInstanceCachePerformance mocks base method.
-func (m *MockClientInterface) DboAPIGetDatabaseInstanceCachePerformance(ctx context.Context, instanceId string, params *sdk.DboAPIGetDatabaseInstanceCachePerformanceParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, instanceId, params}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DboAPIGetDatabaseInstanceCachePerformance", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPIGetDatabaseInstanceCachePerformance indicates an expected call of DboAPIGetDatabaseInstanceCachePerformance.
-func (mr *MockClientInterfaceMockRecorder) DboAPIGetDatabaseInstanceCachePerformance(ctx, instanceId, params interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, instanceId, params}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIGetDatabaseInstanceCachePerformance", reflect.TypeOf((*MockClientInterface)(nil).DboAPIGetDatabaseInstanceCachePerformance), varargs...)
-}
-
 // DboAPIGetDatabaseInstanceInfrastructureMetrics mocks base method.
 func (m *MockClientInterface) DboAPIGetDatabaseInstanceInfrastructureMetrics(ctx context.Context, instanceId string, params *sdk.DboAPIGetDatabaseInstanceInfrastructureMetricsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -1913,26 +1813,6 @@ func (mr *MockClientInterfaceMockRecorder) DboAPIListDatabaseComponents(ctx, par
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, params}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIListDatabaseComponents", reflect.TypeOf((*MockClientInterface)(nil).DboAPIListDatabaseComponents), varargs...)
-}
-
-// DboAPIListDatabaseInstancesLegacy mocks base method.
-func (m *MockClientInterface) DboAPIListDatabaseInstancesLegacy(ctx context.Context, params *sdk.DboAPIListDatabaseInstancesLegacyParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, params}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DboAPIListDatabaseInstancesLegacy", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPIListDatabaseInstancesLegacy indicates an expected call of DboAPIListDatabaseInstancesLegacy.
-func (mr *MockClientInterfaceMockRecorder) DboAPIListDatabaseInstancesLegacy(ctx, params interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, params}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIListDatabaseInstancesLegacy", reflect.TypeOf((*MockClientInterface)(nil).DboAPIListDatabaseInstancesLegacy), varargs...)
 }
 
 // DboAPIUpdateCacheConfiguration mocks base method.
@@ -9103,76 +8983,6 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPICreateCacheTTLWith
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPICreateCacheTTLWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPICreateCacheTTLWithResponse), ctx, groupId, id, body)
 }
 
-// DboAPICreateLogicalDatabases mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPICreateLogicalDatabases(ctx context.Context, instanceId string, params *sdk.DboAPICreateLogicalDatabasesParams, body sdk.DboAPICreateLogicalDatabasesJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, instanceId, params, body}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DboAPICreateLogicalDatabases", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPICreateLogicalDatabases indicates an expected call of DboAPICreateLogicalDatabases.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPICreateLogicalDatabases(ctx, instanceId, params, body interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, instanceId, params, body}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPICreateLogicalDatabases", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPICreateLogicalDatabases), varargs...)
-}
-
-// DboAPICreateLogicalDatabasesWithBody mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPICreateLogicalDatabasesWithBody(ctx context.Context, instanceId string, params *sdk.DboAPICreateLogicalDatabasesParams, contentType string, body io.Reader, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, instanceId, params, contentType, body}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DboAPICreateLogicalDatabasesWithBody", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPICreateLogicalDatabasesWithBody indicates an expected call of DboAPICreateLogicalDatabasesWithBody.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPICreateLogicalDatabasesWithBody(ctx, instanceId, params, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, instanceId, params, contentType, body}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPICreateLogicalDatabasesWithBody", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPICreateLogicalDatabasesWithBody), varargs...)
-}
-
-// DboAPICreateLogicalDatabasesWithBodyWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPICreateLogicalDatabasesWithBodyWithResponse(ctx context.Context, instanceId string, params *sdk.DboAPICreateLogicalDatabasesParams, contentType string, body io.Reader) (*sdk.DboAPICreateLogicalDatabasesResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DboAPICreateLogicalDatabasesWithBodyWithResponse", ctx, instanceId, params, contentType, body)
-	ret0, _ := ret[0].(*sdk.DboAPICreateLogicalDatabasesResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPICreateLogicalDatabasesWithBodyWithResponse indicates an expected call of DboAPICreateLogicalDatabasesWithBodyWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPICreateLogicalDatabasesWithBodyWithResponse(ctx, instanceId, params, contentType, body interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPICreateLogicalDatabasesWithBodyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPICreateLogicalDatabasesWithBodyWithResponse), ctx, instanceId, params, contentType, body)
-}
-
-// DboAPICreateLogicalDatabasesWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPICreateLogicalDatabasesWithResponse(ctx context.Context, instanceId string, params *sdk.DboAPICreateLogicalDatabasesParams, body sdk.DboAPICreateLogicalDatabasesJSONRequestBody) (*sdk.DboAPICreateLogicalDatabasesResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DboAPICreateLogicalDatabasesWithResponse", ctx, instanceId, params, body)
-	ret0, _ := ret[0].(*sdk.DboAPICreateLogicalDatabasesResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPICreateLogicalDatabasesWithResponse indicates an expected call of DboAPICreateLogicalDatabasesWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPICreateLogicalDatabasesWithResponse(ctx, instanceId, params, body interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPICreateLogicalDatabasesWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPICreateLogicalDatabasesWithResponse), ctx, instanceId, params, body)
-}
-
 // DboAPICreateRegistration mocks base method.
 func (m *MockClientWithResponsesInterface) DboAPICreateRegistration(ctx context.Context, body sdk.DboAPICreateRegistrationJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -9313,41 +9123,6 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPICreateRegistration
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPICreateRegistrationWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPICreateRegistrationWithResponse), ctx, body)
 }
 
-// DboAPIDeleteAccount mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPIDeleteAccount(ctx context.Context, id string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, id}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DboAPIDeleteAccount", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPIDeleteAccount indicates an expected call of DboAPIDeleteAccount.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIDeleteAccount(ctx, id interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, id}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIDeleteAccount", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIDeleteAccount), varargs...)
-}
-
-// DboAPIDeleteAccountWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPIDeleteAccountWithResponse(ctx context.Context, id string) (*sdk.DboAPIDeleteAccountResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DboAPIDeleteAccountWithResponse", ctx, id)
-	ret0, _ := ret[0].(*sdk.DboAPIDeleteAccountResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPIDeleteAccountWithResponse indicates an expected call of DboAPIDeleteAccountWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIDeleteAccountWithResponse(ctx, id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIDeleteAccountWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIDeleteAccountWithResponse), ctx, id)
-}
-
 // DboAPIDeleteCacheConfiguration mocks base method.
 func (m *MockClientWithResponsesInterface) DboAPIDeleteCacheConfiguration(ctx context.Context, groupId, id string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -9451,41 +9226,6 @@ func (m *MockClientWithResponsesInterface) DboAPIDeleteCacheTTLWithResponse(ctx 
 func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIDeleteCacheTTLWithResponse(ctx, groupId, cacheId, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIDeleteCacheTTLWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIDeleteCacheTTLWithResponse), ctx, groupId, cacheId, id)
-}
-
-// DboAPIDeleteLogicalDatabase mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPIDeleteLogicalDatabase(ctx context.Context, instanceId, name string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, instanceId, name}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DboAPIDeleteLogicalDatabase", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPIDeleteLogicalDatabase indicates an expected call of DboAPIDeleteLogicalDatabase.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIDeleteLogicalDatabase(ctx, instanceId, name interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, instanceId, name}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIDeleteLogicalDatabase", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIDeleteLogicalDatabase), varargs...)
-}
-
-// DboAPIDeleteLogicalDatabaseWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPIDeleteLogicalDatabaseWithResponse(ctx context.Context, instanceId, name string) (*sdk.DboAPIDeleteLogicalDatabaseResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DboAPIDeleteLogicalDatabaseWithResponse", ctx, instanceId, name)
-	ret0, _ := ret[0].(*sdk.DboAPIDeleteLogicalDatabaseResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPIDeleteLogicalDatabaseWithResponse indicates an expected call of DboAPIDeleteLogicalDatabaseWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIDeleteLogicalDatabaseWithResponse(ctx, instanceId, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIDeleteLogicalDatabaseWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIDeleteLogicalDatabaseWithResponse), ctx, instanceId, name)
 }
 
 // DboAPIExchangeCacheState mocks base method.
@@ -10068,41 +9808,6 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIGetDatabaseInstanc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIGetDatabaseInstance", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIGetDatabaseInstance), varargs...)
 }
 
-// DboAPIGetDatabaseInstanceCachePerformance mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPIGetDatabaseInstanceCachePerformance(ctx context.Context, instanceId string, params *sdk.DboAPIGetDatabaseInstanceCachePerformanceParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, instanceId, params}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DboAPIGetDatabaseInstanceCachePerformance", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPIGetDatabaseInstanceCachePerformance indicates an expected call of DboAPIGetDatabaseInstanceCachePerformance.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIGetDatabaseInstanceCachePerformance(ctx, instanceId, params interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, instanceId, params}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIGetDatabaseInstanceCachePerformance", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIGetDatabaseInstanceCachePerformance), varargs...)
-}
-
-// DboAPIGetDatabaseInstanceCachePerformanceWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPIGetDatabaseInstanceCachePerformanceWithResponse(ctx context.Context, instanceId string, params *sdk.DboAPIGetDatabaseInstanceCachePerformanceParams) (*sdk.DboAPIGetDatabaseInstanceCachePerformanceResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DboAPIGetDatabaseInstanceCachePerformanceWithResponse", ctx, instanceId, params)
-	ret0, _ := ret[0].(*sdk.DboAPIGetDatabaseInstanceCachePerformanceResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPIGetDatabaseInstanceCachePerformanceWithResponse indicates an expected call of DboAPIGetDatabaseInstanceCachePerformanceWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIGetDatabaseInstanceCachePerformanceWithResponse(ctx, instanceId, params interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIGetDatabaseInstanceCachePerformanceWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIGetDatabaseInstanceCachePerformanceWithResponse), ctx, instanceId, params)
-}
-
 // DboAPIGetDatabaseInstanceInfrastructureMetrics mocks base method.
 func (m *MockClientWithResponsesInterface) DboAPIGetDatabaseInstanceInfrastructureMetrics(ctx context.Context, instanceId string, params *sdk.DboAPIGetDatabaseInstanceInfrastructureMetricsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -10396,41 +10101,6 @@ func (m *MockClientWithResponsesInterface) DboAPIListDatabaseComponentsWithRespo
 func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIListDatabaseComponentsWithResponse(ctx, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIListDatabaseComponentsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIListDatabaseComponentsWithResponse), ctx, params)
-}
-
-// DboAPIListDatabaseInstancesLegacy mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPIListDatabaseInstancesLegacy(ctx context.Context, params *sdk.DboAPIListDatabaseInstancesLegacyParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, params}
-	for _, a := range reqEditors {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DboAPIListDatabaseInstancesLegacy", varargs...)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPIListDatabaseInstancesLegacy indicates an expected call of DboAPIListDatabaseInstancesLegacy.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIListDatabaseInstancesLegacy(ctx, params interface{}, reqEditors ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, params}, reqEditors...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIListDatabaseInstancesLegacy", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIListDatabaseInstancesLegacy), varargs...)
-}
-
-// DboAPIListDatabaseInstancesLegacyWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPIListDatabaseInstancesLegacyWithResponse(ctx context.Context, params *sdk.DboAPIListDatabaseInstancesLegacyParams) (*sdk.DboAPIListDatabaseInstancesLegacyResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DboAPIListDatabaseInstancesLegacyWithResponse", ctx, params)
-	ret0, _ := ret[0].(*sdk.DboAPIListDatabaseInstancesLegacyResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DboAPIListDatabaseInstancesLegacyWithResponse indicates an expected call of DboAPIListDatabaseInstancesLegacyWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIListDatabaseInstancesLegacyWithResponse(ctx, params interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIListDatabaseInstancesLegacyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIListDatabaseInstancesLegacyWithResponse), ctx, params)
 }
 
 // DboAPIUpdateCacheConfiguration mocks base method.

--- a/docs/resources/rebalancing_schedule.md
+++ b/docs/resources/rebalancing_schedule.md
@@ -74,7 +74,7 @@ resource "castai_rebalancing_schedule" "spots" {
 
 Optional:
 
-- `aggressive_mode` (Boolean, Deprecated) Deprecated: use aggressive_mode_config instead. When enabled, rebalancing considers all problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic.
+- `aggressive_mode` (Boolean, Deprecated) Deprecated: Use aggressive_mode_config instead. When enabled, rebalancing considers all problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic.
 - `aggressive_mode_config` (Block List, Max: 1) Advanced configuration for the aggressive rebalancing mode. This is the recommended way to configure aggressive rebalancing. Please keep the `aggressive_mode` parameter unset or set it `aggressive_mode=false` before using this config option. When the legacy `aggressive_mode` is set to `true`, it takes precedence over this option. (see [below for nested schema](#nestedblock--launch_configuration--aggressive_mode_config))
 - `execution_conditions` (Block List, Max: 1) (see [below for nested schema](#nestedblock--launch_configuration--execution_conditions))
 - `keep_drain_timeout_nodes` (Boolean) Defines whether the nodes that failed to get drained until a predefined timeout, will be kept with a rebalancing.cast.ai/status=drain-failed annotation instead of forcefully drained.

--- a/docs/resources/rebalancing_schedule.md
+++ b/docs/resources/rebalancing_schedule.md
@@ -74,7 +74,7 @@ resource "castai_rebalancing_schedule" "spots" {
 
 Optional:
 
-- `aggressive_mode` (Boolean) When enabled, rebalancing considers all problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic.
+- `aggressive_mode` (Boolean, Deprecated) Deprecated: use aggressive_mode_config instead. When enabled, rebalancing considers all problematic pods (pods without controller, job pods, pods with removal-disabled annotation) as not-problematic.
 - `aggressive_mode_config` (Block List, Max: 1) Advanced configuration for the aggressive rebalancing mode. This is the recommended way to configure aggressive rebalancing. Please keep the `aggressive_mode` parameter unset or set it `aggressive_mode=false` before using this config option. When the legacy `aggressive_mode` is set to `true`, it takes precedence over this option. (see [below for nested schema](#nestedblock--launch_configuration--aggressive_mode_config))
 - `execution_conditions` (Block List, Max: 1) (see [below for nested schema](#nestedblock--launch_configuration--execution_conditions))
 - `keep_drain_timeout_nodes` (Boolean) Defines whether the nodes that failed to get drained until a predefined timeout, will be kept with a rebalancing.cast.ai/status=drain-failed annotation instead of forcefully drained.

--- a/docs/resources/rebalancing_schedule.md
+++ b/docs/resources/rebalancing_schedule.md
@@ -27,11 +27,12 @@ resource "castai_rebalancing_schedule" "spots" {
     num_targeted_nodes       = 3
     rebalancing_min_nodes    = 2
     keep_drain_timeout_nodes = false
+    # equivalent to the deprecated config: aggressive_mode = true.
     aggressive_mode_config {
-      ignore_local_persistent_volumes        = false
-      ignore_problem_job_pods                = false
+      ignore_local_persistent_volumes        = true
+      ignore_problem_job_pods                = true
       ignore_problem_pods_without_controller = true
-      ignore_problem_removal_disabled_pods   = false
+      ignore_problem_removal_disabled_pods   = true
     }
     selector = jsonencode({
       nodeSelectorTerms = [{

--- a/examples/resources/castai_rebalancing_schedule/resource.tf
+++ b/examples/resources/castai_rebalancing_schedule/resource.tf
@@ -12,11 +12,12 @@ resource "castai_rebalancing_schedule" "spots" {
     num_targeted_nodes       = 3
     rebalancing_min_nodes    = 2
     keep_drain_timeout_nodes = false
+    # equivalent to the deprecated config: aggressive_mode = true.
     aggressive_mode_config {
-      ignore_local_persistent_volumes        = false
-      ignore_problem_job_pods                = false
+      ignore_local_persistent_volumes        = true
+      ignore_problem_job_pods                = true
       ignore_problem_pods_without_controller = true
-      ignore_problem_removal_disabled_pods   = false
+      ignore_problem_removal_disabled_pods   = true
     }
     selector = jsonencode({
       nodeSelectorTerms = [{


### PR DESCRIPTION
Add Deprecated attribute to the aggressive_mode schema field in the rebalancing schedule resource.

Also fixes some flaky tests that are unrelated to the aggressive_mode change.

---
### Kimchi Summary
### What changed
Deprecates the `aggressive_mode` boolean field on `castai_rebalancing_schedule` in favor of the granular `aggressive_mode_config` block, updates the generated SDK to the latest API spec, and renames acceptance-test cluster fixtures to avoid collisions.

### Why
`aggressive_mode` is a coarse-grained setting. The newer `aggressive_mode_config` block lets users selectively control which problematic pods (job pods, pods without controller, removal-disabled pods, local persistent volumes) are ignored during rebalancing, making the deprecation necessary to guide users to the more flexible replacement.

### Key changes
- `castai/resource_rebalancing_schedule.go`  
  - Marks the `aggressive_mode` schema field as `Deprecated` with a migration message pointing to `aggressive_mode_config`.  
  - Updates the field description to indicate deprecation.  
  - Fixes the local variable typo `aggresiveMode` → `aggressiveMode`.
- `castai/resource_edge_configuration_test.go` & `castai/resource_edge_configuration_default_test.go`  
  - Renames test cluster names (e.g., `omni-tf-acc-aws` → `omni-tf-acc-aws-cfg`) to prevent test fixture clashes.
- `castai/sdk/api.gen.go`, `castai/sdk/client.gen.go`, `castai/sdk/mock/client.go`  
  - Regenerates the SDK client to match the latest CAST AI OpenAPI specification, adding new types/fields (e.g., ENA queue info, onboarding-path enum, dedicated-node GPU constraints) and removing obsolete DBO endpoints.
- `docs/resources/rebalancing_schedule.md` & `examples/resources/castai_rebalancing_schedule/resource.tf`  
  - Updates documentation and examples to show an `aggressive_mode_config` configuration equivalent to the deprecated `aggressive_mode = true`.

### Impact
- **Migration**: Users currently setting `aggressive_mode = true` should migrate to:
  ```hcl
  aggressive_mode_config {
    ignore_local_persistent_volumes        = true
    ignore_problem_job_pods                = true
    ignore_problem_pods_without_controller = true
    ignore_problem_removal_disabled_pods   = true
  }
  ```
  Terraform will emit a deprecation warning for the old attribute until it is removed.

---
### Kimchi Summary
### What changed
Deprecates the `aggressive_mode` boolean attribute on `castai_rebalancing_schedule` in favor of the granular `aggressive_mode_config` block. Also updates acceptance test cluster names to avoid collisions and regenerates the CAST AI SDK client from the latest OpenAPI specification.

### Why
The upstream API replaced the blanket `aggressive_mode` flag with fine-grained `aggressive_mode_config` settings, allowing explicit control over which problematic pod constraints to ignore during rebalancing.

### Key changes
- `castai/resource_rebalancing_schedule.go`: Marks `aggressive_mode` as deprecated in the Terraform schema, fixes the `aggresiveMode` → `aggressiveMode` typo, and adds a `//nolint:staticcheck` annotation for backwards-compatible handling of the deprecated SDK field.
- `docs/resources/rebalancing_schedule.md` and `examples/resources/castai_rebalancing_schedule/resource.tf`: Updates documentation and examples to use `aggressive_mode_config` with all flags enabled as the equivalent replacement for `aggressive_mode = true`.
- Acceptance tests (`resource_edge_configuration_default_test.go`, `resource_edge_configuration_test.go`, `resource_edge_location_test.go`): Appends unique suffixes to hardcoded `clusterName` values to prevent parallel test collisions.
- `castai/sdk/api.gen.go`, `castai/sdk/client.gen.go`, `castai/sdk/mock/client.go`: Regenerates the SDK to align with the latest API, including deprecation of `AggressiveMode`, addition of `ServiceAccountsAPIListServiceAccountKeys`, removal of legacy DBO endpoints, and new fields for node template GPU constraints and instance network info.

### Impact
- **Deprecation notice**: Configurations using `aggressive_mode = true` will now receive a deprecation warning. To migrate, use `aggressive_mode_config` with the specific pod constraint flags set to `true`.
- The removed legacy DBO client methods (e.g., `DboAPIDeleteAccount`, `DboAPICreateLogicalDatabases`) were not consumed by any provider resources, so they are a non-breaking internal cleanup.