### PR TITLE
Add readonly EKS example with kvisor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .vscode/
+.kimchi/
 
 # Claude Code context file
 CLAUDE.md

--- a/examples/eks/eks_cluster_readonly_kvisor/README.MD
+++ b/examples/eks/eks_cluster_readonly_kvisor/README.MD
@@ -1,0 +1,41 @@
+# Example of existing EKS cluster connected to CAST AI in READ-ONLY mode with Kvisor storage metrics
+
+Following this example onboards an existing EKS cluster to CAST AI in read-only mode (Phase 1) and installs the CAST AI Kvisor component to collect storage metrics.
+
+> **Prerequisites**
+> - An existing EKS cluster.
+> - IAM Roles for Service Accounts (IRSA) enabled on the cluster, i.e. an OIDC identity provider associated with the EKS cluster.
+> - AWS CLI configured with credentials that can access the cluster.
+
+Kvisor uses IAM Roles for Service Accounts (IRSA) to assume an AWS IAM role that is allowed to call `ec2:DescribeVolumes`. The role is trusted by the `castai-kvisor-controller` service account in the `castai-agent` namespace via the EKS OIDC provider.
+
+Example configuration should be analysed in the following order:
+1. Configure providers and data sources - `providers.tf`
+2. Configure CAST AI related resources to connect the existing EKS cluster to CAST AI in read-only mode and install Kvisor - `castai.tf`
+
+## Usage
+1. Copy `terraform.tfvars.example` to `terraform.tfvars`
+2. Update `terraform.tfvars` file with your cluster name, cluster region, CAST AI API token, and optional Kvisor gRPC address
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| cluster_name | Name of the existing EKS cluster | - |
+| cluster_region | AWS region of the existing EKS cluster | - |
+| castai_api_token | CAST AI API token created in console.cast.ai API Access keys section | - |
+| castai_api_url | CAST AI API URL | https://api.cast.ai |
+| kvisor_grpc_addr | CAST AI Kvisor gRPC address | kvisor.prod-master.cast.ai:443 |
+
+3. Initialize Terraform. Under example root folder run:
+```
+terraform init
+```
+4. Run Terraform apply:
+```
+terraform apply
+```
+5. To destroy resources created by this example:
+```
+terraform destroy
+```
+
+Please refer to this guide if you run into any issues https://docs.cast.ai/docs/terraform-troubleshooting

--- a/examples/eks/eks_cluster_readonly_kvisor/castai.tf
+++ b/examples/eks/eks_cluster_readonly_kvisor/castai.tf
@@ -1,0 +1,155 @@
+# Connect existing EKS cluster to CAST AI in read-only mode and install Kvisor for storage metrics.
+
+data "aws_caller_identity" "current" {}
+
+data "aws_eks_cluster" "existing_cluster" {
+  name = var.cluster_name
+}
+
+data "aws_iam_openid_connect_provider" "eks" {
+  url = data.aws_eks_cluster.existing_cluster.identity[0].oidc[0].issuer
+}
+
+locals {
+  oidc_issuer = trimprefix(data.aws_eks_cluster.existing_cluster.identity[0].oidc[0].issuer, "https://")
+}
+
+# Configure EKS cluster connection to CAST AI in read-only mode.
+resource "castai_eks_cluster" "this" {
+  account_id = data.aws_caller_identity.current.account_id
+  region     = var.cluster_region
+  name       = var.cluster_name
+}
+
+resource "helm_release" "castai_agent" {
+  name             = "castai-agent"
+  repository       = "https://castai.github.io/helm-charts"
+  chart            = "castai-agent"
+  namespace        = "castai-agent"
+  create_namespace = true
+  cleanup_on_fail  = true
+
+  set = concat(
+    [
+      {
+        name  = "provider"
+        value = "eks"
+      },
+      {
+        # Required until https://github.com/castai/helm-charts/issues/135 is fixed.
+        name  = "createNamespace"
+        value = "false"
+      },
+    ],
+    var.castai_api_url != "" ? [{
+      name  = "apiURL"
+      value = var.castai_api_url
+    }] : [],
+  )
+
+  set_sensitive = [
+    {
+      name  = "apiKey"
+      value = castai_eks_cluster.this.cluster_token
+    },
+  ]
+}
+
+# IAM role for Kvisor controller (IRSA) to describe EBS volumes for storage metrics.
+data "aws_iam_policy_document" "kvisor_controller_assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.eks.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_issuer}:sub"
+      values   = ["system:serviceaccount:castai-agent:castai-kvisor-controller"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_issuer}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "kvisor_controller" {
+  name               = "${var.cluster_name}-castai-kvisor-controller"
+  assume_role_policy = data.aws_iam_policy_document.kvisor_controller_assume_role.json
+}
+
+data "aws_iam_policy_document" "kvisor_controller" {
+  statement {
+    actions   = ["ec2:DescribeVolumes"]
+    resources = ["*"]
+    effect    = "Allow"
+  }
+}
+
+resource "aws_iam_role_policy" "kvisor_controller" {
+  name   = "castai-kvisor-controller"
+  role   = aws_iam_role.kvisor_controller.id
+  policy = data.aws_iam_policy_document.kvisor_controller.json
+}
+
+resource "helm_release" "castai_kvisor" {
+  name             = "castai-kvisor"
+  repository       = "https://castai.github.io/helm-charts"
+  chart            = "castai-kvisor"
+  namespace        = "castai-agent"
+  create_namespace = true
+  cleanup_on_fail  = true
+
+  set = [
+    {
+      name  = "castai.clusterID"
+      value = castai_eks_cluster.this.id
+    },
+    {
+      name  = "castai.grpcAddr"
+      value = var.kvisor_grpc_addr
+    },
+    {
+      name  = "controller.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+      value = aws_iam_role.kvisor_controller.arn
+    },
+    {
+      name  = "controller.serviceAccount.name"
+      value = "castai-kvisor-controller"
+    },
+    {
+      name  = "controller.extraArgs.cloud-provider"
+      value = "aws"
+    },
+    {
+      name  = "controller.extraArgs.cloud-provider-aws-region"
+      value = var.cluster_region
+    },
+    {
+      name  = "controller.extraArgs.cloud-provider-storage-sync-enabled"
+      value = "true"
+    },
+    {
+      name  = "agent.enabled"
+      value = "true"
+    },
+    {
+      name  = "agent.extraArgs.storage-stats-enabled"
+      value = "true"
+    },
+  ]
+
+  set_sensitive = [
+    {
+      name  = "castai.apiKey"
+      value = castai_eks_cluster.this.cluster_token
+    },
+  ]
+}

--- a/examples/eks/eks_cluster_readonly_kvisor/providers.tf
+++ b/examples/eks/eks_cluster_readonly_kvisor/providers.tf
@@ -1,0 +1,33 @@
+# Following providers required by EKS and CAST AI modules.
+provider "aws" {
+  region = var.cluster_region
+}
+
+provider "castai" {
+  api_token = var.castai_api_token
+  api_url   = var.castai_api_url
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.existing_cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.existing_cluster.certificate_authority.0.data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    # This requires the awscli to be installed locally where Terraform is executed
+    args = ["eks", "get-token", "--cluster-name", var.cluster_name, "--region", var.cluster_region]
+  }
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = data.aws_eks_cluster.existing_cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.existing_cluster.certificate_authority.0.data)
+    exec = {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      # This requires the awscli to be installed locally where Terraform is executed.
+      args = ["eks", "get-token", "--cluster-name", var.cluster_name, "--region", var.cluster_region]
+    }
+  }
+}

--- a/examples/eks/eks_cluster_readonly_kvisor/terraform.tfvars.example
+++ b/examples/eks/eks_cluster_readonly_kvisor/terraform.tfvars.example
@@ -1,0 +1,5 @@
+cluster_name     = "<place-holder>"
+cluster_region   = "<place-holder>"
+castai_api_token = "<place-holder>"
+castai_api_url   = "https://api.cast.ai"
+kvisor_grpc_addr = "kvisor.prod-master.cast.ai:443"

--- a/examples/eks/eks_cluster_readonly_kvisor/variables.tf
+++ b/examples/eks/eks_cluster_readonly_kvisor/variables.tf
@@ -1,0 +1,28 @@
+# EKS module variables.
+variable "cluster_name" {
+  type        = string
+  description = "EKS cluster name in AWS account."
+}
+
+variable "cluster_region" {
+  type        = string
+  description = "AWS Region in which EKS cluster and supporting resources will be created."
+}
+
+# Variables required for connecting EKS cluster to CAST AI
+variable "castai_api_token" {
+  type        = string
+  description = "CAST AI API token created in console.cast.ai API Access keys section"
+}
+
+variable "castai_api_url" {
+  type        = string
+  description = "CAST AI url to API, default value is https://api.cast.ai"
+  default     = "https://api.cast.ai"
+}
+
+variable "kvisor_grpc_addr" {
+  type        = string
+  description = "CAST AI Kvisor gRPC address."
+  default     = "kvisor.prod-master.cast.ai:443"
+}

--- a/examples/eks/eks_cluster_readonly_kvisor/versions.tf
+++ b/examples/eks/eks_cluster_readonly_kvisor/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    castai = {
+      source = "castai/castai"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+  required_version = ">= 1.3.2"
+}


### PR DESCRIPTION
The example covers Kvisor with storage metrics enabled, but can be expanded to include other monitoring features.

---
### Kimchi Summary
### What changed
Adds a new Terraform example under `examples/eks/eks_cluster_readonly_kvisor/` that demonstrates how to onboard an existing EKS cluster to CAST AI in read-only mode and install the CAST AI Kvisor component to collect storage metrics. Also adds `.kimchi/` to `.gitignore`.

### Why
Provides a ready-to-use reference configuration for users who want to run CAST AI in read-only mode (Phase 1) while enabling Kvisor storage metrics collection via IRSA.

### Key changes
- **`examples/eks/eks_cluster_readonly_kvisor/castai.tf`** — Configures `castai_eks_cluster` for read-only onboarding, deploys the `castai-agent` Helm chart, creates an IRSA IAM role with `ec2:DescribeVolumes` permission, and deploys the `castai-kvisor` Helm chart with storage metrics enabled.
- **`examples/eks/eks_cluster_readonly_kvisor/providers.tf`** — Configures the `aws`, `castai`, `kubernetes`, and `helm` providers, including EKS `get-token` exec authentication.
- **`examples/eks/eks_cluster_readonly_kvisor/variables.tf`** — Defines input variables for `cluster_name`, `cluster_region`, `castai_api_token`, `castai_api_url`, and `kvisor_grpc_addr`.
- **`examples/eks/eks_cluster_readonly_kvisor/versions.tf`** — Pins required provider versions (`helm ~> 3.0`, `aws ~> 6.0`) and sets Terraform `>= 1.3.2`.
- **`examples/eks/eks_cluster_readonly_kvisor/terraform.tfvars.example`** — Provides placeholder values for required variables.
- **`examples/eks/eks_cluster_readonly_kvisor/README.MD`** — Documents prerequisites, configuration order, usage steps, and variable descriptions.
- **`.gitignore`** — Adds `.kimchi/` to the ignore list.

### Impact
No breaking changes. These are additive documentation/example files plus a minor `.gitignore` update.