### PR TITLE
fix: use separate cluster in acc tests

### DIFF
--- a/castai/resource_edge_configuration_test.go
+++ b/castai/resource_edge_configuration_test.go
@@ -306,7 +306,7 @@ func testAccEdgeConfigurationOCIConfig(rName, clusterName string) string {
 	organizationID := testAccGetOrganizationID()
 
 	return ConfigCompose(
-		testAccEdgeLocationOCIConfig(rName),
+		testAccEdgeLocationOCIConfig(rName, clusterName),
 		fmt.Sprintf(`
 resource "castai_edge_configuration" "test" {
   organization_id  = %[1]q
@@ -336,7 +336,7 @@ func testAccEdgeConfigurationOCIUpdated(rName, clusterName string) string {
 	organizationID := testAccGetOrganizationID()
 
 	return ConfigCompose(
-		testAccEdgeLocationOCIConfig(rName),
+		testAccEdgeLocationOCIConfig(rName, clusterName),
 		fmt.Sprintf(`
 resource "castai_edge_configuration" "test" {
   organization_id  = %[1]q

--- a/castai/resource_edge_location_test.go
+++ b/castai/resource_edge_location_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestAccCloudAgnostic_ResourceEdgeLocationOCI(t *testing.T) {
 	rName := fmt.Sprintf("%v-edge-loc-%v", ResourcePrefix, acctest.RandString(8))
+	clusterName := "test-oci-cluster"
 	resourceName := "castai_edge_location.test"
 
 	resource.Test(t, resource.TestCase{
@@ -23,7 +24,7 @@ func TestAccCloudAgnostic_ResourceEdgeLocationOCI(t *testing.T) {
 		CheckDestroy:             testAccCheckEdgeLocationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEdgeLocationOCIConfig(rName),
+				Config: testAccEdgeLocationOCIConfig(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Test OCI edge location"),
@@ -40,13 +41,13 @@ func TestAccCloudAgnostic_ResourceEdgeLocationOCI(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEdgeLocationOCIUpdated(rName),
+				Config: testAccEdgeLocationOCIUpdated(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", "Updated OCI edge location"),
 				),
 			},
 			{
-				Config: testAccEdgeLocationOCICredentialsUpdated(rName),
+				Config: testAccEdgeLocationOCICredentialsUpdated(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "credentials_revision", "2"),
 				),
@@ -55,30 +56,29 @@ func TestAccCloudAgnostic_ResourceEdgeLocationOCI(t *testing.T) {
 	})
 }
 
-func testAccEdgeLocationOCIConfig(rName string) string {
-	return testAccEdgeLocationOCIConfigWithParams(rName, "Test OCI edge location",
+func testAccEdgeLocationOCIConfig(rName, clusterName string) string {
+	return testAccEdgeLocationOCIConfigWithParams(rName, clusterName, "Test OCI edge location",
 		`user_id_wo      = "ocid1.user.oc1..example"
     fingerprint_wo  = "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99"
     private_key_base64_wo  = base64encode("-----BEGIN RSA PRIVATE KEY-----\nMIIE...EXAMPLE...==\n-----END RSA PRIVATE KEY-----\n")`)
 }
 
-func testAccEdgeLocationOCIUpdated(rName string) string {
-	return testAccEdgeLocationOCIConfigWithParams(rName, "Updated OCI edge location",
+func testAccEdgeLocationOCIUpdated(rName, clusterName string) string {
+	return testAccEdgeLocationOCIConfigWithParams(rName, clusterName, "Updated OCI edge location",
 		`user_id_wo      = "ocid1.user.oc1..example"
     fingerprint_wo  = "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99"
     private_key_base64_wo  = base64encode("-----BEGIN RSA PRIVATE KEY-----\nMIIE...EXAMPLE...==\n-----END RSA PRIVATE KEY-----\n")`)
 }
 
-func testAccEdgeLocationOCICredentialsUpdated(rName string) string {
-	return testAccEdgeLocationOCIConfigWithParams(rName, "Updated OCI edge location",
+func testAccEdgeLocationOCICredentialsUpdated(rName, clusterName string) string {
+	return testAccEdgeLocationOCIConfigWithParams(rName, clusterName, "Updated OCI edge location",
 		`user_id_wo      = "ocid1.user.oc1..example"
     fingerprint_wo  = "11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00"
     private_key_base64_wo  = base64encode("-----BEGIN RSA PRIVATE KEY-----\nMIIE...NEWKEY...==\n-----END RSA PRIVATE KEY-----\n")`)
 }
 
-func testAccEdgeLocationOCIConfigWithParams(rName, description, ociCredentials string) string {
+func testAccEdgeLocationOCIConfigWithParams(rName, clusterName, description, ociCredentials string) string {
 	organizationID := testAccGetOrganizationID()
-	clusterName := "test-oci-cluster"
 
 	return ConfigCompose(testOmniClusterConfig(clusterName), fmt.Sprintf(`
 resource "castai_edge_location" "test" {

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -3462,6 +3462,9 @@ type CastaiServiceaccountsV1beta1ServiceAccount struct {
 	// Deprecated:
 	Keys *[]CastaiServiceaccountsV1beta1ServiceAccountKey `json:"keys,omitempty"`
 
+	// KeysCount Number of keys associated with the service account.
+	KeysCount *int64 `json:"keysCount,omitempty"`
+
 	// ManagedBy Method used to create role binding, eg.: console, terraform.
 	ManagedBy *string `json:"managedBy,omitempty"`
 
@@ -5417,6 +5420,7 @@ type DboV1TrafficInsightsType string
 // DboV1UninstallCacheParams defines model for dbo.v1.UninstallCacheParams.
 type DboV1UninstallCacheParams struct {
 	CacheGroupId string `json:"cacheGroupId"`
+	IsRoxy       *bool  `json:"isRoxy"`
 }
 
 // DboV1UninstallDBAgentParams defines model for dbo.v1.UninstallDBAgentParams.
@@ -8398,7 +8402,7 @@ type ScheduledrebalancingV1DrainFailureConfig struct {
 	DisableUncordon *bool `json:"disableUncordon"`
 
 	// UncordonAfterSeconds Time in seconds after which a drain-failed node should be automatically uncordoned.
-	// Clamped to [3600, 259200] (1h–72h). Defaults to 10800 (3h).
+	// Clamped to [60, 259200] (1m–72h). Defaults to 1800 (30 minutes).
 	UncordonAfterSeconds *int32 `json:"uncordonAfterSeconds,omitempty"`
 }
 
@@ -8510,8 +8514,11 @@ type ScheduledrebalancingV1RebalancingOptions struct {
 	EvictGracefully *bool `json:"evictGracefully"`
 
 	// ExecutionConditions Defines the conditions which must be met in order to fully execute the plan.
-	ExecutionConditions   *ScheduledrebalancingV1ExecutionConditions `json:"executionConditions,omitempty"`
-	KeepDrainTimeoutNodes *bool                                      `json:"keepDrainTimeoutNodes"`
+	ExecutionConditions *ScheduledrebalancingV1ExecutionConditions `json:"executionConditions,omitempty"`
+
+	// KeepDrainTimeoutNodes Deprecated: use evictGracefully instead.
+	// Deprecated:
+	KeepDrainTimeoutNodes *bool `json:"keepDrainTimeoutNodes"`
 
 	// MinNodes Minimum number of nodes that should be kept in the cluster after rebalancing.
 	MinNodes *int32 `json:"minNodes,omitempty"`

--- a/castai/sdk/organization_management/api.gen.go
+++ b/castai/sdk/organization_management/api.gen.go
@@ -42,6 +42,15 @@ const (
 	DefinitionMemberKindSUBJECTKINDUSER           DefinitionMemberKind = "SUBJECT_KIND_USER"
 )
 
+// Defines values for GetEnterpriseGroupResponseSsoProvider.
+const (
+	SSOPROVIDEROIDC        GetEnterpriseGroupResponseSsoProvider = "SSO_PROVIDER_OIDC"
+	SSOPROVIDEROKTA        GetEnterpriseGroupResponseSsoProvider = "SSO_PROVIDER_OKTA"
+	SSOPROVIDERSAML        GetEnterpriseGroupResponseSsoProvider = "SSO_PROVIDER_SAML"
+	SSOPROVIDERUNSPECIFIED GetEnterpriseGroupResponseSsoProvider = "SSO_PROVIDER_UNSPECIFIED"
+	SSOPROVIDERWAAD        GetEnterpriseGroupResponseSsoProvider = "SSO_PROVIDER_WAAD"
+)
+
 // Defines values for GroupDefinitionAuthorKind.
 const (
 	GroupDefinitionAuthorKindKINDSERVICEACCOUNT GroupDefinitionAuthorKind = "KIND_SERVICE_ACCOUNT"
@@ -104,10 +113,18 @@ const (
 
 // Defines values for EnterpriseAPIListChildrenOrganizationsParamsSortOrder.
 const (
-	ASC  EnterpriseAPIListChildrenOrganizationsParamsSortOrder = "ASC"
-	Asc  EnterpriseAPIListChildrenOrganizationsParamsSortOrder = "asc"
-	DESC EnterpriseAPIListChildrenOrganizationsParamsSortOrder = "DESC"
-	Desc EnterpriseAPIListChildrenOrganizationsParamsSortOrder = "desc"
+	EnterpriseAPIListChildrenOrganizationsParamsSortOrderASC  EnterpriseAPIListChildrenOrganizationsParamsSortOrder = "ASC"
+	EnterpriseAPIListChildrenOrganizationsParamsSortOrderAsc  EnterpriseAPIListChildrenOrganizationsParamsSortOrder = "asc"
+	EnterpriseAPIListChildrenOrganizationsParamsSortOrderDESC EnterpriseAPIListChildrenOrganizationsParamsSortOrder = "DESC"
+	EnterpriseAPIListChildrenOrganizationsParamsSortOrderDesc EnterpriseAPIListChildrenOrganizationsParamsSortOrder = "desc"
+)
+
+// Defines values for EnterpriseAPIListEnterpriseServiceAccountsParamsSortOrder.
+const (
+	EnterpriseAPIListEnterpriseServiceAccountsParamsSortOrderASC  EnterpriseAPIListEnterpriseServiceAccountsParamsSortOrder = "ASC"
+	EnterpriseAPIListEnterpriseServiceAccountsParamsSortOrderAsc  EnterpriseAPIListEnterpriseServiceAccountsParamsSortOrder = "asc"
+	EnterpriseAPIListEnterpriseServiceAccountsParamsSortOrderDESC EnterpriseAPIListEnterpriseServiceAccountsParamsSortOrder = "DESC"
+	EnterpriseAPIListEnterpriseServiceAccountsParamsSortOrderDesc EnterpriseAPIListEnterpriseServiceAccountsParamsSortOrder = "desc"
 )
 
 // AddUserToChildOrganizationRequest Request message for adding a user to a child organization
@@ -531,6 +548,48 @@ type DefinitionRoleBinding struct {
 	Scopes *[]RoleBindingScope `json:"scopes,omitempty"`
 }
 
+// GetEnterpriseGroupResponse Response message containing the requested enterprise group
+type GetEnterpriseGroupResponse struct {
+	// CreateTime CreateTime is the timestamp when the group was created.
+	CreateTime *time.Time `json:"createTime,omitempty"`
+
+	// Definition Definition is the group definition (members and author).
+	Definition *GetEnterpriseGroupResponseGroupDefinition `json:"definition,omitempty"`
+
+	// Description Description is the description of the group.
+	Description *string `json:"description,omitempty"`
+
+	// Id ID is the unique identifier of the group.
+	Id *string `json:"id,omitempty"`
+
+	// ManagedBy ManagedBy is the method used to create the group, e.g.: console, terraform.
+	ManagedBy *string `json:"managedBy,omitempty"`
+
+	// Name Name is the name of the group.
+	Name *string `json:"name,omitempty"`
+
+	// OrganizationId OrganizationID is the unique identifier of the organization the group belongs to.
+	OrganizationId *string `json:"organizationId,omitempty"`
+
+	// SsoProvider SSOProvider is the SSO provider information if the group is managed by SSO.
+	SsoProvider *GetEnterpriseGroupResponseSsoProvider `json:"ssoProvider,omitempty"`
+
+	// UpdateTime UpdateTime is the timestamp when the group was last updated.
+	UpdateTime *time.Time `json:"updateTime,omitempty"`
+}
+
+// GetEnterpriseGroupResponseSsoProvider SSOProvider is the SSO provider information if the group is managed by SSO.
+type GetEnterpriseGroupResponseSsoProvider string
+
+// GetEnterpriseGroupResponseGroupDefinition GroupDefinition represents the definition of a group
+type GetEnterpriseGroupResponseGroupDefinition struct {
+	// Author Author is the author of the group.
+	Author *GroupDefinitionAuthor `json:"author,omitempty"`
+
+	// Members Members is a list of members.
+	Members *[]GroupDefinitionMember `json:"members,omitempty"`
+}
+
 // GoogleProtobufAny Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 type GoogleProtobufAny struct {
 	// Type The type of the serialized message.
@@ -723,6 +782,52 @@ type ListChildrenOrganizationsResponseChildOrganization struct {
 
 // ListChildrenOrganizationsResponseChildOrganizationType Type of the organization.
 type ListChildrenOrganizationsResponseChildOrganizationType string
+
+// ListEnterpriseServiceAccountsResponse Response message containing the list of service accounts in the enterprise organization
+type ListEnterpriseServiceAccountsResponse struct {
+	// Items List of service accounts.
+	Items *[]ListEnterpriseServiceAccountsResponseServiceAccount `json:"items,omitempty"`
+
+	// NextPageCursor A token to retrieve the next page of results. Pass this value in the
+	//  `page.cursor` field in the subsequent call to `ListEnterpriseServiceAccounts` to retrieve the
+	//  next page of results.
+	NextPageCursor *string `json:"nextPageCursor,omitempty"`
+
+	// PrevPageCursor A token to retrieve the previous page of results. Pass this value in the
+	//  `page.cursor` field in the subsequent call to `ListEnterpriseServiceAccounts` to retrieve the
+	//  previous page of results.
+	PrevPageCursor *string `json:"prevPageCursor,omitempty"`
+
+	// TotalSize The total number of service accounts in the list.
+	TotalSize *int32 `json:"totalSize,omitempty"`
+}
+
+// ListEnterpriseServiceAccountsResponseServiceAccount ServiceAccount represents a service account item in the enterprise.
+type ListEnterpriseServiceAccountsResponseServiceAccount struct {
+	// Author Author is the author of the service account.
+	Author *ServiceAccountAuthor `json:"author,omitempty"`
+
+	// CreateTime CreateTime is the timestamp when the service account was created.
+	CreateTime *time.Time `json:"createTime,omitempty"`
+
+	// Description Description is the description of the service account.
+	Description *string `json:"description,omitempty"`
+
+	// Email Email is the email of the service account.
+	Email *string `json:"email,omitempty"`
+
+	// Id ID is the unique identifier of the service account.
+	Id *string `json:"id,omitempty"`
+
+	// ManagedBy Method used to create the service account, e.g.: console, terraform.
+	ManagedBy *string `json:"managedBy,omitempty"`
+
+	// Name Name is the name of the service account.
+	Name *string `json:"name,omitempty"`
+
+	// OrganizationId OrganizationID is the organization this service account belongs to.
+	OrganizationId *string `json:"organizationId,omitempty"`
+}
 
 // ListGroupsResponse Response message containing the list of groups in the enterprise organization
 type ListGroupsResponse struct {
@@ -1132,6 +1237,18 @@ type ServiceAccountSubject struct {
 	Name *string `json:"name,omitempty"`
 }
 
+// ServiceAccountAuthor Author is the author of the service account.
+type ServiceAccountAuthor struct {
+	// Email Email is the email of the author.
+	Email *string `json:"email,omitempty"`
+
+	// Id ID is the unique identifier of the author.
+	Id *string `json:"id,omitempty"`
+
+	// Kind Kind is the kind of the author (e.g. "user").
+	Kind *string `json:"kind,omitempty"`
+}
+
 // Status The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).
 type Status struct {
 	// Code The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
@@ -1277,6 +1394,29 @@ type EnterpriseAPIListRoleBindingsParams struct {
 	//  &subject_id=x&subject_id=y)
 	SubjectId *[]string `form:"subjectId,omitempty" json:"subjectId,omitempty"`
 }
+
+// EnterpriseAPIListEnterpriseServiceAccountsParams defines parameters for EnterpriseAPIListEnterpriseServiceAccounts.
+type EnterpriseAPIListEnterpriseServiceAccountsParams struct {
+	// PageLimit Defines the number of items that should be returned
+	PageLimit *string `form:"page.limit,omitempty" json:"page.limit,omitempty"`
+
+	// PageCursor Cursor that defines token indicating where to start the next page.
+	//  Empty value indicates to start from beginning of the dataset.
+	PageCursor *string `form:"page.cursor,omitempty" json:"page.cursor,omitempty"`
+
+	// OrganizationId Filter by organization ID. Multiple values can be passed as query
+	//  parameters (e.g., &organization_id=x&organization_id=y).
+	OrganizationId *[]string `form:"organizationId,omitempty" json:"organizationId,omitempty"`
+
+	// SortField The field name to order by. Nested fields can be specified by using a dot (e.g. user.name).
+	SortField *string `form:"sort.field,omitempty" json:"sort.field,omitempty"`
+
+	// SortOrder The order of returned items. Default is ASC.
+	SortOrder *EnterpriseAPIListEnterpriseServiceAccountsParamsSortOrder `form:"sort.order,omitempty" json:"sort.order,omitempty"`
+}
+
+// EnterpriseAPIListEnterpriseServiceAccountsParamsSortOrder defines parameters for EnterpriseAPIListEnterpriseServiceAccounts.
+type EnterpriseAPIListEnterpriseServiceAccountsParamsSortOrder string
 
 // EnterpriseAPIBatchCreateEnterpriseGroupsJSONRequestBody defines body for EnterpriseAPIBatchCreateEnterpriseGroups for application/json ContentType.
 type EnterpriseAPIBatchCreateEnterpriseGroupsJSONRequestBody = BatchCreateEnterpriseGroupsRequest

--- a/castai/sdk/organization_management/client.gen.go
+++ b/castai/sdk/organization_management/client.gen.go
@@ -93,6 +93,9 @@ type ClientInterface interface {
 	// EnterpriseAPIListGroups request
 	EnterpriseAPIListGroups(ctx context.Context, enterpriseId string, params *EnterpriseAPIListGroupsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// EnterpriseAPIGetEnterpriseGroup request
+	EnterpriseAPIGetEnterpriseGroup(ctx context.Context, enterpriseId string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// EnterpriseAPIBatchCreateEnterpriseGroupsWithBody request with any body
 	EnterpriseAPIBatchCreateEnterpriseGroupsWithBody(ctx context.Context, enterpriseId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -145,6 +148,9 @@ type ClientInterface interface {
 
 	EnterpriseAPIBatchUpdateEnterpriseRoleBindings(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchUpdateEnterpriseRoleBindingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// EnterpriseAPIListEnterpriseServiceAccounts request
+	EnterpriseAPIListEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, params *EnterpriseAPIListEnterpriseServiceAccountsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// EnterpriseAPIAddUserToChildOrganizationWithBody request with any body
 	EnterpriseAPIAddUserToChildOrganizationWithBody(ctx context.Context, enterpriseId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -158,6 +164,18 @@ type ClientInterface interface {
 
 func (c *Client) EnterpriseAPIListGroups(ctx context.Context, enterpriseId string, params *EnterpriseAPIListGroupsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewEnterpriseAPIListGroupsRequest(c.Server, enterpriseId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EnterpriseAPIGetEnterpriseGroup(ctx context.Context, enterpriseId string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEnterpriseAPIGetEnterpriseGroupRequest(c.Server, enterpriseId, id)
 	if err != nil {
 		return nil, err
 	}
@@ -408,6 +426,18 @@ func (c *Client) EnterpriseAPIBatchUpdateEnterpriseRoleBindings(ctx context.Cont
 	return c.Client.Do(req)
 }
 
+func (c *Client) EnterpriseAPIListEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, params *EnterpriseAPIListEnterpriseServiceAccountsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEnterpriseAPIListEnterpriseServiceAccountsRequest(c.Server, enterpriseId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) EnterpriseAPIAddUserToChildOrganizationWithBody(ctx context.Context, enterpriseId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewEnterpriseAPIAddUserToChildOrganizationRequestWithBody(c.Server, enterpriseId, contentType, body)
 	if err != nil {
@@ -582,6 +612,47 @@ func NewEnterpriseAPIListGroupsRequest(server string, enterpriseId string, param
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewEnterpriseAPIGetEnterpriseGroupRequest generates requests for EnterpriseAPIGetEnterpriseGroup
+func NewEnterpriseAPIGetEnterpriseGroupRequest(server string, enterpriseId string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "enterpriseId", runtime.ParamLocationPath, enterpriseId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/organization-management/v1/enterprises/%s/groups/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -1433,6 +1504,126 @@ func NewEnterpriseAPIBatchUpdateEnterpriseRoleBindingsRequestWithBody(server str
 	return req, nil
 }
 
+// NewEnterpriseAPIListEnterpriseServiceAccountsRequest generates requests for EnterpriseAPIListEnterpriseServiceAccounts
+func NewEnterpriseAPIListEnterpriseServiceAccountsRequest(server string, enterpriseId string, params *EnterpriseAPIListEnterpriseServiceAccountsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "enterpriseId", runtime.ParamLocationPath, enterpriseId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/organization-management/v1/enterprises/%s/service-accounts", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PageLimit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.limit", runtime.ParamLocationQuery, *params.PageLimit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PageCursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.cursor", runtime.ParamLocationQuery, *params.PageCursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.OrganizationId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "organizationId", runtime.ParamLocationQuery, *params.OrganizationId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.SortField != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "sort.field", runtime.ParamLocationQuery, *params.SortField); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.SortOrder != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "sort.order", runtime.ParamLocationQuery, *params.SortOrder); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewEnterpriseAPIAddUserToChildOrganizationRequest calls the generic EnterpriseAPIAddUserToChildOrganization builder with application/json body
 func NewEnterpriseAPIAddUserToChildOrganizationRequest(server string, enterpriseId string, body EnterpriseAPIAddUserToChildOrganizationJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -1574,6 +1765,9 @@ type ClientWithResponsesInterface interface {
 	// EnterpriseAPIListGroups request
 	EnterpriseAPIListGroupsWithResponse(ctx context.Context, enterpriseId string, params *EnterpriseAPIListGroupsParams) (*EnterpriseAPIListGroupsResponse, error)
 
+	// EnterpriseAPIGetEnterpriseGroup request
+	EnterpriseAPIGetEnterpriseGroupWithResponse(ctx context.Context, enterpriseId string, id string) (*EnterpriseAPIGetEnterpriseGroupResponse, error)
+
 	// EnterpriseAPIBatchCreateEnterpriseGroups request  with any body
 	EnterpriseAPIBatchCreateEnterpriseGroupsWithBodyWithResponse(ctx context.Context, enterpriseId string, contentType string, body io.Reader) (*EnterpriseAPIBatchCreateEnterpriseGroupsResponse, error)
 
@@ -1626,6 +1820,9 @@ type ClientWithResponsesInterface interface {
 
 	EnterpriseAPIBatchUpdateEnterpriseRoleBindingsWithResponse(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchUpdateEnterpriseRoleBindingsJSONRequestBody) (*EnterpriseAPIBatchUpdateEnterpriseRoleBindingsResponse, error)
 
+	// EnterpriseAPIListEnterpriseServiceAccounts request
+	EnterpriseAPIListEnterpriseServiceAccountsWithResponse(ctx context.Context, enterpriseId string, params *EnterpriseAPIListEnterpriseServiceAccountsParams) (*EnterpriseAPIListEnterpriseServiceAccountsResponse, error)
+
 	// EnterpriseAPIAddUserToChildOrganization request  with any body
 	EnterpriseAPIAddUserToChildOrganizationWithBodyWithResponse(ctx context.Context, enterpriseId string, contentType string, body io.Reader) (*EnterpriseAPIAddUserToChildOrganizationResponse, error)
 
@@ -1672,6 +1869,37 @@ func (r EnterpriseAPIListGroupsResponse) StatusCode() int {
 // TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 // Body returns body of byte array
 func (r EnterpriseAPIListGroupsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
+type EnterpriseAPIGetEnterpriseGroupResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *GetEnterpriseGroupResponse
+	JSONDefault  *Status
+}
+
+// Status returns HTTPResponse.Status
+func (r EnterpriseAPIGetEnterpriseGroupResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EnterpriseAPIGetEnterpriseGroupResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r EnterpriseAPIGetEnterpriseGroupResponse) GetBody() []byte {
 	return r.Body
 }
 
@@ -2046,6 +2274,37 @@ func (r EnterpriseAPIBatchUpdateEnterpriseRoleBindingsResponse) GetBody() []byte
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
+type EnterpriseAPIListEnterpriseServiceAccountsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ListEnterpriseServiceAccountsResponse
+	JSONDefault  *Status
+}
+
+// Status returns HTTPResponse.Status
+func (r EnterpriseAPIListEnterpriseServiceAccountsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EnterpriseAPIListEnterpriseServiceAccountsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r EnterpriseAPIListEnterpriseServiceAccountsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
 type EnterpriseAPIAddUserToChildOrganizationResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -2115,6 +2374,15 @@ func (c *ClientWithResponses) EnterpriseAPIListGroupsWithResponse(ctx context.Co
 		return nil, err
 	}
 	return ParseEnterpriseAPIListGroupsResponse(rsp)
+}
+
+// EnterpriseAPIGetEnterpriseGroupWithResponse request returning *EnterpriseAPIGetEnterpriseGroupResponse
+func (c *ClientWithResponses) EnterpriseAPIGetEnterpriseGroupWithResponse(ctx context.Context, enterpriseId string, id string) (*EnterpriseAPIGetEnterpriseGroupResponse, error) {
+	rsp, err := c.EnterpriseAPIGetEnterpriseGroup(ctx, enterpriseId, id)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEnterpriseAPIGetEnterpriseGroupResponse(rsp)
 }
 
 // EnterpriseAPIBatchCreateEnterpriseGroupsWithBodyWithResponse request with arbitrary body returning *EnterpriseAPIBatchCreateEnterpriseGroupsResponse
@@ -2289,6 +2557,15 @@ func (c *ClientWithResponses) EnterpriseAPIBatchUpdateEnterpriseRoleBindingsWith
 	return ParseEnterpriseAPIBatchUpdateEnterpriseRoleBindingsResponse(rsp)
 }
 
+// EnterpriseAPIListEnterpriseServiceAccountsWithResponse request returning *EnterpriseAPIListEnterpriseServiceAccountsResponse
+func (c *ClientWithResponses) EnterpriseAPIListEnterpriseServiceAccountsWithResponse(ctx context.Context, enterpriseId string, params *EnterpriseAPIListEnterpriseServiceAccountsParams) (*EnterpriseAPIListEnterpriseServiceAccountsResponse, error) {
+	rsp, err := c.EnterpriseAPIListEnterpriseServiceAccounts(ctx, enterpriseId, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEnterpriseAPIListEnterpriseServiceAccountsResponse(rsp)
+}
+
 // EnterpriseAPIAddUserToChildOrganizationWithBodyWithResponse request with arbitrary body returning *EnterpriseAPIAddUserToChildOrganizationResponse
 func (c *ClientWithResponses) EnterpriseAPIAddUserToChildOrganizationWithBodyWithResponse(ctx context.Context, enterpriseId string, contentType string, body io.Reader) (*EnterpriseAPIAddUserToChildOrganizationResponse, error) {
 	rsp, err := c.EnterpriseAPIAddUserToChildOrganizationWithBody(ctx, enterpriseId, contentType, body)
@@ -2339,6 +2616,39 @@ func ParseEnterpriseAPIListGroupsResponse(rsp *http.Response) (*EnterpriseAPILis
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ListGroupsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest Status
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEnterpriseAPIGetEnterpriseGroupResponse parses an HTTP response from a EnterpriseAPIGetEnterpriseGroupWithResponse call
+func ParseEnterpriseAPIGetEnterpriseGroupResponse(rsp *http.Response) (*EnterpriseAPIGetEnterpriseGroupResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EnterpriseAPIGetEnterpriseGroupResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest GetEnterpriseGroupResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -2714,6 +3024,39 @@ func ParseEnterpriseAPIBatchUpdateEnterpriseRoleBindingsResponse(rsp *http.Respo
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest BatchUpdateEnterpriseRoleBindingsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest Status
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEnterpriseAPIListEnterpriseServiceAccountsResponse parses an HTTP response from a EnterpriseAPIListEnterpriseServiceAccountsWithResponse call
+func ParseEnterpriseAPIListEnterpriseServiceAccountsResponse(rsp *http.Response) (*EnterpriseAPIListEnterpriseServiceAccountsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EnterpriseAPIListEnterpriseServiceAccountsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListEnterpriseServiceAccountsResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/castai/sdk/organization_management/mock/client.go
+++ b/castai/sdk/organization_management/mock/client.go
@@ -415,6 +415,26 @@ func (mr *MockClientInterfaceMockRecorder) EnterpriseAPIDeleteChildOrganization(
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIDeleteChildOrganization", reflect.TypeOf((*MockClientInterface)(nil).EnterpriseAPIDeleteChildOrganization), varargs...)
 }
 
+// EnterpriseAPIGetEnterpriseGroup mocks base method.
+func (m *MockClientInterface) EnterpriseAPIGetEnterpriseGroup(ctx context.Context, enterpriseId, id string, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, id}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIGetEnterpriseGroup", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIGetEnterpriseGroup indicates an expected call of EnterpriseAPIGetEnterpriseGroup.
+func (mr *MockClientInterfaceMockRecorder) EnterpriseAPIGetEnterpriseGroup(ctx, enterpriseId, id interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, id}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIGetEnterpriseGroup", reflect.TypeOf((*MockClientInterface)(nil).EnterpriseAPIGetEnterpriseGroup), varargs...)
+}
+
 // EnterpriseAPIInviteUsers mocks base method.
 func (m *MockClientInterface) EnterpriseAPIInviteUsers(ctx context.Context, enterpriseId string, body organization_management.EnterpriseAPIInviteUsersJSONRequestBody, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -473,6 +493,26 @@ func (mr *MockClientInterfaceMockRecorder) EnterpriseAPIListChildrenOrganization
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, enterpriseId, params}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIListChildrenOrganizations", reflect.TypeOf((*MockClientInterface)(nil).EnterpriseAPIListChildrenOrganizations), varargs...)
+}
+
+// EnterpriseAPIListEnterpriseServiceAccounts mocks base method.
+func (m *MockClientInterface) EnterpriseAPIListEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, params *organization_management.EnterpriseAPIListEnterpriseServiceAccountsParams, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIListEnterpriseServiceAccounts", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIListEnterpriseServiceAccounts indicates an expected call of EnterpriseAPIListEnterpriseServiceAccounts.
+func (mr *MockClientInterfaceMockRecorder) EnterpriseAPIListEnterpriseServiceAccounts(ctx, enterpriseId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIListEnterpriseServiceAccounts", reflect.TypeOf((*MockClientInterface)(nil).EnterpriseAPIListEnterpriseServiceAccounts), varargs...)
 }
 
 // EnterpriseAPIListGroups mocks base method.
@@ -1193,6 +1233,41 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIDeleteChild
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIDeleteChildOrganizationWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIDeleteChildOrganizationWithResponse), ctx, enterpriseId, id)
 }
 
+// EnterpriseAPIGetEnterpriseGroup mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIGetEnterpriseGroup(ctx context.Context, enterpriseId, id string, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, id}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIGetEnterpriseGroup", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIGetEnterpriseGroup indicates an expected call of EnterpriseAPIGetEnterpriseGroup.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIGetEnterpriseGroup(ctx, enterpriseId, id interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, id}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIGetEnterpriseGroup", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIGetEnterpriseGroup), varargs...)
+}
+
+// EnterpriseAPIGetEnterpriseGroupWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIGetEnterpriseGroupWithResponse(ctx context.Context, enterpriseId, id string) (*organization_management.EnterpriseAPIGetEnterpriseGroupResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnterpriseAPIGetEnterpriseGroupWithResponse", ctx, enterpriseId, id)
+	ret0, _ := ret[0].(*organization_management.EnterpriseAPIGetEnterpriseGroupResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIGetEnterpriseGroupWithResponse indicates an expected call of EnterpriseAPIGetEnterpriseGroupWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIGetEnterpriseGroupWithResponse(ctx, enterpriseId, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIGetEnterpriseGroupWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIGetEnterpriseGroupWithResponse), ctx, enterpriseId, id)
+}
+
 // EnterpriseAPIInviteUsers mocks base method.
 func (m *MockClientWithResponsesInterface) EnterpriseAPIInviteUsers(ctx context.Context, enterpriseId string, body organization_management.EnterpriseAPIInviteUsersJSONRequestBody, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -1296,6 +1371,41 @@ func (m *MockClientWithResponsesInterface) EnterpriseAPIListChildrenOrganization
 func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIListChildrenOrganizationsWithResponse(ctx, enterpriseId, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIListChildrenOrganizationsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIListChildrenOrganizationsWithResponse), ctx, enterpriseId, params)
+}
+
+// EnterpriseAPIListEnterpriseServiceAccounts mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIListEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, params *organization_management.EnterpriseAPIListEnterpriseServiceAccountsParams, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIListEnterpriseServiceAccounts", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIListEnterpriseServiceAccounts indicates an expected call of EnterpriseAPIListEnterpriseServiceAccounts.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIListEnterpriseServiceAccounts(ctx, enterpriseId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIListEnterpriseServiceAccounts", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIListEnterpriseServiceAccounts), varargs...)
+}
+
+// EnterpriseAPIListEnterpriseServiceAccountsWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIListEnterpriseServiceAccountsWithResponse(ctx context.Context, enterpriseId string, params *organization_management.EnterpriseAPIListEnterpriseServiceAccountsParams) (*organization_management.EnterpriseAPIListEnterpriseServiceAccountsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnterpriseAPIListEnterpriseServiceAccountsWithResponse", ctx, enterpriseId, params)
+	ret0, _ := ret[0].(*organization_management.EnterpriseAPIListEnterpriseServiceAccountsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIListEnterpriseServiceAccountsWithResponse indicates an expected call of EnterpriseAPIListEnterpriseServiceAccountsWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIListEnterpriseServiceAccountsWithResponse(ctx, enterpriseId, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIListEnterpriseServiceAccountsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIListEnterpriseServiceAccountsWithResponse), ctx, enterpriseId, params)
 }
 
 // EnterpriseAPIListGroups mocks base method.


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Fixes OCI edge location and edge configuration acceptance tests by passing `clusterName` through shared test helpers instead of hardcoding it. Also regenerates the CAST AI SDK to pick up new enterprise organization management APIs, updated service account fields, and revised rebalancing option documentation.

### Why
The acceptance tests for OCI edge resources were failing because the cluster name was not properly propagated to nested Terraform test configurations. The SDK refresh syncs the provider with the latest platform API definitions.

### Key changes
- `castai/resource_edge_location_test.go`: Updated `testAccEdgeLocationOCIConfig`, `testAccEdgeLocationOCIUpdated`, `testAccEdgeLocationOCICredentialsUpdated`, and `testAccEdgeLocationOCIConfigWithParams` to accept a `clusterName` argument.
- `castai/resource_edge_configuration_test.go`: Updated `testAccEdgeConfigurationOCIConfig` and `testAccEdgeConfigurationOCIUpdated` to pass `clusterName` into `testAccEdgeLocationOCIConfig`.
- `castai/sdk/api.gen.go`: Added `KeysCount` to `CastaiServiceaccountsV1beta1ServiceAccount`, added `IsRoxy` to `DboV1UninstallCacheParams`, added deprecation notice to `KeepDrainTimeoutNodes` in `ScheduledrebalancingV1RebalancingOptions`, and updated clamp/default documentation for `UncordonAfterSeconds`.
- `castai/sdk/organization_management/api.gen.go`: Added `GetEnterpriseGroupResponse`, `ListEnterpriseServiceAccountsResponse`, `ServiceAccountAuthor`, and related parameter types; introduced SSO provider and sort order constants.
- `castai/sdk/organization_management/client.gen.go`: Added `EnterpriseAPIGetEnterpriseGroup` and `EnterpriseAPIListEnterpriseServiceAccounts` request/response methods and parsers.
- `castai/sdk/organization_management/mock/client.go`: Added generated mock methods for the new enterprise group and enterprise service account endpoints.

### Impact
- `KeepDrainTimeoutNodes` is now formally deprecated in the generated SDK; use `evictGracefully` instead.
- Existing sort order constants in the organization management SDK were renamed to fully-qualified identifiers (e.g., `ASC` → `EnterpriseAPIListChildrenOrganizationsParamsSortOrderASC`). Any code importing these constants directly must be updated.