### PR TITLE
feat: add parameters to DeleteCacheGroup calls

### DIFF
--- a/castai/resource_cache_group.go
+++ b/castai/resource_cache_group.go
@@ -177,7 +177,7 @@ func resourceCacheGroupUpdate(ctx context.Context, d *schema.ResourceData, meta 
 func resourceCacheGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderConfig).api
 
-	resp, err := client.DboAPIDeleteCacheGroupWithResponse(ctx, d.Id())
+	resp, err := client.DboAPIDeleteCacheGroupWithResponse(ctx, d.Id(), nil)
 	if err := sdk.CheckOKResponse(resp, err); err != nil {
 		return diag.FromErr(err)
 	}

--- a/castai/resource_cache_group_test.go
+++ b/castai/resource_cache_group_test.go
@@ -206,7 +206,7 @@ func TestCacheGroupResource_Delete(t *testing.T) {
 	deleteResponse := sdk.DboV1DeleteCacheGroupResponse{}
 	deleteBody, _ := json.Marshal(deleteResponse)
 	mockClient.EXPECT().
-		DboAPIDeleteCacheGroup(ctx, cacheGroupID).
+		DboAPIDeleteCacheGroup(ctx, cacheGroupID, nil).
 		Return(&http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header{"Content-Type": []string{"application/json"}},

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -3853,11 +3853,6 @@ type CastaiUsersV1beta1NewMembershipByEmail struct {
 	// RoleBindings The role bindings the user will be bound to after the invitation is claimed.
 	RoleBindings *[]CastaiUsersV1beta1InvitationRoleBinding `json:"roleBindings,omitempty"`
 
-	// RoleId Deprecated: Use role bindings instead.
-	// string roleID.
-	// Deprecated:
-	RoleId *string `json:"roleId,omitempty"`
-
 	// UserEmail email of the invited person.
 	UserEmail string `json:"userEmail"`
 }
@@ -3916,11 +3911,6 @@ type CastaiUsersV1beta1PendingInvitation struct {
 
 	// RoleBindings The role bindings the user will be bound to after the invitation is claimed.
 	RoleBindings *[]CastaiUsersV1beta1InvitationRoleBinding `json:"roleBindings,omitempty"`
-
-	// RoleId Deprecated: Use role bindings instead.
-	// role_id is the role ID of the invited person.
-	// Deprecated:
-	RoleId *string `json:"roleId,omitempty"`
 
 	// ValidUntil invitation expiration date.
 	ValidUntil *time.Time `json:"validUntil,omitempty"`
@@ -4604,6 +4594,7 @@ type DboV1CacheGroup struct {
 
 	// ProtocolType ProtocolType specifies the protocol type used by the database.
 	ProtocolType     DboV1CacheGroupProtocolType      `json:"protocolType"`
+	Roxy             *bool                            `json:"roxy,omitempty"`
 	StatusConditions *DboV1CacheGroupStatusConditions `json:"statusConditions,omitempty"`
 	Version          *int32                           `json:"version,omitempty"`
 }
@@ -5400,7 +5391,7 @@ type DboV1TrafficInsightsType string
 // DboV1UninstallCacheParams defines model for dbo.v1.UninstallCacheParams.
 type DboV1UninstallCacheParams struct {
 	CacheGroupId string `json:"cacheGroupId"`
-	IsRoxy       *bool  `json:"isRoxy"`
+	Roxy         *bool  `json:"roxy"`
 }
 
 // DboV1UninstallDBAgentParams defines model for dbo.v1.UninstallDBAgentParams.
@@ -11591,6 +11582,11 @@ type DboAPIGetCacheSummaryParams struct {
 
 	// Username Filter by username.
 	Username *string `form:"username,omitempty" json:"username,omitempty"`
+}
+
+// DboAPIDeleteCacheGroupParams defines parameters for DboAPIDeleteCacheGroup.
+type DboAPIDeleteCacheGroupParams struct {
+	Roxy *bool `form:"roxy,omitempty" json:"roxy,omitempty"`
 }
 
 // DboAPIGetCacheGroupParams defines parameters for DboAPIGetCacheGroup.

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -247,7 +247,7 @@ type ClientInterface interface {
 	DboAPICreateCacheDiagnosticUploadURL(ctx context.Context, groupId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DboAPIDeleteCacheGroup request
-	DboAPIDeleteCacheGroup(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	DboAPIDeleteCacheGroup(ctx context.Context, id string, params *DboAPIDeleteCacheGroupParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DboAPIGetCacheGroup request
 	DboAPIGetCacheGroup(ctx context.Context, id string, params *DboAPIGetCacheGroupParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1718,8 +1718,8 @@ func (c *Client) DboAPICreateCacheDiagnosticUploadURL(ctx context.Context, group
 	return c.Client.Do(req)
 }
 
-func (c *Client) DboAPIDeleteCacheGroup(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDboAPIDeleteCacheGroupRequest(c.Server, id)
+func (c *Client) DboAPIDeleteCacheGroup(ctx context.Context, id string, params *DboAPIDeleteCacheGroupParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDboAPIDeleteCacheGroupRequest(c.Server, id, params)
 	if err != nil {
 		return nil, err
 	}
@@ -8328,7 +8328,7 @@ func NewDboAPICreateCacheDiagnosticUploadURLRequest(server string, groupId strin
 }
 
 // NewDboAPIDeleteCacheGroupRequest generates requests for DboAPIDeleteCacheGroup
-func NewDboAPIDeleteCacheGroupRequest(server string, id string) (*http.Request, error) {
+func NewDboAPIDeleteCacheGroupRequest(server string, id string, params *DboAPIDeleteCacheGroupParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -8351,6 +8351,28 @@ func NewDboAPIDeleteCacheGroupRequest(server string, id string) (*http.Request, 
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Roxy != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "roxy", runtime.ParamLocationQuery, *params.Roxy); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
@@ -21738,7 +21760,7 @@ type ClientWithResponsesInterface interface {
 	DboAPICreateCacheDiagnosticUploadURLWithResponse(ctx context.Context, groupId string) (*DboAPICreateCacheDiagnosticUploadURLResponse, error)
 
 	// DboAPIDeleteCacheGroup request
-	DboAPIDeleteCacheGroupWithResponse(ctx context.Context, id string) (*DboAPIDeleteCacheGroupResponse, error)
+	DboAPIDeleteCacheGroupWithResponse(ctx context.Context, id string, params *DboAPIDeleteCacheGroupParams) (*DboAPIDeleteCacheGroupResponse, error)
 
 	// DboAPIGetCacheGroup request
 	DboAPIGetCacheGroupWithResponse(ctx context.Context, id string, params *DboAPIGetCacheGroupParams) (*DboAPIGetCacheGroupResponse, error)
@@ -30867,8 +30889,8 @@ func (c *ClientWithResponses) DboAPICreateCacheDiagnosticUploadURLWithResponse(c
 }
 
 // DboAPIDeleteCacheGroupWithResponse request returning *DboAPIDeleteCacheGroupResponse
-func (c *ClientWithResponses) DboAPIDeleteCacheGroupWithResponse(ctx context.Context, id string) (*DboAPIDeleteCacheGroupResponse, error) {
-	rsp, err := c.DboAPIDeleteCacheGroup(ctx, id)
+func (c *ClientWithResponses) DboAPIDeleteCacheGroupWithResponse(ctx context.Context, id string, params *DboAPIDeleteCacheGroupParams) (*DboAPIDeleteCacheGroupResponse, error) {
+	rsp, err := c.DboAPIDeleteCacheGroup(ctx, id, params)
 	if err != nil {
 		return nil, err
 	}

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -1276,9 +1276,9 @@ func (mr *MockClientInterfaceMockRecorder) DboAPIDeleteCacheConfiguration(ctx, g
 }
 
 // DboAPIDeleteCacheGroup mocks base method.
-func (m *MockClientInterface) DboAPIDeleteCacheGroup(ctx context.Context, id string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+func (m *MockClientInterface) DboAPIDeleteCacheGroup(ctx context.Context, id string, params *sdk.DboAPIDeleteCacheGroupParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, id}
+	varargs := []interface{}{ctx, id, params}
 	for _, a := range reqEditors {
 		varargs = append(varargs, a)
 	}
@@ -1289,9 +1289,9 @@ func (m *MockClientInterface) DboAPIDeleteCacheGroup(ctx context.Context, id str
 }
 
 // DboAPIDeleteCacheGroup indicates an expected call of DboAPIDeleteCacheGroup.
-func (mr *MockClientInterfaceMockRecorder) DboAPIDeleteCacheGroup(ctx, id interface{}, reqEditors ...interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) DboAPIDeleteCacheGroup(ctx, id, params interface{}, reqEditors ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, id}, reqEditors...)
+	varargs := append([]interface{}{ctx, id, params}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIDeleteCacheGroup", reflect.TypeOf((*MockClientInterface)(nil).DboAPIDeleteCacheGroup), varargs...)
 }
 
@@ -9139,9 +9139,9 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIDeleteCacheConfigu
 }
 
 // DboAPIDeleteCacheGroup mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPIDeleteCacheGroup(ctx context.Context, id string, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+func (m *MockClientWithResponsesInterface) DboAPIDeleteCacheGroup(ctx context.Context, id string, params *sdk.DboAPIDeleteCacheGroupParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, id}
+	varargs := []interface{}{ctx, id, params}
 	for _, a := range reqEditors {
 		varargs = append(varargs, a)
 	}
@@ -9152,25 +9152,25 @@ func (m *MockClientWithResponsesInterface) DboAPIDeleteCacheGroup(ctx context.Co
 }
 
 // DboAPIDeleteCacheGroup indicates an expected call of DboAPIDeleteCacheGroup.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIDeleteCacheGroup(ctx, id interface{}, reqEditors ...interface{}) *gomock.Call {
+func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIDeleteCacheGroup(ctx, id, params interface{}, reqEditors ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, id}, reqEditors...)
+	varargs := append([]interface{}{ctx, id, params}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIDeleteCacheGroup", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIDeleteCacheGroup), varargs...)
 }
 
 // DboAPIDeleteCacheGroupWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) DboAPIDeleteCacheGroupWithResponse(ctx context.Context, id string) (*sdk.DboAPIDeleteCacheGroupResponse, error) {
+func (m *MockClientWithResponsesInterface) DboAPIDeleteCacheGroupWithResponse(ctx context.Context, id string, params *sdk.DboAPIDeleteCacheGroupParams) (*sdk.DboAPIDeleteCacheGroupResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DboAPIDeleteCacheGroupWithResponse", ctx, id)
+	ret := m.ctrl.Call(m, "DboAPIDeleteCacheGroupWithResponse", ctx, id, params)
 	ret0, _ := ret[0].(*sdk.DboAPIDeleteCacheGroupResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DboAPIDeleteCacheGroupWithResponse indicates an expected call of DboAPIDeleteCacheGroupWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIDeleteCacheGroupWithResponse(ctx, id interface{}) *gomock.Call {
+func (mr *MockClientWithResponsesInterfaceMockRecorder) DboAPIDeleteCacheGroupWithResponse(ctx, id, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIDeleteCacheGroupWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIDeleteCacheGroupWithResponse), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DboAPIDeleteCacheGroupWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).DboAPIDeleteCacheGroupWithResponse), ctx, id, params)
 }
 
 // DboAPIDeleteCacheTTL mocks base method.

--- a/castai/sdk/organization_management/api.gen.go
+++ b/castai/sdk/organization_management/api.gen.go
@@ -356,6 +356,25 @@ type BatchDeleteEnterpriseRoleBindingsRequestDeleteRoleBindingRequest struct {
 	OrganizationId string `json:"organizationId"`
 }
 
+// BatchDeleteEnterpriseServiceAccountsRequest Request message for batch deleting enterprise service accounts.
+type BatchDeleteEnterpriseServiceAccountsRequest struct {
+	// EnterpriseId ID of the enterprise organization.
+	EnterpriseId string `json:"enterpriseId"`
+
+	// Requests The requests specifying the service accounts to delete.
+	//  A maximum of 100 service accounts can be deleted in a batch.
+	Requests []BatchDeleteEnterpriseServiceAccountsRequestDeleteServiceAccountRequest `json:"requests"`
+}
+
+// BatchDeleteEnterpriseServiceAccountsRequestDeleteServiceAccountRequest Request message for deleting a single service account.
+type BatchDeleteEnterpriseServiceAccountsRequestDeleteServiceAccountRequest struct {
+	// Id The ID of the service account to delete.
+	Id string `json:"id"`
+
+	// OrganizationId Organization ID — must be the enterprise itself or a direct child (deleted_at IS NULL).
+	OrganizationId string `json:"organizationId"`
+}
+
 // BatchUpdateEnterpriseGroupsRequest Request message for batch updating groups in an enterprise
 type BatchUpdateEnterpriseGroupsRequest struct {
 	// EnterpriseId Required field that identifies the enterprise.
@@ -1471,6 +1490,9 @@ type EnterpriseAPIBatchUpdateEnterpriseRoleBindingsJSONRequestBody = BatchUpdate
 
 // EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody defines body for EnterpriseAPIBatchCreateEnterpriseServiceAccounts for application/json ContentType.
 type EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody = BatchCreateEnterpriseServiceAccountsRequest
+
+// EnterpriseAPIBatchDeleteEnterpriseServiceAccountsJSONRequestBody defines body for EnterpriseAPIBatchDeleteEnterpriseServiceAccounts for application/json ContentType.
+type EnterpriseAPIBatchDeleteEnterpriseServiceAccountsJSONRequestBody = BatchDeleteEnterpriseServiceAccountsRequest
 
 // EnterpriseAPIAddUserToChildOrganizationJSONRequestBody defines body for EnterpriseAPIAddUserToChildOrganization for application/json ContentType.
 type EnterpriseAPIAddUserToChildOrganizationJSONRequestBody = AddUserToChildOrganizationRequest

--- a/castai/sdk/organization_management/client.gen.go
+++ b/castai/sdk/organization_management/client.gen.go
@@ -156,6 +156,11 @@ type ClientInterface interface {
 
 	EnterpriseAPIBatchCreateEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody request with any body
+	EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody(ctx context.Context, enterpriseId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	EnterpriseAPIBatchDeleteEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchDeleteEnterpriseServiceAccountsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// EnterpriseAPIAddUserToChildOrganizationWithBody request with any body
 	EnterpriseAPIAddUserToChildOrganizationWithBody(ctx context.Context, enterpriseId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -457,6 +462,30 @@ func (c *Client) EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBody(ctx c
 
 func (c *Client) EnterpriseAPIBatchCreateEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewEnterpriseAPIBatchCreateEnterpriseServiceAccountsRequest(c.Server, enterpriseId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody(ctx context.Context, enterpriseId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEnterpriseAPIBatchDeleteEnterpriseServiceAccountsRequestWithBody(c.Server, enterpriseId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EnterpriseAPIBatchDeleteEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchDeleteEnterpriseServiceAccountsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEnterpriseAPIBatchDeleteEnterpriseServiceAccountsRequest(c.Server, enterpriseId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1700,6 +1729,53 @@ func NewEnterpriseAPIBatchCreateEnterpriseServiceAccountsRequestWithBody(server 
 	return req, nil
 }
 
+// NewEnterpriseAPIBatchDeleteEnterpriseServiceAccountsRequest calls the generic EnterpriseAPIBatchDeleteEnterpriseServiceAccounts builder with application/json body
+func NewEnterpriseAPIBatchDeleteEnterpriseServiceAccountsRequest(server string, enterpriseId string, body EnterpriseAPIBatchDeleteEnterpriseServiceAccountsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEnterpriseAPIBatchDeleteEnterpriseServiceAccountsRequestWithBody(server, enterpriseId, "application/json", bodyReader)
+}
+
+// NewEnterpriseAPIBatchDeleteEnterpriseServiceAccountsRequestWithBody generates requests for EnterpriseAPIBatchDeleteEnterpriseServiceAccounts with any type of body
+func NewEnterpriseAPIBatchDeleteEnterpriseServiceAccountsRequestWithBody(server string, enterpriseId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "enterpriseId", runtime.ParamLocationPath, enterpriseId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/organization-management/v1/enterprises/%s/service-accounts:batchDelete", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewEnterpriseAPIAddUserToChildOrganizationRequest calls the generic EnterpriseAPIAddUserToChildOrganization builder with application/json body
 func NewEnterpriseAPIAddUserToChildOrganizationRequest(server string, enterpriseId string, body EnterpriseAPIAddUserToChildOrganizationJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -1903,6 +1979,11 @@ type ClientWithResponsesInterface interface {
 	EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithBodyWithResponse(ctx context.Context, enterpriseId string, contentType string, body io.Reader) (*EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse, error)
 
 	EnterpriseAPIBatchCreateEnterpriseServiceAccountsWithResponse(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody) (*EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse, error)
+
+	// EnterpriseAPIBatchDeleteEnterpriseServiceAccounts request  with any body
+	EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBodyWithResponse(ctx context.Context, enterpriseId string, contentType string, body io.Reader) (*EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse, error)
+
+	EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithResponse(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchDeleteEnterpriseServiceAccountsJSONRequestBody) (*EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse, error)
 
 	// EnterpriseAPIAddUserToChildOrganization request  with any body
 	EnterpriseAPIAddUserToChildOrganizationWithBodyWithResponse(ctx context.Context, enterpriseId string, contentType string, body io.Reader) (*EnterpriseAPIAddUserToChildOrganizationResponse, error)
@@ -2417,6 +2498,36 @@ func (r EnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse) GetBody() []b
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
+type EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSONDefault  *Status
+}
+
+// Status returns HTTPResponse.Status
+func (r EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
 type EnterpriseAPIAddUserToChildOrganizationResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -2693,6 +2804,23 @@ func (c *ClientWithResponses) EnterpriseAPIBatchCreateEnterpriseServiceAccountsW
 		return nil, err
 	}
 	return ParseEnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse(rsp)
+}
+
+// EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBodyWithResponse request with arbitrary body returning *EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse
+func (c *ClientWithResponses) EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBodyWithResponse(ctx context.Context, enterpriseId string, contentType string, body io.Reader) (*EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse, error) {
+	rsp, err := c.EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody(ctx, enterpriseId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse(rsp)
+}
+
+func (c *ClientWithResponses) EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithResponse(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchDeleteEnterpriseServiceAccountsJSONRequestBody) (*EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse, error) {
+	rsp, err := c.EnterpriseAPIBatchDeleteEnterpriseServiceAccounts(ctx, enterpriseId, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse(rsp)
 }
 
 // EnterpriseAPIAddUserToChildOrganizationWithBodyWithResponse request with arbitrary body returning *EnterpriseAPIAddUserToChildOrganizationResponse
@@ -3224,6 +3352,32 @@ func ParseEnterpriseAPIBatchCreateEnterpriseServiceAccountsResponse(rsp *http.Re
 		}
 		response.JSON200 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest Status
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse parses an HTTP response from a EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithResponse call
+func ParseEnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse(rsp *http.Response) (*EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest Status
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/castai/sdk/organization_management/mock/client.go
+++ b/castai/sdk/organization_management/mock/client.go
@@ -315,6 +315,46 @@ func (mr *MockClientInterfaceMockRecorder) EnterpriseAPIBatchDeleteEnterpriseRol
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchDeleteEnterpriseRoleBindingsWithBody", reflect.TypeOf((*MockClientInterface)(nil).EnterpriseAPIBatchDeleteEnterpriseRoleBindingsWithBody), varargs...)
 }
 
+// EnterpriseAPIBatchDeleteEnterpriseServiceAccounts mocks base method.
+func (m *MockClientInterface) EnterpriseAPIBatchDeleteEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body organization_management.EnterpriseAPIBatchDeleteEnterpriseServiceAccountsJSONRequestBody, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchDeleteEnterpriseServiceAccounts", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchDeleteEnterpriseServiceAccounts indicates an expected call of EnterpriseAPIBatchDeleteEnterpriseServiceAccounts.
+func (mr *MockClientInterfaceMockRecorder) EnterpriseAPIBatchDeleteEnterpriseServiceAccounts(ctx, enterpriseId, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchDeleteEnterpriseServiceAccounts", reflect.TypeOf((*MockClientInterface)(nil).EnterpriseAPIBatchDeleteEnterpriseServiceAccounts), varargs...)
+}
+
+// EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody mocks base method.
+func (m *MockClientInterface) EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody(ctx context.Context, enterpriseId, contentType string, body io.Reader, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody indicates an expected call of EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody.
+func (mr *MockClientInterfaceMockRecorder) EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody(ctx, enterpriseId, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody", reflect.TypeOf((*MockClientInterface)(nil).EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody), varargs...)
+}
+
 // EnterpriseAPIBatchUpdateEnterpriseGroups mocks base method.
 func (m *MockClientInterface) EnterpriseAPIBatchUpdateEnterpriseGroups(ctx context.Context, enterpriseId string, body organization_management.EnterpriseAPIBatchUpdateEnterpriseGroupsJSONRequestBody, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -1096,6 +1136,76 @@ func (m *MockClientWithResponsesInterface) EnterpriseAPIBatchDeleteEnterpriseRol
 func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIBatchDeleteEnterpriseRoleBindingsWithResponse(ctx, enterpriseId, body interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchDeleteEnterpriseRoleBindingsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIBatchDeleteEnterpriseRoleBindingsWithResponse), ctx, enterpriseId, body)
+}
+
+// EnterpriseAPIBatchDeleteEnterpriseServiceAccounts mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIBatchDeleteEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body organization_management.EnterpriseAPIBatchDeleteEnterpriseServiceAccountsJSONRequestBody, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchDeleteEnterpriseServiceAccounts", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchDeleteEnterpriseServiceAccounts indicates an expected call of EnterpriseAPIBatchDeleteEnterpriseServiceAccounts.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIBatchDeleteEnterpriseServiceAccounts(ctx, enterpriseId, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchDeleteEnterpriseServiceAccounts", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIBatchDeleteEnterpriseServiceAccounts), varargs...)
+}
+
+// EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody(ctx context.Context, enterpriseId, contentType string, body io.Reader, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody indicates an expected call of EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody(ctx, enterpriseId, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody), varargs...)
+}
+
+// EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBodyWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBodyWithResponse(ctx context.Context, enterpriseId, contentType string, body io.Reader) (*organization_management.EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBodyWithResponse", ctx, enterpriseId, contentType, body)
+	ret0, _ := ret[0].(*organization_management.EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBodyWithResponse indicates an expected call of EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBodyWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBodyWithResponse(ctx, enterpriseId, contentType, body interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBodyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBodyWithResponse), ctx, enterpriseId, contentType, body)
+}
+
+// EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithResponse(ctx context.Context, enterpriseId string, body organization_management.EnterpriseAPIBatchDeleteEnterpriseServiceAccountsJSONRequestBody) (*organization_management.EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithResponse", ctx, enterpriseId, body)
+	ret0, _ := ret[0].(*organization_management.EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithResponse indicates an expected call of EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithResponse(ctx, enterpriseId, body interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithResponse), ctx, enterpriseId, body)
 }
 
 // EnterpriseAPIBatchUpdateEnterpriseGroups mocks base method.


### PR DESCRIPTION
### Sumary
This PR updates `terraform-provider-castai` to match an upstream change in the `DboAPI` OpenAPI spec: the `DeleteCacheGroup` endpoint gained an optional query parameter. The provider doesn't use this parameter today, but the regenerated SDK now requires callers to pass a `*DboAPIDeleteCacheGroupParams` struct, so the call site and its unit test have been updated to pass `nil`.

### Key Changes
- Updated `DboAPIDeleteCacheGroupWithResponse` call site in `castai/resource_cache_group.go` to pass `nil` for the new params argument.
- Updated the corresponding mock expectation in `castai/resource_cache_group_test.go` to match the new interface.
- Executed `make generate-all`:
  - Regenerated `castai/sdk/{api,client}.gen.go` and `castai/sdk/mock/client.go` from the latest spec.
  - Regenerated the `organization_management` SDK against its current spec

### Compatibility
No runtime behavior change — `DeleteCacheGroup` is still called without any query parameters. The other SDK changes are unused by this provider (verified via `make build` and `make test`).

---
### Kimchi Summary
### What changed
Regenerates the CAST AI SDK and updates the provider to align with the latest API specification. Cache group deletion now accepts an optional `roxy` query parameter, and new enterprise organization management endpoints support batch deletion of service accounts.

### Why
Keeps the Terraform provider in sync with upstream API schema changes.

### Key changes
- **`castai/sdk/api.gen.go`**: Adds `Roxy` field to `DboV1CacheGroup`; introduces `DboAPIDeleteCacheGroupParams` with optional `roxy` query parameter; renames `IsRoxy` to `Roxy` in `DboV1UninstallCacheParams`; removes deprecated `RoleId` from `CastaiUsersV1beta1NewMembershipByEmail` and `CastaiUsersV1beta1PendingInvitation`.
- **`castai/sdk/client.gen.go`**: Updates `DboAPIDeleteCacheGroup`, `DboAPIDeleteCacheGroupWithResponse`, and `NewDboAPIDeleteCacheGroupRequest` to accept `*DboAPIDeleteCacheGroupParams`.
- **`castai/resource_cache_group.go`**: Passes `nil` for the new params argument in `DboAPIDeleteCacheGroupWithResponse`.
- **`castai/resource_cache_group_test.go`**: Updates mock expectations to match the new `DboAPIDeleteCacheGroup` signature.
- **`castai/sdk/organization_management/api.gen.go`**: Adds `BatchDeleteEnterpriseServiceAccountsRequest` and related request body types.
- **`castai/sdk/organization_management/client.gen.go`**: Adds `EnterpriseAPIBatchDeleteEnterpriseServiceAccounts` methods.
- **`castai/sdk/organization_management/mock/client.go`**: Adds generated mocks for the new batch delete enterprise service accounts endpoints.

### Impact
- **Breaking SDK change**: Direct callers of `DboAPIDeleteCacheGroup` or `DboAPIDeleteCacheGroupWithResponse` must now provide a `*DboAPIDeleteCacheGroupParams` argument (pass `nil` to preserve prior behavior).
- No Terraform schema or resource behavior changes yet; the provider passes `nil` during cache group deletion until `roxy` configuration is exposed in HCL.