### PR TITLE
KUBE-1439: Remove ec2:CreateKeyPair permission

### DIFF
--- a/castai/policies/iam-policy.json
+++ b/castai/policies/iam-policy.json
@@ -28,7 +28,6 @@
       "Effect": "Allow",
       "Action": [
         "iam:CreateServiceLinkedRole",
-        "ec2:CreateKeyPair",
         "ec2:CreateTags",
         "ec2:DeleteKeyPair",
         "ec2:DescribeCapacityReservations",

--- a/examples/eks/eks_cluster_optional_readonly/iam.tf
+++ b/examples/eks/eks_cluster_optional_readonly/iam.tf
@@ -126,7 +126,6 @@ resource "aws_iam_role_policy" "inline_role_policy" {
         Effect = "Allow",
         Action = [
           "ec2:CreateTags",
-          "ec2:CreateKeyPair",
           "ec2:DeleteKeyPair",
           "ec2:CreateTags",
           "ec2:ImportKeyPair",


### PR DESCRIPTION
**What changed**

Removed the ec2:CreateKeyPair permission from the IAM Policy.

**Why**

 The `ec2:CreateKeyPair `permission was never actually used via an SDK API call . It was only listed as an IAM permission string in managed  policies and onboarding scripts. Several customers raised concerns about its inclusion in the EKS cross-role policy for no apparent reason, so it was cleaned up.   

**Impact**

 - No functional change, this permission was never exercised by any SDK call.                                                                                                                               
 - No impact on ec2:DeleteKeyPair and ec2:ImportKeyPair, those remain because they are actually used via the AWS SDK in the key pair lifecycle.

---
### Kimchi Summary
### What changed
Removed the unused `ec2:CreateKeyPair` permission from the CAST AI IAM policy template and the optional readonly EKS cluster example IAM policy.

### Why
`ec2:CreateKeyPair` is no longer required for CAST AI cluster operations, so it is being removed from the documented policies to follow the principle of least privilege.

### Key changes
- `castai/policies/iam-policy.json`: Removed `ec2:CreateKeyPair` from the `Action` list.
- `examples/eks/eks_cluster_optional_readonly/iam.tf`: Removed `ec2:CreateKeyPair` from the inline role policy `Action` list.

### Impact
This is a policy-tightening change with no expected runtime impact. Users applying the updated example policy will grant one fewer EC2 permission, but functionality remains unchanged.