### PR TITLE
Import omni cluster

### DIFF
--- a/castai/resource_omni_cluster.go
+++ b/castai/resource_omni_cluster.go
@@ -3,6 +3,7 @@ package castai
 import (
 	"context"
 	"fmt"
+	"github.com/samber/lo"
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -235,10 +236,25 @@ func (r *omniClusterResource) ImportState(ctx context.Context, req resource.Impo
 		return
 	}
 
+	omniClusterResp, err := r.client.omniAPI.ClustersAPIGetClusterWithResponse(ctx, *clusterData.JSON200.OrganizationId, clusterID, nil)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read omni cluster", err.Error())
+		return
+	}
+
+	if omniClusterResp.StatusCode() != http.StatusOK {
+		resp.Diagnostics.AddError("Unexpected omni cluster status", fmt.Sprintf("status code: %d, body: %s", omniClusterResp.StatusCode(), string(omniClusterResp.Body)))
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &omniClusterModel{
 		ID:             types.StringValue(clusterID),
 		OrganizationID: types.StringValue(*clusterData.JSON200.OrganizationId),
 		ClusterID:      types.StringValue(clusterID),
+		Status: &omniClusterStatusModel{
+			OmniAgentVersion: types.StringValue(lo.FromPtr(omniClusterResp.JSON200.OmniAgentVersion)),
+			PodCIDR:          types.StringValue(lo.FromPtr(omniClusterResp.JSON200.PodCidr)),
+		},
 	})...)
 }
 

--- a/castai/resource_omni_cluster.go
+++ b/castai/resource_omni_cluster.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	_ resource.Resource              = (*omniClusterResource)(nil)
-	_ resource.ResourceWithConfigure = (*omniClusterResource)(nil)
+	_ resource.Resource                = (*omniClusterResource)(nil)
+	_ resource.ResourceWithConfigure   = (*omniClusterResource)(nil)
+	_ resource.ResourceWithImportState = (*omniClusterResource)(nil)
 )
 
 type omniClusterResource struct {
@@ -215,6 +216,30 @@ func (r *omniClusterResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *omniClusterResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	clusterID := req.ID
+
+	clusterData, err := fetchClusterData(ctx, r.client.api, clusterID)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to fetch cluster data for import", err.Error())
+		return
+	}
+	if clusterData == nil {
+		resp.Diagnostics.AddError("Cluster not found", fmt.Sprintf("cluster %q not found", clusterID))
+		return
+	}
+	if clusterData.JSON200.OrganizationId == nil {
+		resp.Diagnostics.AddError("Missing organization ID", fmt.Sprintf("cluster %q has no organization ID", clusterID))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &omniClusterModel{
+		ID:             types.StringValue(clusterID),
+		OrganizationID: types.StringValue(*clusterData.JSON200.OrganizationId),
+		ClusterID:      types.StringValue(clusterID),
+	})...)
 }
 
 func (r *omniClusterResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -225,6 +225,22 @@ const (
 	USER           CastaiRbacV1beta1Kind = "USER"
 )
 
+// Defines values for CastaiRbacV1beta1LabelSelectorCondition.
+const (
+	LABELSELECTORCONDITIONAND         CastaiRbacV1beta1LabelSelectorCondition = "LABEL_SELECTOR_CONDITION_AND"
+	LABELSELECTORCONDITIONOR          CastaiRbacV1beta1LabelSelectorCondition = "LABEL_SELECTOR_CONDITION_OR"
+	LABELSELECTORCONDITIONUNSPECIFIED CastaiRbacV1beta1LabelSelectorCondition = "LABEL_SELECTOR_CONDITION_UNSPECIFIED"
+)
+
+// Defines values for CastaiRbacV1beta1LabelSelectorOperator.
+const (
+	LABELSELECTOROPERATORDOESNOTEXIST CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_DOES_NOT_EXIST"
+	LABELSELECTOROPERATOREXISTS       CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_EXISTS"
+	LABELSELECTOROPERATORIN           CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_IN"
+	LABELSELECTOROPERATORNOTIN        CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_NOT_IN"
+	LABELSELECTOROPERATORUNSPECIFIED  CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_UNSPECIFIED"
+)
+
 // Defines values for CastaiRbacV1beta1PoliciesState.
 const (
 	CastaiRbacV1beta1PoliciesStateACCEPTED CastaiRbacV1beta1PoliciesState = "ACCEPTED"
@@ -1466,6 +1482,9 @@ type GroupsIsTheGroupsToBeUpdated struct {
 
 	// Description Description is the description of the group.
 	Description *string `json:"description,omitempty"`
+
+	// LabelSelector LabelSelector represents a label selector for namespaces.
+	LabelSelector *CastaiRbacV1beta1LabelSelector `json:"labelSelector,omitempty"`
 
 	// Name Name is the name of the group.
 	Name string `json:"name"`
@@ -2997,6 +3016,9 @@ type CastaiRbacV1beta1CreateGroupRequestGroup struct {
 	// Description Description is the description of the group.
 	Description *string `json:"description,omitempty"`
 
+	// LabelSelector LabelSelector represents a label selector for namespaces.
+	LabelSelector *CastaiRbacV1beta1LabelSelector `json:"labelSelector,omitempty"`
+
 	// Name Name is the name of the group.
 	Name string `json:"name"`
 }
@@ -3040,6 +3062,9 @@ type CastaiRbacV1beta1Group struct {
 	// Id ID is the unique identifier of the group.
 	Id *string `json:"id,omitempty"`
 
+	// LabelSelector LabelSelector represents a label selector for namespaces.
+	LabelSelector *CastaiRbacV1beta1LabelSelector `json:"labelSelector,omitempty"`
+
 	// ManagedBy Method used to create group, eg.: console, terraform.
 	ManagedBy *string `json:"managedBy,omitempty"`
 
@@ -3073,6 +3098,33 @@ type CastaiRbacV1beta1GroupSubject struct {
 
 // CastaiRbacV1beta1Kind Kind represents the type of the member.
 type CastaiRbacV1beta1Kind string
+
+// CastaiRbacV1beta1LabelSelector LabelSelector represents a label selector for namespaces.
+type CastaiRbacV1beta1LabelSelector struct {
+	// Condition LabelSelectorCondition represents the condition of a label selector.
+	Condition CastaiRbacV1beta1LabelSelectorCondition `json:"condition"`
+
+	// Requirements Requirements is the list of label selector requirements.
+	Requirements []CastaiRbacV1beta1LabelSelectorRequirement `json:"requirements"`
+}
+
+// CastaiRbacV1beta1LabelSelectorCondition LabelSelectorCondition represents the condition of a label selector.
+type CastaiRbacV1beta1LabelSelectorCondition string
+
+// CastaiRbacV1beta1LabelSelectorOperator LabelSelectorOperator represents the operator of a label selector requirement.
+type CastaiRbacV1beta1LabelSelectorOperator string
+
+// CastaiRbacV1beta1LabelSelectorRequirement LabelSelectorRequirement represents a single label selector requirement.
+type CastaiRbacV1beta1LabelSelectorRequirement struct {
+	// Key Key is the label key that the selector applies to.
+	Key string `json:"key"`
+
+	// Operator LabelSelectorOperator represents the operator of a label selector requirement.
+	Operator CastaiRbacV1beta1LabelSelectorOperator `json:"operator"`
+
+	// Values Values is the list of label values that the requirement applies to.
+	Values *[]string `json:"values,omitempty"`
+}
 
 // CastaiRbacV1beta1ListPermissionGroupsResponse ListPermissionGroupsResponse is the response message for listing available permission groups.
 type CastaiRbacV1beta1ListPermissionGroupsResponse struct {
@@ -10549,6 +10601,7 @@ type WorkloadoptimizationV1ResourceMetricSource struct {
 type WorkloadoptimizationV1ResourceMetrics struct {
 	Avg          float64   `json:"avg"`
 	AvgPredicted float64   `json:"avgPredicted"`
+	Limit        float64   `json:"limit"`
 	Max          float64   `json:"max"`
 	Min          float64   `json:"min"`
 	P25          float64   `json:"p25"`
@@ -10778,7 +10831,8 @@ type WorkloadoptimizationV1StartupSettings struct {
 	// PeriodSeconds Defines the duration (in seconds) during which elevated resource usage is expected at startup.
 	// When set, recommendations will be adjusted to disregard resource spikes within this period.
 	// If not specified, the workload will receive standard recommendations without startup considerations.
-	PeriodSeconds *int32 `json:"periodSeconds"`
+	PeriodSeconds           *int32                                         `json:"periodSeconds"`
+	TwoPhaseRecommendations *WorkloadoptimizationV1TwoPhaseRecommendations `json:"twoPhaseRecommendations,omitempty"`
 }
 
 // WorkloadoptimizationV1SummaryConfidence defines model for workloadoptimization.v1.SummaryConfidence.
@@ -10853,6 +10907,12 @@ type WorkloadoptimizationV1SystemOverrideTriggeredEvent struct {
 type WorkloadoptimizationV1TimeSeriesMetric struct {
 	Timestamp time.Time `json:"timestamp"`
 	Value     float64   `json:"value"`
+}
+
+// WorkloadoptimizationV1TwoPhaseRecommendations defines model for workloadoptimization.v1.TwoPhaseRecommendations.
+type WorkloadoptimizationV1TwoPhaseRecommendations struct {
+	Enabled           bool                                    `json:"enabled"`
+	RequestsOnStartup *WorkloadoptimizationV1ResourceQuantity `json:"requestsOnStartup,omitempty"`
 }
 
 // WorkloadoptimizationV1UnboundMemoryGrowthEvent defines model for workloadoptimization.v1.UnboundMemoryGrowthEvent.
@@ -11100,6 +11160,7 @@ type WorkloadoptimizationV1WorkloadMetricContainer struct {
 	CpuCoresPredictionsAggregated *WorkloadoptimizationV1AggregatedPredictionMetrics `json:"cpuCoresPredictionsAggregated,omitempty"`
 	CpuStallPct                   *[]WorkloadoptimizationV1ResourceMetrics           `json:"cpuStallPct,omitempty"`
 	CpuStallPctAggregated         *WorkloadoptimizationV1AggregatedCPUStallMetrics   `json:"cpuStallPctAggregated,omitempty"`
+	FirstSeenResources            *WorkloadoptimizationV1Resources                   `json:"firstSeenResources,omitempty"`
 	Jvm                           *WorkloadoptimizationV1JVMContainerMetrics         `json:"jvm,omitempty"`
 	MemoryGib                     []WorkloadoptimizationV1ResourceMetrics            `json:"memoryGib"`
 	MemoryGibAggregated           WorkloadoptimizationV1AggregatedMetrics            `json:"memoryGibAggregated"`
@@ -11807,6 +11868,9 @@ type ExternalClusterAPIGetConnectAndEnableCASTAICmdParams struct {
 	// OnboardingPath Installation method (script, helm, castctl, …).
 	// Defaults to ONBOARDING_PATH_SCRIPT for backward compatibility.
 	OnboardingPath *ExternalClusterAPIGetConnectAndEnableCASTAICmdParamsOnboardingPath `form:"onboardingPath,omitempty" json:"onboardingPath,omitempty"`
+
+	// InstallReliabilityMetrics Whether CAST AI Reliability Metrics should be installed.
+	InstallReliabilityMetrics *bool `form:"installReliabilityMetrics,omitempty" json:"installReliabilityMetrics,omitempty"`
 }
 
 // ExternalClusterAPIGetConnectAndEnableCASTAICmdParamsOnboardingPath defines parameters for ExternalClusterAPIGetConnectAndEnableCASTAICmd.

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -7537,8 +7537,13 @@ type NodetemplatesV1TemplateConstraints struct {
 	LifecycleTaintsDisabled *bool  `json:"lifecycleTaintsDisabled"`
 	MaxCpu                  *int32 `json:"maxCpu"`
 	MaxMemory               *int32 `json:"maxMemory"`
-	MinCpu                  *int32 `json:"minCpu"`
-	MinMemory               *int32 `json:"minMemory"`
+
+	// MaxPricePerCpu Maximum price per vCPU (hourly, in USD) for instance type filtering.
+	// Instance types whose price/vCPU exceeds this threshold are excluded.
+	// When price adjustments are configured, the filter applies to the adjusted price.
+	MaxPricePerCpu *float64 `json:"maxPricePerCpu"`
+	MinCpu         *int32   `json:"minCpu"`
+	MinMemory      *int32   `json:"minMemory"`
 
 	// OnDemand Should include on-demand instances in the considered pool.
 	OnDemand       *bool                                             `json:"onDemand"`
@@ -11657,6 +11662,7 @@ type DboAPIGetCacheGroupParams struct {
 
 	// MetricsRangeEnd End of period.
 	MetricsRangeEnd *time.Time `form:"metricsRange.end,omitempty" json:"metricsRange.end,omitempty"`
+	Roxy            *bool      `form:"roxy,omitempty" json:"roxy,omitempty"`
 }
 
 // DboAPIGetCacheGroupPerformanceParams defines parameters for DboAPIGetCacheGroupPerformance.
@@ -11678,6 +11684,7 @@ type DboAPIGetCacheGroupPerformanceParams struct {
 
 	// Username Filter by username. Cannot be combined with endpoint_name.
 	Username *string `form:"username,omitempty" json:"username,omitempty"`
+	Roxy     *bool   `form:"roxy,omitempty" json:"roxy,omitempty"`
 }
 
 // DboAPIGetCacheGroupPerformanceSummaryParams defines parameters for DboAPIGetCacheGroupPerformanceSummary.
@@ -11696,6 +11703,7 @@ type DboAPIGetCacheGroupPerformanceSummaryParams struct {
 
 	// Username Filter by username. Cannot be combined with endpoint_name.
 	Username *string `form:"username,omitempty" json:"username,omitempty"`
+	Roxy     *bool   `form:"roxy,omitempty" json:"roxy,omitempty"`
 }
 
 // DboAPIGetCacheGroupMetricsFilterOptionsParams defines parameters for DboAPIGetCacheGroupMetricsFilterOptions.

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -11273,6 +11273,22 @@ func NewExternalClusterAPIGetConnectAndEnableCASTAICmdRequest(server string, par
 
 		}
 
+		if params.InstallReliabilityMetrics != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "installReliabilityMetrics", runtime.ParamLocationQuery, *params.InstallReliabilityMetrics); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -8444,6 +8444,22 @@ func NewDboAPIGetCacheGroupRequest(server string, id string, params *DboAPIGetCa
 
 		}
 
+		if params.Roxy != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "roxy", runtime.ParamLocationQuery, *params.Roxy); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 
@@ -8615,6 +8631,22 @@ func NewDboAPIGetCacheGroupPerformanceRequest(server string, id string, params *
 
 		}
 
+		if params.Roxy != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "roxy", runtime.ParamLocationQuery, *params.Roxy); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 
@@ -8722,6 +8754,22 @@ func NewDboAPIGetCacheGroupPerformanceSummaryRequest(server string, id string, p
 		if params.Username != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "username", runtime.ParamLocationQuery, *params.Username); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Roxy != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "roxy", runtime.ParamLocationQuery, *params.Roxy); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/castai/sdk/omni/api.gen.go
+++ b/castai/sdk/omni/api.gen.go
@@ -178,6 +178,12 @@ type Cluster struct {
 	// Name Name of the cluster.
 	Name *string `json:"name,omitempty"`
 
+	// OmniAgentVersion The version of omni agent running on the cluster.
+	OmniAgentVersion *string `json:"omniAgentVersion,omitempty"`
+
+	// PodCidr The comma-separated list of pod CIDRs of the cluster.
+	PodCidr *string `json:"podCidr,omitempty"`
+
 	// ProviderType The type of the cluster.
 	ProviderType *ClusterProviderType `json:"providerType,omitempty"`
 
@@ -244,8 +250,27 @@ type EdgeClusterCNIOverlayEncap string
 
 // EdgeClusterControlPlane EdgeClusterControlPlane contains control plane configuration overrides for the edge cluster.
 type EdgeClusterControlPlane struct {
+	// ApiServerPort ApiServerPort is the port used for the API server.
+	ApiServerPort *int32 `json:"apiServerPort,omitempty"`
+
+	// ExternalAddress ExternalAddress is the IP address or hostname used to reach the API server from outside the cluster
+	//  if you can't reach in-cluster LoadBalancer services (e.g.: cluster is hidden behind an external LoadBalancer).
+	ExternalAddress *string `json:"externalAddress,omitempty"`
+
 	// Ha Switch from HA mode to single control plane and etcd replica. If not set default is HA.
 	Ha *bool `json:"ha,omitempty"`
+
+	// KonnectivityPort KonnectivityPort is the port used for konnectivity server.
+	KonnectivityPort *int32 `json:"konnectivityPort,omitempty"`
+
+	// ServiceAnnotations ServiceAnnotations are custom annotations to apply to the control plane service.
+	ServiceAnnotations *map[string]string `json:"serviceAnnotations,omitempty"`
+}
+
+// EdgeClusterLiqoSpec EdgeClusterLiqoSpec contains configuration overrides for liqo.
+type EdgeClusterLiqoSpec struct {
+	// GatewayServer GatewayServerConfig contains overrides for the Gateway server.
+	GatewayServer *GatewayServerConfig `json:"gatewayServer,omitempty"`
 }
 
 // EdgeClusterNetworking EdgeClusterNetworking contains networking configuration options for the edge cluster.
@@ -265,6 +290,9 @@ type EdgeClusterNetworking struct {
 type EdgeClusterSpec struct {
 	// ControlPlane Control plane configuration overrides.
 	ControlPlane *EdgeClusterControlPlane `json:"controlPlane,omitempty"`
+
+	// Liqo Liqo configuration overrides.
+	Liqo *EdgeClusterLiqoSpec `json:"liqo,omitempty"`
 
 	// Networking Networking configuration.
 	Networking *EdgeClusterNetworking `json:"networking,omitempty"`
@@ -293,8 +321,11 @@ type EdgeConfiguration struct {
 	// EdgeCount The number of edges using this configuration.
 	EdgeCount *int32 `json:"edgeCount,omitempty"`
 
-	// EdgeLocationId The ID of the Edge Location configuration belongs to.
+	// EdgeLocationId The ID of the Edge Location this Edge Configuration belongs to.
 	EdgeLocationId *string `json:"edgeLocationId,omitempty"`
+
+	// EdgeLocationName The Name of the Edge Location this Edge Configuration belongs to.
+	EdgeLocationName *string `json:"edgeLocationName,omitempty"`
 
 	// Gcp GCP specific configuration.
 	Gcp *GCPConfiguration `json:"gcp,omitempty"`
@@ -607,6 +638,21 @@ type GPUConfigTimeSharing struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 }
 
+// GatewayServerConfig GatewayServerConfig contains configuration overrides for the Liqo gateway server.
+type GatewayServerConfig struct {
+	// ExternalAddress ExternalAddress is the IP address or hostname used to reach the Liqo gateway server from outside the cluster.
+	ExternalAddress *string `json:"externalAddress,omitempty"`
+
+	// ExternalPort ExternalPort is the port used for the Liqo gateway server.
+	ExternalPort *int32 `json:"externalPort,omitempty"`
+
+	// ServiceAnnotations ServiceAnnotations are custom annotations to apply to the Liqo gateway service.
+	ServiceAnnotations *map[string]string `json:"serviceAnnotations,omitempty"`
+
+	// ServiceLabels ServiceLabels are custom labels to apply to the Liqo gateway service.
+	ServiceLabels *map[string]string `json:"serviceLabels,omitempty"`
+}
+
 // GoogleProtobufAny Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
 type GoogleProtobufAny struct {
 	// Type The type of the serialized message.
@@ -710,6 +756,14 @@ type OCIParamCredentials struct {
 
 // OCIParamNetworking Networking configuration of OCI edge location.
 type OCIParamNetworking struct {
+	// AvailabilityDomainWithPrefix The OCI Availability Domain with a prefix - to be used for FSS File Storage by that location.
+	//  Only used if OCI CSI is enabled during onboarding.
+	AvailabilityDomainWithPrefix *string `json:"availabilityDomainWithPrefix,omitempty"`
+
+	// MountTargetId The OCID of the OCI File Storage mount target associated with the edge location.
+	//  Only used if OCI CSI is enabled during onboarding.
+	MountTargetId *string `json:"mountTargetId,omitempty"`
+
 	// SecurityGroupId The id of the security group to be used in the selected region.
 	SecurityGroupId *string `json:"securityGroupId,omitempty"`
 
@@ -776,7 +830,7 @@ type RegisteredClusterStatus struct {
 	// OmniAgentVersion The version of omni agent running on the cluster.
 	OmniAgentVersion string `json:"omniAgentVersion"`
 
-	// PodCidr The pod CIDR of the cluster.
+	// PodCidr The comma-separated list of pod CIDRs of the cluster.
 	PodCidr string `json:"podCidr"`
 }
 
@@ -806,7 +860,7 @@ type ReportStatusRequestCluster struct {
 	// ExternalCidr The external CIDR.
 	ExternalCidr *string `json:"externalCidr,omitempty"`
 
-	// PodCidr The pod CIDR.
+	// PodCidr The comma-separated list of pod CIDRs.
 	PodCidr *string `json:"podCidr,omitempty"`
 
 	// Status The status of the cluster.

--- a/castai/sdk/organization_management/api.gen.go
+++ b/castai/sdk/organization_management/api.gen.go
@@ -111,6 +111,13 @@ const (
 	MEMBERSTATUSUNSPECIFIED   EnterpriseAPIListMembersParamsStatus = "MEMBER_STATUS_UNSPECIFIED"
 )
 
+// Defines values for EnterpriseAPIGetEnterpriseMemberParamsType.
+const (
+	GETENTERPRISEMEMBERTYPEINVITATION  EnterpriseAPIGetEnterpriseMemberParamsType = "GET_ENTERPRISE_MEMBER_TYPE_INVITATION"
+	GETENTERPRISEMEMBERTYPEUNSPECIFIED EnterpriseAPIGetEnterpriseMemberParamsType = "GET_ENTERPRISE_MEMBER_TYPE_UNSPECIFIED"
+	GETENTERPRISEMEMBERTYPEUSER        EnterpriseAPIGetEnterpriseMemberParamsType = "GET_ENTERPRISE_MEMBER_TYPE_USER"
+)
+
 // Defines values for EnterpriseAPIListChildrenOrganizationsParamsSortOrder.
 const (
 	EnterpriseAPIListChildrenOrganizationsParamsSortOrderASC  EnterpriseAPIListChildrenOrganizationsParamsSortOrder = "ASC"
@@ -507,6 +514,36 @@ type BatchUpdateEnterpriseRoleBindingsResponse struct {
 	RoleBindings *[]RoleBinding `json:"roleBindings,omitempty"`
 }
 
+// BatchUpdateEnterpriseServiceAccountsRequest Request message for batch updating service accounts in an enterprise.
+type BatchUpdateEnterpriseServiceAccountsRequest struct {
+	// EnterpriseId ID of the enterprise organization.
+	EnterpriseId string `json:"enterpriseId"`
+
+	// Requests List of service accounts to update. Maximum 100 per request.
+	Requests []BatchUpdateEnterpriseServiceAccountsRequestUpdateServiceAccountRequest `json:"requests"`
+}
+
+// BatchUpdateEnterpriseServiceAccountsRequestUpdateServiceAccountRequest UpdateServiceAccountRequest is a single service account to update.
+type BatchUpdateEnterpriseServiceAccountsRequestUpdateServiceAccountRequest struct {
+	// Description If absent, the existing description is preserved. If present and empty, the description is cleared.
+	Description *string `json:"description,omitempty"`
+
+	// Name If absent, the existing name is preserved.
+	Name *string `json:"name,omitempty"`
+
+	// OrganizationId Organization ID — must be the enterprise itself or a direct child (deleted_at IS NULL).
+	OrganizationId string `json:"organizationId"`
+
+	// ServiceAccountId ID of the service account to update.
+	ServiceAccountId string `json:"serviceAccountId"`
+}
+
+// BatchUpdateEnterpriseServiceAccountsResponse Response message for batch updating service accounts in an enterprise.
+type BatchUpdateEnterpriseServiceAccountsResponse struct {
+	// Items Updated service accounts.
+	Items *[]ListEnterpriseServiceAccountsResponseServiceAccount `json:"items,omitempty"`
+}
+
 // ChildOrganizationOrganizationCounters OrganizationCounters holds organization counters.
 type ChildOrganizationOrganizationCounters struct {
 	// Clusters Number of clusters in the organization.
@@ -634,6 +671,12 @@ type GetEnterpriseGroupResponseGroupDefinition struct {
 
 	// Members Members is a list of members.
 	Members *[]GroupDefinitionMember `json:"members,omitempty"`
+}
+
+// GetEnterpriseMemberResponse GetEnterpriseMemberResponse message containing user or invitation in the enterprise org or its child
+type GetEnterpriseMemberResponse struct {
+	// Item Users in the enterprise or child organization
+	Item *ListMembersResponseItem `json:"item,omitempty"`
 }
 
 // GoogleProtobufAny Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
@@ -1397,6 +1440,15 @@ type EnterpriseAPIListMembersParamsSortOrder string
 // EnterpriseAPIListMembersParamsStatus defines parameters for EnterpriseAPIListMembers.
 type EnterpriseAPIListMembersParamsStatus string
 
+// EnterpriseAPIGetEnterpriseMemberParams defines parameters for EnterpriseAPIGetEnterpriseMember.
+type EnterpriseAPIGetEnterpriseMemberParams struct {
+	// Type Kind of member to fetch. Required; must be either USER or INVITATION.
+	Type *EnterpriseAPIGetEnterpriseMemberParamsType `form:"type,omitempty" json:"type,omitempty"`
+}
+
+// EnterpriseAPIGetEnterpriseMemberParamsType defines parameters for EnterpriseAPIGetEnterpriseMember.
+type EnterpriseAPIGetEnterpriseMemberParamsType string
+
 // EnterpriseAPIListChildrenOrganizationsParams defines parameters for EnterpriseAPIListChildrenOrganizations.
 type EnterpriseAPIListChildrenOrganizationsParams struct {
 	// PageLimit Defines the number of items that should be returned
@@ -1493,6 +1545,9 @@ type EnterpriseAPIBatchCreateEnterpriseServiceAccountsJSONRequestBody = BatchCre
 
 // EnterpriseAPIBatchDeleteEnterpriseServiceAccountsJSONRequestBody defines body for EnterpriseAPIBatchDeleteEnterpriseServiceAccounts for application/json ContentType.
 type EnterpriseAPIBatchDeleteEnterpriseServiceAccountsJSONRequestBody = BatchDeleteEnterpriseServiceAccountsRequest
+
+// EnterpriseAPIBatchUpdateEnterpriseServiceAccountsJSONRequestBody defines body for EnterpriseAPIBatchUpdateEnterpriseServiceAccounts for application/json ContentType.
+type EnterpriseAPIBatchUpdateEnterpriseServiceAccountsJSONRequestBody = BatchUpdateEnterpriseServiceAccountsRequest
 
 // EnterpriseAPIAddUserToChildOrganizationJSONRequestBody defines body for EnterpriseAPIAddUserToChildOrganization for application/json ContentType.
 type EnterpriseAPIAddUserToChildOrganizationJSONRequestBody = AddUserToChildOrganizationRequest

--- a/castai/sdk/organization_management/client.gen.go
+++ b/castai/sdk/organization_management/client.gen.go
@@ -119,6 +119,9 @@ type ClientInterface interface {
 	// EnterpriseAPIListMembers request
 	EnterpriseAPIListMembers(ctx context.Context, enterpriseId string, params *EnterpriseAPIListMembersParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// EnterpriseAPIGetEnterpriseMember request
+	EnterpriseAPIGetEnterpriseMember(ctx context.Context, enterpriseId string, id string, params *EnterpriseAPIGetEnterpriseMemberParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// EnterpriseAPIListChildrenOrganizations request
 	EnterpriseAPIListChildrenOrganizations(ctx context.Context, enterpriseId string, params *EnterpriseAPIListChildrenOrganizationsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -160,6 +163,11 @@ type ClientInterface interface {
 	EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody(ctx context.Context, enterpriseId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	EnterpriseAPIBatchDeleteEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchDeleteEnterpriseServiceAccountsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody request with any body
+	EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody(ctx context.Context, enterpriseId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	EnterpriseAPIBatchUpdateEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchUpdateEnterpriseServiceAccountsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EnterpriseAPIAddUserToChildOrganizationWithBody request with any body
 	EnterpriseAPIAddUserToChildOrganizationWithBody(ctx context.Context, enterpriseId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -294,6 +302,18 @@ func (c *Client) EnterpriseAPIInviteUsers(ctx context.Context, enterpriseId stri
 
 func (c *Client) EnterpriseAPIListMembers(ctx context.Context, enterpriseId string, params *EnterpriseAPIListMembersParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewEnterpriseAPIListMembersRequest(c.Server, enterpriseId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EnterpriseAPIGetEnterpriseMember(ctx context.Context, enterpriseId string, id string, params *EnterpriseAPIGetEnterpriseMemberParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEnterpriseAPIGetEnterpriseMemberRequest(c.Server, enterpriseId, id, params)
 	if err != nil {
 		return nil, err
 	}
@@ -486,6 +506,30 @@ func (c *Client) EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBody(ctx c
 
 func (c *Client) EnterpriseAPIBatchDeleteEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchDeleteEnterpriseServiceAccountsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewEnterpriseAPIBatchDeleteEnterpriseServiceAccountsRequest(c.Server, enterpriseId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody(ctx context.Context, enterpriseId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEnterpriseAPIBatchUpdateEnterpriseServiceAccountsRequestWithBody(c.Server, enterpriseId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EnterpriseAPIBatchUpdateEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchUpdateEnterpriseServiceAccountsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEnterpriseAPIBatchUpdateEnterpriseServiceAccountsRequest(c.Server, enterpriseId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1069,6 +1113,69 @@ func NewEnterpriseAPIListMembersRequest(server string, enterpriseId string, para
 		if params.Status != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, *params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewEnterpriseAPIGetEnterpriseMemberRequest generates requests for EnterpriseAPIGetEnterpriseMember
+func NewEnterpriseAPIGetEnterpriseMemberRequest(server string, enterpriseId string, id string, params *EnterpriseAPIGetEnterpriseMemberParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "enterpriseId", runtime.ParamLocationPath, enterpriseId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/organization-management/v1/enterprises/%s/members/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Type != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "type", runtime.ParamLocationQuery, *params.Type); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -1776,6 +1883,53 @@ func NewEnterpriseAPIBatchDeleteEnterpriseServiceAccountsRequestWithBody(server 
 	return req, nil
 }
 
+// NewEnterpriseAPIBatchUpdateEnterpriseServiceAccountsRequest calls the generic EnterpriseAPIBatchUpdateEnterpriseServiceAccounts builder with application/json body
+func NewEnterpriseAPIBatchUpdateEnterpriseServiceAccountsRequest(server string, enterpriseId string, body EnterpriseAPIBatchUpdateEnterpriseServiceAccountsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEnterpriseAPIBatchUpdateEnterpriseServiceAccountsRequestWithBody(server, enterpriseId, "application/json", bodyReader)
+}
+
+// NewEnterpriseAPIBatchUpdateEnterpriseServiceAccountsRequestWithBody generates requests for EnterpriseAPIBatchUpdateEnterpriseServiceAccounts with any type of body
+func NewEnterpriseAPIBatchUpdateEnterpriseServiceAccountsRequestWithBody(server string, enterpriseId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "enterpriseId", runtime.ParamLocationPath, enterpriseId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/organization-management/v1/enterprises/%s/service-accounts:batchUpdate", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewEnterpriseAPIAddUserToChildOrganizationRequest calls the generic EnterpriseAPIAddUserToChildOrganization builder with application/json body
 func NewEnterpriseAPIAddUserToChildOrganizationRequest(server string, enterpriseId string, body EnterpriseAPIAddUserToChildOrganizationJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -1943,6 +2097,9 @@ type ClientWithResponsesInterface interface {
 	// EnterpriseAPIListMembers request
 	EnterpriseAPIListMembersWithResponse(ctx context.Context, enterpriseId string, params *EnterpriseAPIListMembersParams) (*EnterpriseAPIListMembersResponse, error)
 
+	// EnterpriseAPIGetEnterpriseMember request
+	EnterpriseAPIGetEnterpriseMemberWithResponse(ctx context.Context, enterpriseId string, id string, params *EnterpriseAPIGetEnterpriseMemberParams) (*EnterpriseAPIGetEnterpriseMemberResponse, error)
+
 	// EnterpriseAPIListChildrenOrganizations request
 	EnterpriseAPIListChildrenOrganizationsWithResponse(ctx context.Context, enterpriseId string, params *EnterpriseAPIListChildrenOrganizationsParams) (*EnterpriseAPIListChildrenOrganizationsResponse, error)
 
@@ -1984,6 +2141,11 @@ type ClientWithResponsesInterface interface {
 	EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithBodyWithResponse(ctx context.Context, enterpriseId string, contentType string, body io.Reader) (*EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse, error)
 
 	EnterpriseAPIBatchDeleteEnterpriseServiceAccountsWithResponse(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchDeleteEnterpriseServiceAccountsJSONRequestBody) (*EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse, error)
+
+	// EnterpriseAPIBatchUpdateEnterpriseServiceAccounts request  with any body
+	EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBodyWithResponse(ctx context.Context, enterpriseId string, contentType string, body io.Reader) (*EnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse, error)
+
+	EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithResponse(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchUpdateEnterpriseServiceAccountsJSONRequestBody) (*EnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse, error)
 
 	// EnterpriseAPIAddUserToChildOrganization request  with any body
 	EnterpriseAPIAddUserToChildOrganizationWithBodyWithResponse(ctx context.Context, enterpriseId string, contentType string, body io.Reader) (*EnterpriseAPIAddUserToChildOrganizationResponse, error)
@@ -2216,6 +2378,37 @@ func (r EnterpriseAPIListMembersResponse) StatusCode() int {
 // TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 // Body returns body of byte array
 func (r EnterpriseAPIListMembersResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
+type EnterpriseAPIGetEnterpriseMemberResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *GetEnterpriseMemberResponse
+	JSONDefault  *Status
+}
+
+// Status returns HTTPResponse.Status
+func (r EnterpriseAPIGetEnterpriseMemberResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EnterpriseAPIGetEnterpriseMemberResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r EnterpriseAPIGetEnterpriseMemberResponse) GetBody() []byte {
 	return r.Body
 }
 
@@ -2528,6 +2721,37 @@ func (r EnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse) GetBody() []b
 
 // TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 
+type EnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *BatchUpdateEnterpriseServiceAccountsResponse
+	JSONDefault  *Status
+}
+
+// Status returns HTTPResponse.Status
+func (r EnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r EnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
 type EnterpriseAPIAddUserToChildOrganizationResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -2685,6 +2909,15 @@ func (c *ClientWithResponses) EnterpriseAPIListMembersWithResponse(ctx context.C
 	return ParseEnterpriseAPIListMembersResponse(rsp)
 }
 
+// EnterpriseAPIGetEnterpriseMemberWithResponse request returning *EnterpriseAPIGetEnterpriseMemberResponse
+func (c *ClientWithResponses) EnterpriseAPIGetEnterpriseMemberWithResponse(ctx context.Context, enterpriseId string, id string, params *EnterpriseAPIGetEnterpriseMemberParams) (*EnterpriseAPIGetEnterpriseMemberResponse, error) {
+	rsp, err := c.EnterpriseAPIGetEnterpriseMember(ctx, enterpriseId, id, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEnterpriseAPIGetEnterpriseMemberResponse(rsp)
+}
+
 // EnterpriseAPIListChildrenOrganizationsWithResponse request returning *EnterpriseAPIListChildrenOrganizationsResponse
 func (c *ClientWithResponses) EnterpriseAPIListChildrenOrganizationsWithResponse(ctx context.Context, enterpriseId string, params *EnterpriseAPIListChildrenOrganizationsParams) (*EnterpriseAPIListChildrenOrganizationsResponse, error) {
 	rsp, err := c.EnterpriseAPIListChildrenOrganizations(ctx, enterpriseId, params)
@@ -2821,6 +3054,23 @@ func (c *ClientWithResponses) EnterpriseAPIBatchDeleteEnterpriseServiceAccountsW
 		return nil, err
 	}
 	return ParseEnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse(rsp)
+}
+
+// EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBodyWithResponse request with arbitrary body returning *EnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse
+func (c *ClientWithResponses) EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBodyWithResponse(ctx context.Context, enterpriseId string, contentType string, body io.Reader) (*EnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse, error) {
+	rsp, err := c.EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody(ctx, enterpriseId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse(rsp)
+}
+
+func (c *ClientWithResponses) EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithResponse(ctx context.Context, enterpriseId string, body EnterpriseAPIBatchUpdateEnterpriseServiceAccountsJSONRequestBody) (*EnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse, error) {
+	rsp, err := c.EnterpriseAPIBatchUpdateEnterpriseServiceAccounts(ctx, enterpriseId, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse(rsp)
 }
 
 // EnterpriseAPIAddUserToChildOrganizationWithBodyWithResponse request with arbitrary body returning *EnterpriseAPIAddUserToChildOrganizationResponse
@@ -3064,6 +3314,39 @@ func ParseEnterpriseAPIListMembersResponse(rsp *http.Response) (*EnterpriseAPILi
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ListMembersResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest Status
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEnterpriseAPIGetEnterpriseMemberResponse parses an HTTP response from a EnterpriseAPIGetEnterpriseMemberWithResponse call
+func ParseEnterpriseAPIGetEnterpriseMemberResponse(rsp *http.Response) (*EnterpriseAPIGetEnterpriseMemberResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EnterpriseAPIGetEnterpriseMemberResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest GetEnterpriseMemberResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -3378,6 +3661,39 @@ func ParseEnterpriseAPIBatchDeleteEnterpriseServiceAccountsResponse(rsp *http.Re
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest Status
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse parses an HTTP response from a EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithResponse call
+func ParseEnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse(rsp *http.Response) (*EnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest BatchUpdateEnterpriseServiceAccountsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest Status
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/castai/sdk/organization_management/mock/client.go
+++ b/castai/sdk/organization_management/mock/client.go
@@ -435,6 +435,46 @@ func (mr *MockClientInterfaceMockRecorder) EnterpriseAPIBatchUpdateEnterpriseRol
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchUpdateEnterpriseRoleBindingsWithBody", reflect.TypeOf((*MockClientInterface)(nil).EnterpriseAPIBatchUpdateEnterpriseRoleBindingsWithBody), varargs...)
 }
 
+// EnterpriseAPIBatchUpdateEnterpriseServiceAccounts mocks base method.
+func (m *MockClientInterface) EnterpriseAPIBatchUpdateEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body organization_management.EnterpriseAPIBatchUpdateEnterpriseServiceAccountsJSONRequestBody, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchUpdateEnterpriseServiceAccounts", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchUpdateEnterpriseServiceAccounts indicates an expected call of EnterpriseAPIBatchUpdateEnterpriseServiceAccounts.
+func (mr *MockClientInterfaceMockRecorder) EnterpriseAPIBatchUpdateEnterpriseServiceAccounts(ctx, enterpriseId, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchUpdateEnterpriseServiceAccounts", reflect.TypeOf((*MockClientInterface)(nil).EnterpriseAPIBatchUpdateEnterpriseServiceAccounts), varargs...)
+}
+
+// EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody mocks base method.
+func (m *MockClientInterface) EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody(ctx context.Context, enterpriseId, contentType string, body io.Reader, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody indicates an expected call of EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody.
+func (mr *MockClientInterfaceMockRecorder) EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody(ctx, enterpriseId, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody", reflect.TypeOf((*MockClientInterface)(nil).EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody), varargs...)
+}
+
 // EnterpriseAPICreateChildOrganization mocks base method.
 func (m *MockClientInterface) EnterpriseAPICreateChildOrganization(ctx context.Context, enterpriseId string, body organization_management.EnterpriseAPICreateChildOrganizationJSONRequestBody, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -513,6 +553,26 @@ func (mr *MockClientInterfaceMockRecorder) EnterpriseAPIGetEnterpriseGroup(ctx, 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, enterpriseId, id}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIGetEnterpriseGroup", reflect.TypeOf((*MockClientInterface)(nil).EnterpriseAPIGetEnterpriseGroup), varargs...)
+}
+
+// EnterpriseAPIGetEnterpriseMember mocks base method.
+func (m *MockClientInterface) EnterpriseAPIGetEnterpriseMember(ctx context.Context, enterpriseId, id string, params *organization_management.EnterpriseAPIGetEnterpriseMemberParams, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, id, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIGetEnterpriseMember", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIGetEnterpriseMember indicates an expected call of EnterpriseAPIGetEnterpriseMember.
+func (mr *MockClientInterfaceMockRecorder) EnterpriseAPIGetEnterpriseMember(ctx, enterpriseId, id, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, id, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIGetEnterpriseMember", reflect.TypeOf((*MockClientInterface)(nil).EnterpriseAPIGetEnterpriseMember), varargs...)
 }
 
 // EnterpriseAPIInviteUsers mocks base method.
@@ -1348,6 +1408,76 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIBatchUpdate
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchUpdateEnterpriseRoleBindingsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIBatchUpdateEnterpriseRoleBindingsWithResponse), ctx, enterpriseId, body)
 }
 
+// EnterpriseAPIBatchUpdateEnterpriseServiceAccounts mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIBatchUpdateEnterpriseServiceAccounts(ctx context.Context, enterpriseId string, body organization_management.EnterpriseAPIBatchUpdateEnterpriseServiceAccountsJSONRequestBody, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchUpdateEnterpriseServiceAccounts", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchUpdateEnterpriseServiceAccounts indicates an expected call of EnterpriseAPIBatchUpdateEnterpriseServiceAccounts.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIBatchUpdateEnterpriseServiceAccounts(ctx, enterpriseId, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchUpdateEnterpriseServiceAccounts", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIBatchUpdateEnterpriseServiceAccounts), varargs...)
+}
+
+// EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody(ctx context.Context, enterpriseId, contentType string, body io.Reader, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody indicates an expected call of EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody(ctx, enterpriseId, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBody), varargs...)
+}
+
+// EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBodyWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBodyWithResponse(ctx context.Context, enterpriseId, contentType string, body io.Reader) (*organization_management.EnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBodyWithResponse", ctx, enterpriseId, contentType, body)
+	ret0, _ := ret[0].(*organization_management.EnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBodyWithResponse indicates an expected call of EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBodyWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBodyWithResponse(ctx, enterpriseId, contentType, body interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBodyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithBodyWithResponse), ctx, enterpriseId, contentType, body)
+}
+
+// EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithResponse(ctx context.Context, enterpriseId string, body organization_management.EnterpriseAPIBatchUpdateEnterpriseServiceAccountsJSONRequestBody) (*organization_management.EnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithResponse", ctx, enterpriseId, body)
+	ret0, _ := ret[0].(*organization_management.EnterpriseAPIBatchUpdateEnterpriseServiceAccountsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithResponse indicates an expected call of EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithResponse(ctx, enterpriseId, body interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIBatchUpdateEnterpriseServiceAccountsWithResponse), ctx, enterpriseId, body)
+}
+
 // EnterpriseAPICreateChildOrganization mocks base method.
 func (m *MockClientWithResponsesInterface) EnterpriseAPICreateChildOrganization(ctx context.Context, enterpriseId string, body organization_management.EnterpriseAPICreateChildOrganizationJSONRequestBody, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -1486,6 +1616,41 @@ func (m *MockClientWithResponsesInterface) EnterpriseAPIGetEnterpriseGroupWithRe
 func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIGetEnterpriseGroupWithResponse(ctx, enterpriseId, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIGetEnterpriseGroupWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIGetEnterpriseGroupWithResponse), ctx, enterpriseId, id)
+}
+
+// EnterpriseAPIGetEnterpriseMember mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIGetEnterpriseMember(ctx context.Context, enterpriseId, id string, params *organization_management.EnterpriseAPIGetEnterpriseMemberParams, reqEditors ...organization_management.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, enterpriseId, id, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnterpriseAPIGetEnterpriseMember", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIGetEnterpriseMember indicates an expected call of EnterpriseAPIGetEnterpriseMember.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIGetEnterpriseMember(ctx, enterpriseId, id, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, enterpriseId, id, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIGetEnterpriseMember", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIGetEnterpriseMember), varargs...)
+}
+
+// EnterpriseAPIGetEnterpriseMemberWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) EnterpriseAPIGetEnterpriseMemberWithResponse(ctx context.Context, enterpriseId, id string, params *organization_management.EnterpriseAPIGetEnterpriseMemberParams) (*organization_management.EnterpriseAPIGetEnterpriseMemberResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnterpriseAPIGetEnterpriseMemberWithResponse", ctx, enterpriseId, id, params)
+	ret0, _ := ret[0].(*organization_management.EnterpriseAPIGetEnterpriseMemberResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnterpriseAPIGetEnterpriseMemberWithResponse indicates an expected call of EnterpriseAPIGetEnterpriseMemberWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) EnterpriseAPIGetEnterpriseMemberWithResponse(ctx, enterpriseId, id, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterpriseAPIGetEnterpriseMemberWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).EnterpriseAPIGetEnterpriseMemberWithResponse), ctx, enterpriseId, id, params)
 }
 
 // EnterpriseAPIInviteUsers mocks base method.

--- a/castai/sdk/patching_engine/api.gen.go
+++ b/castai/sdk/patching_engine/api.gen.go
@@ -347,6 +347,9 @@ type ObjectFilterLabelsOperator string
 
 // ObjectFilterV2 ObjectFilterV2 represents an advanced filter for Kubernetes objects with support for exact and regex matching.
 type ObjectFilterV2 struct {
+	// CelExpression CEL expression to filter objects. When set, the object must match the expression.
+	CelExpression *string `json:"celExpression,omitempty"`
+
 	// ExcludeKinds Kinds of the objects that should be excluded from applying mutation. Empty means none kinds.
 	ExcludeKinds *[]ObjectFilterV2Matcher `json:"excludeKinds,omitempty"`
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed

Implements `terraform import` support for the `castai_omni_cluster` resource so existing Omni clusters can be brought under Terraform management. Also regenerates the CAST AI SDK files from the latest OpenAPI specs.

### Why

Without import support, users who already have Omni clusters provisioned outside Terraform would need to recreate them to manage them with this provider.

### Key changes

- `castai/resource_omni_cluster.go`
  - Adds `resource.ResourceWithImportState` interface assertion.
  - Implements `ImportState`, which fetches the cluster by ID, validates the organization ID, reads the Omni cluster details, and populates the resource state with `ID`, `OrganizationID`, `ClusterID`, and `Status` (`OmniAgentVersion`, `PodCIDR`).
- `castai/sdk/api.gen.go`, `castai/sdk/client.gen.go`, `castai/sdk/omni/api.gen.go`, `castai/sdk/organization_management/*`, `castai/sdk/patching_engine/api.gen.go`
  - Regenerated SDK files reflecting the latest API schemas, including new RBAC label selector types, enterprise member/service-account endpoints, node template `MaxPricePerCpu`, workload optimization fields, and Omni cluster status fields.

### Impact

Users can now import an existing Omni cluster with:

```bash
terraform import castai_omni_cluster.<name> <cluster-id>
```

The import reads live cluster data, so the imported state will reflect the current `OrganizationID` and status values returned by the API.