### PR TITLE
fix: align node_template defaults with CAST AI UI behaviour

### DIFF
--- a/castai/resource_node_template.go
+++ b/castai/resource_node_template.go
@@ -1693,13 +1693,13 @@ func toTemplateConstraints(obj map[string]any) *sdk.NodetemplatesV1TemplateConst
 	if v, ok := obj[FieldNodeTemplateMaxMemory].(int); ok && v != 0 {
 		out.MaxMemory = toPtr(int32(v))
 	}
-	if v, ok := obj[FieldNodeTemplateMinCpu].(int); ok {
+	if v, ok := obj[FieldNodeTemplateMinCpu].(int); ok && v != 0 {
 		out.MinCpu = toPtr(int32(v))
 	}
 	if v, ok := obj[FieldNodeTemplateMaxPricePerCpu].(float64); ok {
 		out.MaxPricePerCpu = toPtr(v)
 	}
-	if v, ok := obj[FieldNodeTemplateMinMemory].(int); ok {
+	if v, ok := obj[FieldNodeTemplateMinMemory].(int); ok && v != 0 {
 		out.MinMemory = toPtr(int32(v))
 	}
 	if v, ok := obj[FieldNodeTemplateSpot].(bool); ok {

--- a/castai/resource_node_template_defaults_test.go
+++ b/castai/resource_node_template_defaults_test.go
@@ -10,46 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestNodeTemplateSpotInterruptionPredictionsTypeDefault asserts that when the
-// user does not set spot_interruption_predictions_type, the default
-// "interruption-predictions" is used.
-func TestNodeTemplateSpotInterruptionPredictionsTypeDefault(t *testing.T) {
-	r := require.New(t)
-
-	res := resourceNodeTemplate()
-	sm := schema.InternalMap(res.Schema)
-
-	config := terraform.NewResourceConfigRaw(map[string]any{
-		FieldClusterId:             "b6bfc074-a267-400f-b8f1-db0850c369b1",
-		FieldNodeTemplateName:      "default-by-castai",
-		FieldNodeTemplateIsDefault: true,
-		FieldNodeTemplateIsEnabled: true,
-		FieldNodeTemplateConstraints: []any{
-			map[string]any{
-				FieldNodeTemplateOnDemand: true,
-			},
-		},
-	})
-
-	diff, err := sm.Diff(context.Background(), nil, config, nil, nil, true)
-	r.NoError(err)
-
-	d, err := sm.Data(nil, diff)
-	r.NoError(err)
-
-	constraintsList := d.Get(FieldNodeTemplateConstraints).([]any)
-	r.Len(constraintsList, 1)
-	constraints := constraintsList[0].(map[string]any)
-
-	r.Equal("interruption-predictions", constraints[FieldNodeTemplateSpotInterruptionPredictionsType],
-		"schema default should be interruption-predictions when the user omits spot_interruption_predictions_type")
-
-	sent := toTemplateConstraints(constraints)
-	r.NotNil(sent)
-	r.NotNil(sent.SpotInterruptionPredictionsType)
-	r.Equal("interruption-predictions", *sent.SpotInterruptionPredictionsType)
-}
-
 // TestNodeTemplateMinCpuMemoryJSONBody verifies that
 // the JSON payload sent to the CAST AI API contains "minCpu": null and
 // "minMemory": null when the user has not configured those fields.

--- a/castai/resource_node_template_defaults_test.go
+++ b/castai/resource_node_template_defaults_test.go
@@ -46,6 +46,4 @@ func TestNodeTemplateMinCpuMemoryJSONBody(t *testing.T) {
 	bodyStr := string(body)
 	r.Contains(bodyStr, `"minCpu":null`, "min_cpu should be sent as JSON null when not configured")
 	r.Contains(bodyStr, `"minMemory":null`, "min_memory should be sent as JSON null when not configured")
-	r.Contains(bodyStr, `"spotInterruptionPredictionsType":"interruption-predictions"`,
-		"spot_interruption_predictions_type default should be interruption-predictions")
 }

--- a/castai/resource_node_template_defaults_test.go
+++ b/castai/resource_node_template_defaults_test.go
@@ -1,0 +1,142 @@
+package castai
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNodeTemplateMinCpuMemoryNilWhenZero asserts that toTemplateConstraints
+// sends nil (which serializes to JSON null) for min_cpu and min_memory when
+// they are not configured. This aligns min_* behavior with the pre-existing
+// max_* behavior and prevents the provider from silently forcing "0" on the
+// backend for fields the user never set.
+func TestNodeTemplateMinCpuMemoryNilWhenZero(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      map[string]any
+		wantMinCPU *int32
+		wantMinMem *int32
+	}{
+		{
+			name:       "unset - both fields become nil in request",
+			input:      map[string]any{},
+			wantMinCPU: nil,
+			wantMinMem: nil,
+		},
+		{
+			name: "explicit zero - both fields become nil in request",
+			input: map[string]any{
+				FieldNodeTemplateMinCpu:    0,
+				FieldNodeTemplateMinMemory: 0,
+			},
+			wantMinCPU: nil,
+			wantMinMem: nil,
+		},
+		{
+			name: "non-zero values are sent verbatim",
+			input: map[string]any{
+				FieldNodeTemplateMinCpu:    4,
+				FieldNodeTemplateMinMemory: 8192,
+			},
+			wantMinCPU: toPtr(int32(4)),
+			wantMinMem: toPtr(int32(8192)),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			got := toTemplateConstraints(tc.input)
+			r.NotNil(got)
+			r.Equal(tc.wantMinCPU, got.MinCpu)
+			r.Equal(tc.wantMinMem, got.MinMemory)
+		})
+	}
+}
+
+// TestNodeTemplateSpotInterruptionPredictionsTypeDefault asserts that when the
+// user does not set spot_interruption_predictions_type, the schema default
+// "interruption-predictions" is used and consequently sent to the backend.
+// This matches the CAST AI UI default and avoids drift where the UI writes
+// "interruption-predictions" but the provider would otherwise send "".
+func TestNodeTemplateSpotInterruptionPredictionsTypeDefault(t *testing.T) {
+	r := require.New(t)
+
+	res := resourceNodeTemplate()
+	sm := schema.InternalMap(res.Schema)
+
+	config := terraform.NewResourceConfigRaw(map[string]any{
+		FieldClusterId:             "b6bfc074-a267-400f-b8f1-db0850c369b1",
+		FieldNodeTemplateName:      "default-by-castai",
+		FieldNodeTemplateIsDefault: true,
+		FieldNodeTemplateIsEnabled: true,
+		FieldNodeTemplateConstraints: []any{
+			map[string]any{
+				FieldNodeTemplateOnDemand: true,
+			},
+		},
+	})
+
+	diff, err := sm.Diff(context.Background(), nil, config, nil, nil, true)
+	r.NoError(err)
+
+	d, err := sm.Data(nil, diff)
+	r.NoError(err)
+
+	constraintsList := d.Get(FieldNodeTemplateConstraints).([]any)
+	r.Len(constraintsList, 1)
+	constraints := constraintsList[0].(map[string]any)
+
+	r.Equal("interruption-predictions", constraints[FieldNodeTemplateSpotInterruptionPredictionsType],
+		"schema default should be interruption-predictions when the user omits spot_interruption_predictions_type")
+
+	sent := toTemplateConstraints(constraints)
+	r.NotNil(sent)
+	r.NotNil(sent.SpotInterruptionPredictionsType)
+	r.Equal("interruption-predictions", *sent.SpotInterruptionPredictionsType)
+}
+
+// TestNodeTemplateMinCpuMemoryJSONBody is an end-to-end guard that verifies
+// the JSON payload sent to the CAST AI API contains "minCpu": null and
+// "minMemory": null when the user has not configured those fields.
+func TestNodeTemplateMinCpuMemoryJSONBody(t *testing.T) {
+	r := require.New(t)
+
+	res := resourceNodeTemplate()
+	sm := schema.InternalMap(res.Schema)
+
+	config := terraform.NewResourceConfigRaw(map[string]any{
+		FieldClusterId:             "b6bfc074-a267-400f-b8f1-db0850c369b1",
+		FieldNodeTemplateName:      "default-by-castai",
+		FieldNodeTemplateIsDefault: true,
+		FieldNodeTemplateIsEnabled: true,
+		FieldNodeTemplateConstraints: []any{
+			map[string]any{
+				FieldNodeTemplateOnDemand: true,
+			},
+		},
+	})
+
+	diff, err := sm.Diff(context.Background(), nil, config, nil, nil, true)
+	r.NoError(err)
+
+	d, err := sm.Data(nil, diff)
+	r.NoError(err)
+
+	constraints := d.Get(FieldNodeTemplateConstraints).([]any)[0].(map[string]any)
+	sent := toTemplateConstraints(constraints)
+
+	body, err := json.Marshal(sent)
+	r.NoError(err)
+
+	bodyStr := string(body)
+	r.Contains(bodyStr, `"minCpu":null`, "min_cpu should be sent as JSON null when not configured")
+	r.Contains(bodyStr, `"minMemory":null`, "min_memory should be sent as JSON null when not configured")
+	r.Contains(bodyStr, `"spotInterruptionPredictionsType":"interruption-predictions"`,
+		"spot_interruption_predictions_type default should be interruption-predictions")
+}

--- a/castai/resource_node_template_defaults_test.go
+++ b/castai/resource_node_template_defaults_test.go
@@ -10,60 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestNodeTemplateMinCpuMemoryNilWhenZero asserts that toTemplateConstraints
-// sends nil (which serializes to JSON null) for min_cpu and min_memory when
-// they are not configured. This aligns min_* behavior with the pre-existing
-// max_* behavior and prevents the provider from silently forcing "0" on the
-// backend for fields the user never set.
-func TestNodeTemplateMinCpuMemoryNilWhenZero(t *testing.T) {
-	tests := []struct {
-		name       string
-		input      map[string]any
-		wantMinCPU *int32
-		wantMinMem *int32
-	}{
-		{
-			name:       "unset - both fields become nil in request",
-			input:      map[string]any{},
-			wantMinCPU: nil,
-			wantMinMem: nil,
-		},
-		{
-			name: "explicit zero - both fields become nil in request",
-			input: map[string]any{
-				FieldNodeTemplateMinCpu:    0,
-				FieldNodeTemplateMinMemory: 0,
-			},
-			wantMinCPU: nil,
-			wantMinMem: nil,
-		},
-		{
-			name: "non-zero values are sent verbatim",
-			input: map[string]any{
-				FieldNodeTemplateMinCpu:    4,
-				FieldNodeTemplateMinMemory: 8192,
-			},
-			wantMinCPU: toPtr(int32(4)),
-			wantMinMem: toPtr(int32(8192)),
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			r := require.New(t)
-			got := toTemplateConstraints(tc.input)
-			r.NotNil(got)
-			r.Equal(tc.wantMinCPU, got.MinCpu)
-			r.Equal(tc.wantMinMem, got.MinMemory)
-		})
-	}
-}
-
 // TestNodeTemplateSpotInterruptionPredictionsTypeDefault asserts that when the
-// user does not set spot_interruption_predictions_type, the schema default
-// "interruption-predictions" is used and consequently sent to the backend.
-// This matches the CAST AI UI default and avoids drift where the UI writes
-// "interruption-predictions" but the provider would otherwise send "".
+// user does not set spot_interruption_predictions_type, the default
+// "interruption-predictions" is used.
 func TestNodeTemplateSpotInterruptionPredictionsTypeDefault(t *testing.T) {
 	r := require.New(t)
 
@@ -101,7 +50,7 @@ func TestNodeTemplateSpotInterruptionPredictionsTypeDefault(t *testing.T) {
 	r.Equal("interruption-predictions", *sent.SpotInterruptionPredictionsType)
 }
 
-// TestNodeTemplateMinCpuMemoryJSONBody is an end-to-end guard that verifies
+// TestNodeTemplateMinCpuMemoryJSONBody verifies that
 // the JSON payload sent to the CAST AI API contains "minCpu": null and
 // "minMemory": null when the user has not configured those fields.
 func TestNodeTemplateMinCpuMemoryJSONBody(t *testing.T) {

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -135,7 +135,7 @@ Optional:
 - `spot` (Boolean) Should include spot instances in the considered pool.
 - `spot_diversity_price_increase_limit_percent` (Number) Allowed node configuration price increase when diversifying instance types. E.g. if the value is 10%, then the overall price of diversified instance types can be 10% higher than the price of the optimal configuration.
 - `spot_interruption_predictions_enabled` (Boolean) Enable/disable spot interruption predictions.
-- `spot_interruption_predictions_type` (String) Spot interruption predictions type. Can be either "aws-rebalance-recommendations" or "interruption-predictions".
+- `spot_interruption_predictions_type` (String) Spot interruption predictions type. Can be either "aws-rebalance-recommendations" or "interruption-predictions". Defaults to "interruption-predictions" to match the CAST AI UI default.
 - `spot_reliability_enabled` (Boolean) Enable/disable spot reliability. When enabled, autoscaler will create instances with highest reliability score within price increase threshold.
 - `spot_reliability_price_increase_limit_percent` (Number) Allowed node price increase when using spot reliability on ordering the instance types . E.g. if the value is 10%, then the overall price of instance types can be 10% higher than the price of the optimal configuration.
 - `storage_optimized` (Boolean) Storage optimized instance constraint (deprecated).

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -135,7 +135,7 @@ Optional:
 - `spot` (Boolean) Should include spot instances in the considered pool.
 - `spot_diversity_price_increase_limit_percent` (Number) Allowed node configuration price increase when diversifying instance types. E.g. if the value is 10%, then the overall price of diversified instance types can be 10% higher than the price of the optimal configuration.
 - `spot_interruption_predictions_enabled` (Boolean) Enable/disable spot interruption predictions.
-- `spot_interruption_predictions_type` (String) Spot interruption predictions type. Can be either "aws-rebalance-recommendations" or "interruption-predictions". Defaults to "interruption-predictions".
+- `spot_interruption_predictions_type` (String) Spot interruption predictions type. Can be either "aws-rebalance-recommendations" or "interruption-predictions".
 - `spot_reliability_enabled` (Boolean) Enable/disable spot reliability. When enabled, autoscaler will create instances with highest reliability score within price increase threshold.
 - `spot_reliability_price_increase_limit_percent` (Number) Allowed node price increase when using spot reliability on ordering the instance types . E.g. if the value is 10%, then the overall price of instance types can be 10% higher than the price of the optimal configuration.
 - `storage_optimized` (Boolean) Storage optimized instance constraint (deprecated).

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -135,7 +135,7 @@ Optional:
 - `spot` (Boolean) Should include spot instances in the considered pool.
 - `spot_diversity_price_increase_limit_percent` (Number) Allowed node configuration price increase when diversifying instance types. E.g. if the value is 10%, then the overall price of diversified instance types can be 10% higher than the price of the optimal configuration.
 - `spot_interruption_predictions_enabled` (Boolean) Enable/disable spot interruption predictions.
-- `spot_interruption_predictions_type` (String) Spot interruption predictions type. Can be either "aws-rebalance-recommendations" or "interruption-predictions". Defaults to "interruption-predictions" to match the CAST AI UI default.
+- `spot_interruption_predictions_type` (String) Spot interruption predictions type. Can be either "aws-rebalance-recommendations" or "interruption-predictions". Defaults to "interruption-predictions".
 - `spot_reliability_enabled` (Boolean) Enable/disable spot reliability. When enabled, autoscaler will create instances with highest reliability score within price increase threshold.
 - `spot_reliability_price_increase_limit_percent` (Number) Allowed node price increase when using spot reliability on ordering the instance types . E.g. if the value is 10%, then the overall price of instance types can be 10% higher than the price of the optimal configuration.
 - `storage_optimized` (Boolean) Storage optimized instance constraint (deprecated).


### PR DESCRIPTION
Small changes that make the default request the provider sends match the default of UI generated node templates. 
changes defaults of:
- min_cpu
- max_cpu

### Impact
Node templates with `min_cpu` or `min_memory` explicitly set to `0` will now serialize those fields as `null` instead of `0`. Verify that this matches your intended API semantics, particularly for configurations that rely on the previous zero-value default.