### PR TITLE
feat: support max price per cpu constraint

### DIFF
--- a/castai/resource_allocation_group.go
+++ b/castai/resource_allocation_group.go
@@ -63,9 +63,9 @@ func resourceAllocationGroup() *schema.Resource {
 	OR (default) - workload needs to have at least one label to be included
 	AND - workload needs to have all the labels to be included`,
 				Optional: true,
-				Default:  sdk.OR,
+				Default:  sdk.CostreportV1beta1FilterOperatorOR,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
-					string(sdk.AND), string(sdk.OR),
+					string(sdk.CostreportV1beta1FilterOperatorAND), string(sdk.CostreportV1beta1FilterOperatorOR),
 				}, false)),
 			},
 		},
@@ -231,7 +231,7 @@ func resourceAllocationGroupDelete(ctx context.Context, d *schema.ResourceData, 
 }
 
 func toLabelsOperator(d *schema.ResourceData) *sdk.CostreportV1beta1FilterOperator {
-	defaultLabelOperator := sdk.OR
+	defaultLabelOperator := sdk.CostreportV1beta1FilterOperatorOR
 	if v, ok := d.GetOk("labels_operator"); ok {
 		if lv := v.(string); lv != "" {
 			labelOperator := sdk.CostreportV1beta1FilterOperator(lv)
@@ -260,7 +260,7 @@ func toLabels(lv map[string]interface{}) []sdk.CostreportV1beta1AllocationGroupF
 	if len(lv) > 0 {
 		labelsStringMap := toStringMap(lv)
 
-		operator := sdk.CostreportV1beta1AllocationGroupFilterLabelValueOperatorEqual
+		operator := sdk.Equal
 
 		if len(labelsStringMap) > 0 {
 			labels := make([]sdk.CostreportV1beta1AllocationGroupFilterLabelValue, 0, len(labelsStringMap))

--- a/castai/resource_node_template.go
+++ b/castai/resource_node_template.go
@@ -51,6 +51,7 @@ const (
 	FieldNodeTemplateMinCount                                 = "min_count"
 	FieldNodeTemplateMinCpu                                   = "min_cpu"
 	FieldNodeTemplateMinMemory                                = "min_memory"
+	FieldNodeTemplateMaxPricePerCpu                           = "max_price_per_cpu"
 	FieldNodeTemplateName                                     = "name"
 	FieldNodeTemplateOnDemand                                 = "on_demand"
 	FieldNodeTemplateOs                                       = "os"
@@ -296,6 +297,11 @@ func resourceNodeTemplate() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "Min CPU cores per node.",
+						},
+						FieldNodeTemplateMaxPricePerCpu: {
+							Type:        schema.TypeFloat,
+							Optional:    true,
+							Description: "Maximum price per vCPU threshold. When price adjustments are configured, the filter applies to the adjusted price.",
 						},
 						FieldNodeTemplateMaxCpu: {
 							Type:        schema.TypeInt,
@@ -1081,6 +1087,9 @@ func flattenConstraints(c *sdk.NodetemplatesV1TemplateConstraints) ([]map[string
 	if c.MinCpu != nil {
 		out[FieldNodeTemplateMinCpu] = c.MinCpu
 	}
+	if c.MaxPricePerCpu != nil {
+		out[FieldNodeTemplateMaxPricePerCpu] = c.MaxPricePerCpu
+	}
 	if c.MaxCpu != nil {
 		out[FieldNodeTemplateMaxCpu] = c.MaxCpu
 	}
@@ -1686,6 +1695,9 @@ func toTemplateConstraints(obj map[string]any) *sdk.NodetemplatesV1TemplateConst
 	}
 	if v, ok := obj[FieldNodeTemplateMinCpu].(int); ok {
 		out.MinCpu = toPtr(int32(v))
+	}
+	if v, ok := obj[FieldNodeTemplateMaxPricePerCpu].(float64); ok {
+		out.MaxPricePerCpu = toPtr(v)
 	}
 	if v, ok := obj[FieldNodeTemplateMinMemory].(int); ok {
 		out.MinMemory = toPtr(int32(v))

--- a/castai/resource_node_template_test.go
+++ b/castai/resource_node_template_test.go
@@ -222,6 +222,7 @@ constraints.0.instance_families.0.include.# = 0
 constraints.0.is_gpu_only = false
 constraints.0.max_cpu = 10000
 constraints.0.max_memory = 0
+constraints.0.max_price_per_cpu = 0
 constraints.0.min_cpu = 10
 constraints.0.min_memory = 0
 constraints.0.dedicated_node_affinity.# = 1

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -227,18 +227,17 @@ const (
 
 // Defines values for CastaiRbacV1beta1LabelSelectorCondition.
 const (
-	LABELSELECTORCONDITIONAND         CastaiRbacV1beta1LabelSelectorCondition = "LABEL_SELECTOR_CONDITION_AND"
-	LABELSELECTORCONDITIONOR          CastaiRbacV1beta1LabelSelectorCondition = "LABEL_SELECTOR_CONDITION_OR"
-	LABELSELECTORCONDITIONUNSPECIFIED CastaiRbacV1beta1LabelSelectorCondition = "LABEL_SELECTOR_CONDITION_UNSPECIFIED"
+	CastaiRbacV1beta1LabelSelectorConditionAND         CastaiRbacV1beta1LabelSelectorCondition = "AND"
+	CastaiRbacV1beta1LabelSelectorConditionOR          CastaiRbacV1beta1LabelSelectorCondition = "OR"
+	CastaiRbacV1beta1LabelSelectorConditionUNSPECIFIED CastaiRbacV1beta1LabelSelectorCondition = "UNSPECIFIED"
 )
 
 // Defines values for CastaiRbacV1beta1LabelSelectorOperator.
 const (
-	LABELSELECTOROPERATORDOESNOTEXIST CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_DOES_NOT_EXIST"
-	LABELSELECTOROPERATOREXISTS       CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_EXISTS"
-	LABELSELECTOROPERATORIN           CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_IN"
-	LABELSELECTOROPERATORNOTIN        CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_NOT_IN"
-	LABELSELECTOROPERATORUNSPECIFIED  CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_UNSPECIFIED"
+	CastaiRbacV1beta1LabelSelectorOperatorDOESNOTEXIST CastaiRbacV1beta1LabelSelectorOperator = "DOES_NOT_EXIST"
+	CastaiRbacV1beta1LabelSelectorOperatorEXISTS       CastaiRbacV1beta1LabelSelectorOperator = "EXISTS"
+	CastaiRbacV1beta1LabelSelectorOperatorIN           CastaiRbacV1beta1LabelSelectorOperator = "IN"
+	CastaiRbacV1beta1LabelSelectorOperatorNOTIN        CastaiRbacV1beta1LabelSelectorOperator = "NOT_IN"
 )
 
 // Defines values for CastaiRbacV1beta1PoliciesState.
@@ -293,16 +292,16 @@ const (
 
 // Defines values for CostreportV1beta1AllocationGroupFilterLabelValueOperator.
 const (
-	CostreportV1beta1AllocationGroupFilterLabelValueOperatorDoesNotExist CostreportV1beta1AllocationGroupFilterLabelValueOperator = "DoesNotExist"
-	CostreportV1beta1AllocationGroupFilterLabelValueOperatorEqual        CostreportV1beta1AllocationGroupFilterLabelValueOperator = "Equal"
-	CostreportV1beta1AllocationGroupFilterLabelValueOperatorExists       CostreportV1beta1AllocationGroupFilterLabelValueOperator = "Exists"
-	CostreportV1beta1AllocationGroupFilterLabelValueOperatorNotEqual     CostreportV1beta1AllocationGroupFilterLabelValueOperator = "NotEqual"
+	DoesNotExist CostreportV1beta1AllocationGroupFilterLabelValueOperator = "DoesNotExist"
+	Equal        CostreportV1beta1AllocationGroupFilterLabelValueOperator = "Equal"
+	Exists       CostreportV1beta1AllocationGroupFilterLabelValueOperator = "Exists"
+	NotEqual     CostreportV1beta1AllocationGroupFilterLabelValueOperator = "NotEqual"
 )
 
 // Defines values for CostreportV1beta1FilterOperator.
 const (
-	AND CostreportV1beta1FilterOperator = "AND"
-	OR  CostreportV1beta1FilterOperator = "OR"
+	CostreportV1beta1FilterOperatorAND CostreportV1beta1FilterOperator = "AND"
+	CostreportV1beta1FilterOperatorOR  CostreportV1beta1FilterOperator = "OR"
 )
 
 // Defines values for CostreportV1beta1NoDataReason.
@@ -3177,11 +3176,29 @@ type CastaiRbacV1beta1OrganizationScope struct {
 
 // CastaiRbacV1beta1PermissionGroup PermissionGroup represents a named group of permissions.
 type CastaiRbacV1beta1PermissionGroup struct {
+	// CategoryDescription Description of the category.
+	CategoryDescription *string `json:"categoryDescription,omitempty"`
+
+	// CategoryDisplayName Human-readable display name for the category.
+	CategoryDisplayName *string `json:"categoryDisplayName,omitempty"`
+
+	// Description Description of the permission group.
+	Description *string `json:"description,omitempty"`
+
+	// DisplayName Human-readable display name for the permission group.
+	DisplayName *string `json:"displayName,omitempty"`
+
 	// Name Name of the permission group.
 	Name *string `json:"name,omitempty"`
 
 	// Permissions List of permissions in this group.
 	Permissions *[]CastaiRbacV1beta1Permissions `json:"permissions,omitempty"`
+
+	// ResourceDescription Description of the resource.
+	ResourceDescription *string `json:"resourceDescription,omitempty"`
+
+	// ResourceDisplayName Human-readable display name for the resource.
+	ResourceDisplayName *string `json:"resourceDisplayName,omitempty"`
 }
 
 // CastaiRbacV1beta1Permissions defines model for castai.rbac.v1beta1.Permissions.
@@ -3802,6 +3819,9 @@ type CastaiUsersV1beta1CurrentUserProfileResponse struct {
 	// Email User email.
 	Email     *string `json:"email,omitempty"`
 	EmailHash *string `json:"emailHash,omitempty"`
+
+	// Fingerprint Fingerprint is a unique identifier for the user's device or browser.
+	Fingerprint *string `json:"fingerprint"`
 
 	// FirstLogin User first login.
 	FirstLogin *bool `json:"firstLogin,omitempty"`

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -126,6 +126,7 @@ Optional:
 - `is_gpu_only` (Boolean) GPU instance constraint - will only pick nodes with GPU if true
 - `max_cpu` (Number) Max CPU cores per node.
 - `max_memory` (Number) Max Memory (Mib) per node.
+- `max_price_per_cpu` (Number) Maximum price per vCPU threshold. When price adjustments are configured, the filter applies to the adjusted price.
 - `min_cpu` (Number) Min CPU cores per node.
 - `min_memory` (Number) Min Memory (Mib) per node.
 - `on_demand` (Boolean) Should include on-demand instances in the considered pool.


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for a `max_price_per_cpu` constraint on CAST AI node templates, allowing users to set a maximum price per vCPU threshold that also respects configured price adjustments.

### Why
Provides finer-grained cost control over node template candidate selection by filtering out instance types whose per-vCPU price exceeds the configured limit.

### Key changes
- `castai/resource_node_template.go`: adds `max_price_per_cpu` field to node template constraints schema, flattening, and Terraform-to-SDK mapping.
- `castai/resource_node_template_test.go`: updates expected test output to include `constraints.0.max_price_per_cpu`.
- `docs/resources/node_template.md`: documents the new `max_price_per_cpu` constraint.
- `castai/sdk/api.gen.go`: regenerates SDK types, updating enum constant names and values (e.g. `CostreportV1beta1FilterOperatorAND`, shorter enum strings) and adding new permission/user profile fields.
- `castai/resource_allocation_group.go`: updates references to regenerated SDK enum constants for filter and label operators.

### Impact
- Users can now specify `constraints.max_price_per_cpu` in `castai_node_template` resources.
- The SDK regeneration changes enum string values and constant names; existing state using the old enum values may require a refresh/plan cycle but should remain compatible because the new values match the API contract.