### PR TITLE
CSU-5463: add reproduction tests for spot field perpetual drift

### DIFF
--- a/castai/resource_node_template_drift_test.go
+++ b/castai/resource_node_template_drift_test.go
@@ -1,0 +1,84 @@
+package castai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNodeTemplateSpotFieldsNoDriftWhenUnset reproduces CSU-5463. When the API
+// returns spot-related constraint values but the user's Terraform configuration
+// does not set them, the provider should not produce a perpetual diff. The fix
+// is to mark those fields as Computed so that Terraform uses the API/state
+// value instead of the zero value when the field is absent from configuration.
+func TestNodeTemplateSpotFieldsNoDriftWhenUnset(t *testing.T) {
+	r := require.New(t)
+	res := resourceNodeTemplate()
+	sm := schema.InternalMap(res.Schema)
+
+	clusterID := "b6bfc074-a267-400f-b8f1-db0850c369b1"
+	name := "default-by-castai"
+
+	// State returned by the API / stored in Terraform state.
+	state := &terraform.InstanceState{
+		ID: name,
+		Attributes: map[string]string{
+			FieldClusterId:                                             clusterID,
+			FieldNodeTemplateName:                                      name,
+			fmt.Sprintf("%s.#", FieldNodeTemplateConstraints):          "1",
+			fmt.Sprintf("%s.0.%s", FieldNodeTemplateConstraints, FieldNodeTemplateOnDemand): "true",
+			fmt.Sprintf("%s.0.%s", FieldNodeTemplateConstraints, FieldNodeTemplateMinCpu):   "2",
+			fmt.Sprintf("%s.0.%s", FieldNodeTemplateConstraints, FieldNodeTemplateSpotDiversityPriceIncreaseLimitPercent):   "21",
+			fmt.Sprintf("%s.0.%s", FieldNodeTemplateConstraints, FieldNodeTemplateSpotReliabilityPriceIncreaseLimitPercent): "20",
+			fmt.Sprintf("%s.0.%s", FieldNodeTemplateConstraints, FieldNodeTemplateSpotInterruptionPredictionsType):          "interruption-predictions",
+		},
+	}
+
+	// User configuration that does NOT set the spot-related fields.
+	config := terraform.NewResourceConfigRaw(map[string]interface{}{
+		FieldClusterId:        clusterID,
+		FieldNodeTemplateName: name,
+		FieldNodeTemplateConstraints: []interface{}{
+			map[string]interface{}{
+				FieldNodeTemplateOnDemand: true,
+				FieldNodeTemplateMinCpu:   2,
+			},
+		},
+	})
+
+	diff, err := sm.Diff(context.Background(), state, config, nil, nil, true)
+	r.NoError(err)
+
+	d, err := sm.Data(state, diff)
+	r.NoError(err)
+
+	spotDiversityPath := fmt.Sprintf("%s.0.%s", FieldNodeTemplateConstraints, FieldNodeTemplateSpotDiversityPriceIncreaseLimitPercent)
+	spotReliabilityPath := fmt.Sprintf("%s.0.%s", FieldNodeTemplateConstraints, FieldNodeTemplateSpotReliabilityPriceIncreaseLimitPercent)
+	spotTypePath := fmt.Sprintf("%s.0.%s", FieldNodeTemplateConstraints, FieldNodeTemplateSpotInterruptionPredictionsType)
+
+	fmt.Printf("d.Get(%q) = %#v\n", spotDiversityPath, d.Get(spotDiversityPath))
+	fmt.Printf("d.Get(%q) = %#v\n", spotReliabilityPath, d.Get(spotReliabilityPath))
+	fmt.Printf("d.Get(%q) = %#v\n", spotTypePath, d.Get(spotTypePath))
+	fmt.Printf("d.HasChange(%q) = %v\n", spotDiversityPath, d.HasChange(spotDiversityPath))
+	fmt.Printf("d.HasChange(%q) = %v\n", spotReliabilityPath, d.HasChange(spotReliabilityPath))
+	fmt.Printf("d.HasChange(%q) = %v\n", spotTypePath, d.HasChange(spotTypePath))
+
+	// Simulate what the provider would send to the API on update.
+	// updateNodeTemplate does: req.Constraints = toTemplateConstraints(v[0].(map[string]any))
+	constraintsConfig := d.Get(FieldNodeTemplateConstraints).([]interface{})[0].(map[string]interface{})
+	sentConstraints := toTemplateConstraints(constraintsConfig)
+	sentJSON, err := json.MarshalIndent(sentConstraints, "", "  ")
+	r.NoError(err)
+	fmt.Printf("Constraints JSON sent to API on update:\n%s\n", string(sentJSON))
+
+	// With the fix these fields are Computed; when absent from config Terraform
+	// should keep the state value and report no change.
+	r.False(d.HasChange(spotDiversityPath), "spot_diversity_price_increase_limit_percent should not drift when not configured")
+	r.False(d.HasChange(spotReliabilityPath), "spot_reliability_price_increase_limit_percent should not drift when not configured")
+	r.False(d.HasChange(spotTypePath), "spot_interruption_predictions_type should not drift when not configured")
+}

--- a/castai/resource_node_template_test.go
+++ b/castai/resource_node_template_test.go
@@ -966,12 +966,14 @@ func TestAccEKS_ResourceNodeTemplate_basic(t *testing.T) {
 }
 
 // TestAccEKS_ResourceNodeTemplate_defaultSpotFieldsDrift reproduces CSU-5463.
-// The customer's issue is specifically on the default node template
-// "default-by-castai", where spot-related detail fields were populated by
-// CAST AI (e.g. during a spot-reliability rollout) and then persisted even
-// after spot was disabled. The Terraform config does not set those fields,
-// so the provider tries to clear them on every apply, but the API keeps
-// returning them, causing a perpetual diff.
+// The customer's flow was:
+//  1. Create the default node template with only on_demand in constraints.
+//  2. In the CAST AI UI, remove the lingering zero-valued constraints and
+//     set min_cpu = 16.
+//  3. Re-apply the same Terraform config.
+//  4. Terraform tries to reset min_cpu to null and clear the spot detail
+//     fields, but the spot detail fields never get cleared, causing a
+//     perpetual diff.
 func TestAccEKS_ResourceNodeTemplate_defaultSpotFieldsDrift(t *testing.T) {
 	rName := fmt.Sprintf("%v-default-spot-drift-%v", ResourcePrefix, acctest.RandString(8))
 	resourceName := "castai_node_template.default"
@@ -983,34 +985,42 @@ func TestAccEKS_ResourceNodeTemplate_defaultSpotFieldsDrift(t *testing.T) {
 		// Default node templates cannot be deleted, so there is no destroy check.
 		Steps: []resource.TestStep{
 			{
-				// First seed the default template with the spot detail fields.
-				// In the customer case these values were written by CAST AI, not
-				// by Terraform, but setting them through Terraform lets us
-				// reproduce the same backend state.
-				Config: testAccDefaultNodeTemplateSpotDriftInitialConfig(rName, clusterName),
+				// Step 1: Terraform creates the default template with a minimal
+				// constraints block.
+				Config: testAccDefaultNodeTemplateSpotDriftConfig(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "default-by-castai"),
 					resource.TestCheckResourceAttr(resourceName, "is_default", "true"),
-					resource.TestCheckResourceAttr(resourceName, "constraints.0.spot_reliability_price_increase_limit_percent", "20"),
-					resource.TestCheckResourceAttr(resourceName, "constraints.0.spot_diversity_price_increase_limit_percent", "21"),
-					resource.TestCheckResourceAttr(resourceName, "constraints.0.spot_interruption_predictions_type", "interruption-predictions"),
-				),
-			},
-			{
-				// Now apply the same config the customer has: default template
-				// with on_demand/min_cpu only, no spot detail fields.
-				Config: testAccDefaultNodeTemplateSpotDriftUpdatedConfig(rName, clusterName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "default-by-castai"),
-					resource.TestCheckResourceAttr(resourceName, "constraints.0.min_cpu", "2"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.on_demand", "true"),
 				),
 			},
 			{
-				// This step fails if the provider still shows drift. With the
-				// current provider/API behavior, the spot detail fields keep
-				// coming back from the API, so the plan is non-empty.
-				Config:   testAccDefaultNodeTemplateSpotDriftUpdatedConfig(rName, clusterName),
+				// Step 2: Simulate the customer making changes in the CAST AI UI.
+				// They set min_cpu = 16 and the three spot detail fields. This
+				// bypasses Terraform state.
+				Config: testAccDefaultNodeTemplateSpotDriftConfig(rName, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccSetDefaultNodeTemplateConstraintsViaAPI(resourceName, 16),
+				),
+			},
+			{
+				// Step 3: Re-apply the same Terraform config. The provider will
+				// try to clear min_cpu and the spot detail fields. min_cpu is
+				// expected to be cleared, the spot detail fields are expected to
+				// drift.
+				Config: testAccDefaultNodeTemplateSpotDriftConfig(rName, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "constraints.0.on_demand", "true"),
+					// After the fix this should also be cleared. Until then the
+					// API keeps returning 16 and this check would fail, which is
+					// part of demonstrating the drift.
+					resource.TestCheckNoResourceAttr(resourceName, "constraints.0.min_cpu"),
+				),
+			},
+			{
+				// Step 4: A subsequent plan should be empty. With the bug, it is
+				// not empty because the spot detail fields keep coming back.
+				Config:   testAccDefaultNodeTemplateSpotDriftConfig(rName, clusterName),
 				PlanOnly: true,
 			},
 		},
@@ -1023,7 +1033,7 @@ func TestAccEKS_ResourceNodeTemplate_defaultSpotFieldsDrift(t *testing.T) {
 	})
 }
 
-func testAccDefaultNodeTemplateSpotDriftInitialConfig(rName, clusterName string) string {
+func testAccDefaultNodeTemplateSpotDriftConfig(rName, clusterName string) string {
 	return ConfigCompose(testAccEKSClusterConfig(rName, clusterName), testAccNodeConfig(rName), `
 		resource "castai_node_template" "default" {
 			cluster_id       = castai_eks_cluster.test.id
@@ -1034,31 +1044,47 @@ func testAccDefaultNodeTemplateSpotDriftInitialConfig(rName, clusterName string)
 
 			constraints {
 				on_demand = true
-				min_cpu   = 2
-
-				spot_reliability_price_increase_limit_percent = 20
-				spot_diversity_price_increase_limit_percent   = 21
-				spot_interruption_predictions_type            = "interruption-predictions"
 			}
 		}
 	`)
 }
 
-func testAccDefaultNodeTemplateSpotDriftUpdatedConfig(rName, clusterName string) string {
-	return ConfigCompose(testAccEKSClusterConfig(rName, clusterName), testAccNodeConfig(rName), `
-		resource "castai_node_template" "default" {
-			cluster_id       = castai_eks_cluster.test.id
-			name             = "default-by-castai"
-			is_default       = true
-			is_enabled       = true
-			configuration_id = castai_node_configuration.test.id
-
-			constraints {
-				on_demand = true
-				min_cpu   = 2
-			}
+// testAccSetDefaultNodeTemplateConstraintsViaAPI simulates a user editing the
+// default node template in the CAST AI UI. It sets min_cpu and the three
+// spot-related detail fields that drift in CSU-5463.
+func testAccSetDefaultNodeTemplateConstraintsViaAPI(resourceName string, minCPU int32) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %q not found in state", resourceName)
 		}
-	`)
+
+		clusterID := rs.Primary.Attributes["cluster_id"]
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		client := testAccProvider.Meta().(*ProviderConfig).api
+
+		req := sdk.NodeTemplatesAPIUpdateNodeTemplateJSONRequestBody{
+			Constraints: &sdk.NodetemplatesV1TemplateConstraints{
+				OnDemand:                                 toPtr(true),
+				MinCpu:                                   toPtr(minCPU),
+				SpotReliabilityPriceIncreaseLimitPercent: toPtr(int32(20)),
+				SpotDiversityPriceIncreaseLimitPercent:   toPtr(int32(21)),
+				SpotInterruptionPredictionsType:          toPtr("interruption-predictions"),
+			},
+		}
+
+		resp, err := client.NodeTemplatesAPIUpdateNodeTemplateWithResponse(ctx, clusterID, "default-by-castai", req)
+		if err != nil {
+			return fmt.Errorf("updating default node template via API: %w", err)
+		}
+		if err := sdk.CheckOKResponse(resp, err); err != nil {
+			return fmt.Errorf("updating default node template via API: %w", err)
+		}
+
+		return nil
+	}
 }
 
 func testAccNodeTemplateConfig(rName, clusterName string) string {

--- a/castai/resource_node_template_test.go
+++ b/castai/resource_node_template_test.go
@@ -1024,7 +1024,7 @@ func TestAccEKS_ResourceNodeTemplate_defaultSpotFieldsDrift(t *testing.T) {
 }
 
 func testAccDefaultNodeTemplateSpotDriftInitialConfig(rName, clusterName string) string {
-	return ConfigCompose(testAccEKSClusterConfig(rName, clusterName), testAccNodeConfig(rName), fmt.Sprintf(`
+	return ConfigCompose(testAccEKSClusterConfig(rName, clusterName), testAccNodeConfig(rName), `
 		resource "castai_node_template" "default" {
 			cluster_id       = castai_eks_cluster.test.id
 			name             = "default-by-castai"
@@ -1041,11 +1041,11 @@ func testAccDefaultNodeTemplateSpotDriftInitialConfig(rName, clusterName string)
 				spot_interruption_predictions_type            = "interruption-predictions"
 			}
 		}
-	`, rName))
+	`)
 }
 
 func testAccDefaultNodeTemplateSpotDriftUpdatedConfig(rName, clusterName string) string {
-	return ConfigCompose(testAccEKSClusterConfig(rName, clusterName), testAccNodeConfig(rName), fmt.Sprintf(`
+	return ConfigCompose(testAccEKSClusterConfig(rName, clusterName), testAccNodeConfig(rName), `
 		resource "castai_node_template" "default" {
 			cluster_id       = castai_eks_cluster.test.id
 			name             = "default-by-castai"
@@ -1058,7 +1058,7 @@ func testAccDefaultNodeTemplateSpotDriftUpdatedConfig(rName, clusterName string)
 				min_cpu   = 2
 			}
 		}
-	`, rName))
+	`)
 }
 
 func testAccNodeTemplateConfig(rName, clusterName string) string {

--- a/castai/resource_node_template_test.go
+++ b/castai/resource_node_template_test.go
@@ -965,6 +965,90 @@ func TestAccEKS_ResourceNodeTemplate_basic(t *testing.T) {
 	})
 }
 
+// TestAccEKS_ResourceNodeTemplate_spotFieldsDrift reproduces CSU-5463.
+// It creates a node template with spot-related constraint fields set, then
+// removes those fields from the Terraform configuration. With the buggy
+// provider, the API keeps returning the old values, so a subsequent plan
+// still shows a diff (perpetual drift). The final PlanOnly step therefore
+// fails until the fields are marked Computed.
+func TestAccEKS_ResourceNodeTemplate_spotFieldsDrift(t *testing.T) {
+	rName := fmt.Sprintf("%v-node-template-spot-drift-%v", ResourcePrefix, acctest.RandString(8))
+	resourceName := "castai_node_template.test"
+	clusterName, _ := lo.Coalesce(os.Getenv("CLUSTER_NAME"), "cost-terraform")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckNodeTemplateDestroy(rName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNodeTemplateSpotDriftInitialConfig(rName, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "constraints.0.spot_reliability_price_increase_limit_percent", "20"),
+					resource.TestCheckResourceAttr(resourceName, "constraints.0.spot_diversity_price_increase_limit_percent", "21"),
+					resource.TestCheckResourceAttr(resourceName, "constraints.0.spot_interruption_predictions_type", "interruption-predictions"),
+				),
+			},
+			{
+				Config: testAccNodeTemplateSpotDriftUpdatedConfig(rName, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "constraints.0.min_cpu", "2"),
+					resource.TestCheckResourceAttr(resourceName, "constraints.0.on_demand", "true"),
+				),
+			},
+			{
+				// This step fails on the buggy provider because the previous
+				// apply did not actually clear the spot fields in the API,
+				// so Terraform still wants to change them to null.
+				Config:   testAccNodeTemplateSpotDriftUpdatedConfig(rName, clusterName),
+				PlanOnly: true,
+			},
+		},
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"aws": {
+				Source:            "hashicorp/aws",
+				VersionConstraint: "~> 4.0",
+			},
+		},
+	})
+}
+
+func testAccNodeTemplateSpotDriftInitialConfig(rName, clusterName string) string {
+	return ConfigCompose(testAccEKSClusterConfig(rName, clusterName), testAccNodeConfig(rName), fmt.Sprintf(`
+		resource "castai_node_template" "test" {
+			cluster_id       = castai_eks_cluster.test.id
+			name             = %[1]q
+			configuration_id = castai_node_configuration.test.id
+
+			constraints {
+				on_demand = true
+				min_cpu   = 2
+
+				spot_reliability_price_increase_limit_percent = 20
+				spot_diversity_price_increase_limit_percent   = 21
+				spot_interruption_predictions_type            = "interruption-predictions"
+			}
+		}
+	`, rName))
+}
+
+func testAccNodeTemplateSpotDriftUpdatedConfig(rName, clusterName string) string {
+	return ConfigCompose(testAccEKSClusterConfig(rName, clusterName), testAccNodeConfig(rName), fmt.Sprintf(`
+		resource "castai_node_template" "test" {
+			cluster_id       = castai_eks_cluster.test.id
+			name             = %[1]q
+			configuration_id = castai_node_configuration.test.id
+
+			constraints {
+				on_demand = true
+				min_cpu   = 2
+			}
+		}
+	`, rName))
+}
+
 func testAccNodeTemplateConfig(rName, clusterName string) string {
 	return ConfigCompose(testAccEKSClusterConfig(rName, clusterName), testAccNodeConfig(rName), testAccEdgeLocationsConfig(rName, clusterName), fmt.Sprintf(`
 		resource "castai_node_template" "test" {

--- a/castai/resource_node_template_test.go
+++ b/castai/resource_node_template_test.go
@@ -965,44 +965,52 @@ func TestAccEKS_ResourceNodeTemplate_basic(t *testing.T) {
 	})
 }
 
-// TestAccEKS_ResourceNodeTemplate_spotFieldsDrift reproduces CSU-5463.
-// It creates a node template with spot-related constraint fields set, then
-// removes those fields from the Terraform configuration. With the buggy
-// provider, the API keeps returning the old values, so a subsequent plan
-// still shows a diff (perpetual drift). The final PlanOnly step therefore
-// fails until the fields are marked Computed.
-func TestAccEKS_ResourceNodeTemplate_spotFieldsDrift(t *testing.T) {
-	rName := fmt.Sprintf("%v-node-template-spot-drift-%v", ResourcePrefix, acctest.RandString(8))
-	resourceName := "castai_node_template.test"
+// TestAccEKS_ResourceNodeTemplate_defaultSpotFieldsDrift reproduces CSU-5463.
+// The customer's issue is specifically on the default node template
+// "default-by-castai", where spot-related detail fields were populated by
+// CAST AI (e.g. during a spot-reliability rollout) and then persisted even
+// after spot was disabled. The Terraform config does not set those fields,
+// so the provider tries to clear them on every apply, but the API keeps
+// returning them, causing a perpetual diff.
+func TestAccEKS_ResourceNodeTemplate_defaultSpotFieldsDrift(t *testing.T) {
+	rName := fmt.Sprintf("%v-default-spot-drift-%v", ResourcePrefix, acctest.RandString(8))
+	resourceName := "castai_node_template.default"
 	clusterName, _ := lo.Coalesce(os.Getenv("CLUSTER_NAME"), "cost-terraform")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:             testAccCheckNodeTemplateDestroy(rName),
+		// Default node templates cannot be deleted, so there is no destroy check.
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNodeTemplateSpotDriftInitialConfig(rName, clusterName),
+				// First seed the default template with the spot detail fields.
+				// In the customer case these values were written by CAST AI, not
+				// by Terraform, but setting them through Terraform lets us
+				// reproduce the same backend state.
+				Config: testAccDefaultNodeTemplateSpotDriftInitialConfig(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name", "default-by-castai"),
+					resource.TestCheckResourceAttr(resourceName, "is_default", "true"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.spot_reliability_price_increase_limit_percent", "20"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.spot_diversity_price_increase_limit_percent", "21"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.spot_interruption_predictions_type", "interruption-predictions"),
 				),
 			},
 			{
-				Config: testAccNodeTemplateSpotDriftUpdatedConfig(rName, clusterName),
+				// Now apply the same config the customer has: default template
+				// with on_demand/min_cpu only, no spot detail fields.
+				Config: testAccDefaultNodeTemplateSpotDriftUpdatedConfig(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name", "default-by-castai"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.min_cpu", "2"),
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.on_demand", "true"),
 				),
 			},
 			{
-				// This step fails on the buggy provider because the previous
-				// apply did not actually clear the spot fields in the API,
-				// so Terraform still wants to change them to null.
-				Config:   testAccNodeTemplateSpotDriftUpdatedConfig(rName, clusterName),
+				// This step fails if the provider still shows drift. With the
+				// current provider/API behavior, the spot detail fields keep
+				// coming back from the API, so the plan is non-empty.
+				Config:   testAccDefaultNodeTemplateSpotDriftUpdatedConfig(rName, clusterName),
 				PlanOnly: true,
 			},
 		},
@@ -1015,11 +1023,13 @@ func TestAccEKS_ResourceNodeTemplate_spotFieldsDrift(t *testing.T) {
 	})
 }
 
-func testAccNodeTemplateSpotDriftInitialConfig(rName, clusterName string) string {
+func testAccDefaultNodeTemplateSpotDriftInitialConfig(rName, clusterName string) string {
 	return ConfigCompose(testAccEKSClusterConfig(rName, clusterName), testAccNodeConfig(rName), fmt.Sprintf(`
-		resource "castai_node_template" "test" {
+		resource "castai_node_template" "default" {
 			cluster_id       = castai_eks_cluster.test.id
-			name             = %[1]q
+			name             = "default-by-castai"
+			is_default       = true
+			is_enabled       = true
 			configuration_id = castai_node_configuration.test.id
 
 			constraints {
@@ -1034,11 +1044,13 @@ func testAccNodeTemplateSpotDriftInitialConfig(rName, clusterName string) string
 	`, rName))
 }
 
-func testAccNodeTemplateSpotDriftUpdatedConfig(rName, clusterName string) string {
+func testAccDefaultNodeTemplateSpotDriftUpdatedConfig(rName, clusterName string) string {
 	return ConfigCompose(testAccEKSClusterConfig(rName, clusterName), testAccNodeConfig(rName), fmt.Sprintf(`
-		resource "castai_node_template" "test" {
+		resource "castai_node_template" "default" {
 			cluster_id       = castai_eks_cluster.test.id
-			name             = %[1]q
+			name             = "default-by-castai"
+			is_default       = true
+			is_enabled       = true
 			configuration_id = castai_node_configuration.test.id
 
 			constraints {

--- a/castai/resource_node_template_test.go
+++ b/castai/resource_node_template_test.go
@@ -986,7 +986,7 @@ func TestAccEKS_ResourceNodeTemplate_defaultSpotFieldsDrift(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Step 1: Terraform creates the default template with a minimal
-				// constraints block.
+				// constraints block (only on_demand).
 				Config: testAccDefaultNodeTemplateSpotDriftConfig(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "default-by-castai"),
@@ -995,33 +995,27 @@ func TestAccEKS_ResourceNodeTemplate_defaultSpotFieldsDrift(t *testing.T) {
 				),
 			},
 			{
-				// Step 2: Simulate the customer making changes in the CAST AI UI.
-				// They set min_cpu = 16 and the three spot detail fields. This
-				// bypasses Terraform state.
+				// Step 2: Simulate the customer editing the template in the
+				// CAST AI UI. The Check writes min_cpu = 16 and the three spot
+				// detail fields directly via the API, bypassing Terraform. After
+				// the Check runs, the refresh sees the new values that are not
+				// in config, so a non-empty plan is expected here.
 				Config: testAccDefaultNodeTemplateSpotDriftConfig(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSetDefaultNodeTemplateConstraintsViaAPI(resourceName, 16),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 			{
-				// Step 3: Re-apply the same Terraform config. The provider will
-				// try to clear min_cpu and the spot detail fields. min_cpu is
-				// expected to be cleared, the spot detail fields are expected to
-				// drift.
+				// Step 3: Re-apply the same Terraform config. The apply must
+				// clear every field that the previous step added so that the
+				// refresh plan is empty. With the bug, the spot detail fields
+				// are not cleared and this step fails because the refresh plan
+				// is non-empty.
 				Config: testAccDefaultNodeTemplateSpotDriftConfig(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "constraints.0.on_demand", "true"),
-					// After the fix this should also be cleared. Until then the
-					// API keeps returning 16 and this check would fail, which is
-					// part of demonstrating the drift.
-					resource.TestCheckNoResourceAttr(resourceName, "constraints.0.min_cpu"),
 				),
-			},
-			{
-				// Step 4: A subsequent plan should be empty. With the bug, it is
-				// not empty because the spot detail fields keep coming back.
-				Config:   testAccDefaultNodeTemplateSpotDriftConfig(rName, clusterName),
-				PlanOnly: true,
 			},
 		},
 		ExternalProviders: map[string]resource.ExternalProvider{


### PR DESCRIPTION
Adds an integration acceptance test (TestAccEKS_ResourceNodeTemplate_spotFieldsDrift) that creates a node template with spot detail fields, removes them from config, and then asserts that a subsequent plan is empty. 

---
### Kimchi Summary
### What changed
This PR adds unit and acceptance tests to reproduce and guard against CSU-5463, where spot-related node template constraint fields drift when they are returned by the API but omitted from Terraform configuration.

### Why
When the CAST AI API populates spot detail fields on a node template that the user never configured, Terraform can produce a perpetual diff. These tests capture the expected plan behavior so the fix cannot silently regress.

### Key changes
- `castai/resource_node_template_drift_test.go`: New unit test `TestNodeTemplateSpotFieldsNoDriftWhenUnset` that simulates API state containing `spot_diversity_price_increase_limit_percent`, `spot_reliability_price_increase_limit_percent`, and `spot_interruption_predictions_type` while the user's config omits them, then asserts that `d.HasChange` is false for each field.
- `castai/resource_node_template_test.go`: New acceptance test `TestAccEKS_ResourceNodeTemplate_defaultSpotFieldsDrift` that replicates the customer flow—create a minimal default template, modify it via the API/UI, re-apply the same config, and verify the refresh plan is empty.
- `testAccDefaultNodeTemplateSpotDriftConfig`: Helper that returns a minimal default `castai_node_template` with only `on_demand` in `constraints`.
- `testAccSetDefaultNodeTemplateConstraintsViaAPI`: Helper that uses the SDK to set `min_cpu` and the three spot detail fields directly, simulating a UI edit.

### Impact
The new tests assume the `castai_node_template` schema marks the spot-related constraint fields as `Computed` (or equivalent), so Terraform keeps the state/API value instead of the zero value when the field is absent from config. If that schema change is not already in place, these tests will fail until it is applied.