### PR TITLE
CO-4590: Deprecate Node AWS Rebalancing Recommendation

### DIFF
--- a/castai/resource_autoscaler.go
+++ b/castai/resource_autoscaler.go
@@ -391,9 +391,19 @@ func resourceAutoscaler() *schema.Resource {
 												FieldSpotInterruptionPredictionsType: {
 													Type:             schema.TypeString,
 													Optional:         true,
-													Default:          "AWSRebalanceRecommendations",
-													Description:      "define the type of the spot interruption prediction to handle. Allowed values are AWSRebalanceRecommendations, CASTAIInterruptionPredictions.",
+													Default:          "CASTAIInterruptionPredictions",
+													Description:      "define the type of the spot interruption prediction to handle. The value \"AWSRebalanceRecommendations\" is deprecated; use \"CASTAIInterruptionPredictions\".",
+													Deprecated:       "The value \"AWSRebalanceRecommendations\" is deprecated. Cast AI ML predictions are now used for all spot interruption prediction.",
 													ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"AWSRebalanceRecommendations", "CASTAIInterruptionPredictions"}, false)),
+													DiffSuppressFunc: func(k, oldVal, newVal string, d *schema.ResourceData) bool {
+														normalize := func(v string) string {
+															if v == "AWSRebalanceRecommendations" {
+																return "CASTAIInterruptionPredictions"
+															}
+															return v
+														}
+														return normalize(oldVal) == normalize(newVal)
+													},
 												},
 											},
 										},

--- a/castai/resource_node_template.go
+++ b/castai/resource_node_template.go
@@ -291,8 +291,13 @@ func resourceNodeTemplate() *schema.Resource {
 						FieldNodeTemplateSpotInterruptionPredictionsType: {
 							Type:             schema.TypeString,
 							Optional:         true,
-							Description:      "Spot interruption predictions type. Can be either \"aws-rebalance-recommendations\" or \"interruption-predictions\".",
+							Default:          "interruption-predictions",
+							Description:      "Spot interruption predictions type. Only \"interruption-predictions\" is supported.",
+							Deprecated:       "The value \"aws-rebalance-recommendations\" is deprecated and will be removed in a future major version. Cast AI ML predictions (\"interruption-predictions\") are now used for all spot interruption prediction.",
 							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"aws-rebalance-recommendations", "interruption-predictions"}, false)),
+							DiffSuppressFunc: func(k, oldVal, newVal string, d *schema.ResourceData) bool {
+								return normalizeSpotInterruptionPredictionsType(oldVal) == normalizeSpotInterruptionPredictionsType(newVal)
+							},
 						},
 						FieldNodeTemplateMinCpu: {
 							Type:        schema.TypeInt,
@@ -1077,8 +1082,10 @@ func flattenConstraints(c *sdk.NodetemplatesV1TemplateConstraints) ([]map[string
 		out[FieldNodeTemplateSpotInterruptionPredictionsEnabled] = c.SpotInterruptionPredictionsEnabled
 	}
 	if c.SpotInterruptionPredictionsType != nil {
-		out[FieldNodeTemplateSpotInterruptionPredictionsType] = c.SpotInterruptionPredictionsType
+		normalized := normalizeSpotInterruptionPredictionsType(*c.SpotInterruptionPredictionsType)
+		out[FieldNodeTemplateSpotInterruptionPredictionsType] = &normalized
 	}
+
 	if c.MinMemory != nil {
 		out[FieldNodeTemplateMinMemory] = c.MinMemory
 	}
@@ -1756,7 +1763,7 @@ func toTemplateConstraints(obj map[string]any) *sdk.NodetemplatesV1TemplateConst
 		out.SpotInterruptionPredictionsEnabled = toPtr(v)
 	}
 	if v, ok := obj[FieldNodeTemplateSpotInterruptionPredictionsType].(string); ok {
-		out.SpotInterruptionPredictionsType = toPtr(v)
+		out.SpotInterruptionPredictionsType = toPtr(normalizeSpotInterruptionPredictionsType(v))
 	}
 	if v, ok := obj[FieldNodeTemplateCustomPriority].([]any); ok && len(v) > 0 {
 		if ok {
@@ -2145,4 +2152,13 @@ func gpuSharingStrategyToTerraform(s sdk.NodetemplatesV1GPUSharingStrategy) stri
 	default:
 		return ""
 	}
+}
+
+// normalizeSpotInterruptionPredictionsType maps the deprecated "aws-rebalance-recommendations"
+// value to "interruption-predictions". Used in DiffSuppressFunc and read-path normalization.
+func normalizeSpotInterruptionPredictionsType(v string) string {
+	if v == "aws-rebalance-recommendations" {
+		return "interruption-predictions"
+	}
+	return v
 }

--- a/castai/resource_node_template_test.go
+++ b/castai/resource_node_template_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/samber/lo"
 
 	"github.com/golang/mock/gomock"
@@ -248,7 +249,7 @@ constraints.0.spot_diversity_price_increase_limit_percent = 20
 constraints.0.spot_reliability_enabled = true
 constraints.0.spot_reliability_price_increase_limit_percent = 10
 constraints.0.spot_interruption_predictions_enabled = true
-constraints.0.spot_interruption_predictions_type = aws-rebalance-recommendations
+constraints.0.spot_interruption_predictions_type = interruption-predictions
 constraints.0.storage_optimized = false
 constraints.0.storage_optimized_state = enabled
 constraints.0.use_spot_fallbacks = false
@@ -1794,6 +1795,126 @@ func Test_toTemplateConstraintsAWSConstraints(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := toTemplateConstraintsAWSConstraints(tt.input)
 			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_normalizeSpotInterruptionPredictionsType(t *testing.T) {
+	tests := map[string]struct {
+		input string
+		want  string
+	}{
+		"aws-rebalance-recommendations is normalized": {
+			input: "aws-rebalance-recommendations",
+			want:  "interruption-predictions",
+		},
+		"interruption-predictions stays as-is": {
+			input: "interruption-predictions",
+			want:  "interruption-predictions",
+		},
+		"empty string stays as-is": {
+			input: "",
+			want:  "",
+		},
+		"unknown value stays as-is": {
+			input: "some-other-value",
+			want:  "some-other-value",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := normalizeSpotInterruptionPredictionsType(tt.input)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_flattenConstraints_normalizesSpotInterruptionPredictionsType(t *testing.T) {
+	tests := map[string]struct {
+		apiType  string
+		wantType string
+	}{
+		"aws-rebalance-recommendations normalized on read": {
+			apiType:  "aws-rebalance-recommendations",
+			wantType: "interruption-predictions",
+		},
+		"interruption-predictions stays on read": {
+			apiType:  "interruption-predictions",
+			wantType: "interruption-predictions",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			input := &sdk.NodetemplatesV1TemplateConstraints{
+				SpotInterruptionPredictionsEnabled: toPtr(true),
+				SpotInterruptionPredictionsType:    toPtr(tt.apiType),
+			}
+			result, err := flattenConstraints(input)
+			require.NoError(t, err)
+			require.Len(t, result, 1)
+			got, ok := result[0][FieldNodeTemplateSpotInterruptionPredictionsType].(*string)
+			require.True(t, ok)
+			require.Equal(t, tt.wantType, *got)
+		})
+	}
+}
+
+func Test_toNodeTemplateConstraints_normalizesSpotInterruptionPredictionsType(t *testing.T) {
+	tests := map[string]struct {
+		inputType string
+		wantType  string
+	}{
+		"aws-rebalance-recommendations normalized on write": {
+			inputType: "aws-rebalance-recommendations",
+			wantType:  "interruption-predictions",
+		},
+		"interruption-predictions stays on write": {
+			inputType: "interruption-predictions",
+			wantType:  "interruption-predictions",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			obj := map[string]any{
+				FieldNodeTemplateSpotInterruptionPredictionsEnabled: true,
+				FieldNodeTemplateSpotInterruptionPredictionsType:    tt.inputType,
+			}
+			result := toTemplateConstraints(obj)
+			require.NotNil(t, result.SpotInterruptionPredictionsType)
+			require.Equal(t, tt.wantType, *result.SpotInterruptionPredictionsType)
+		})
+	}
+}
+
+func Test_spotInterruptionPredictionsType_diffSuppression(t *testing.T) {
+	s := resourceNodeTemplate().Schema["constraints"].Elem.(*schema.Resource).Schema[FieldNodeTemplateSpotInterruptionPredictionsType]
+	require.NotNil(t, s.DiffSuppressFunc)
+
+	tests := map[string]struct {
+		oldVal       string
+		newVal       string
+		wantSuppress bool
+	}{
+		"same value - suppress": {
+			oldVal: "interruption-predictions", newVal: "interruption-predictions", wantSuppress: true,
+		},
+		"deprecated old, normalized new - suppress": {
+			oldVal: "aws-rebalance-recommendations", newVal: "interruption-predictions", wantSuppress: true,
+		},
+		"normalized old, deprecated new - suppress": {
+			oldVal: "interruption-predictions", newVal: "aws-rebalance-recommendations", wantSuppress: true,
+		},
+		"both deprecated - suppress": {
+			oldVal: "aws-rebalance-recommendations", newVal: "aws-rebalance-recommendations", wantSuppress: true,
+		},
+		"different real values - no suppress": {
+			oldVal: "interruption-predictions", newVal: "some-other-value", wantSuppress: false,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := s.DiffSuppressFunc("", tt.oldVal, tt.newVal, nil)
+			require.Equal(t, tt.wantSuppress, got)
 		})
 	}
 }

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -227,18 +227,17 @@ const (
 
 // Defines values for CastaiRbacV1beta1LabelSelectorCondition.
 const (
-	LABELSELECTORCONDITIONAND         CastaiRbacV1beta1LabelSelectorCondition = "LABEL_SELECTOR_CONDITION_AND"
-	LABELSELECTORCONDITIONOR          CastaiRbacV1beta1LabelSelectorCondition = "LABEL_SELECTOR_CONDITION_OR"
-	LABELSELECTORCONDITIONUNSPECIFIED CastaiRbacV1beta1LabelSelectorCondition = "LABEL_SELECTOR_CONDITION_UNSPECIFIED"
+	CastaiRbacV1beta1LabelSelectorConditionAND         CastaiRbacV1beta1LabelSelectorCondition = "AND"
+	CastaiRbacV1beta1LabelSelectorConditionOR          CastaiRbacV1beta1LabelSelectorCondition = "OR"
+	CastaiRbacV1beta1LabelSelectorConditionUNSPECIFIED CastaiRbacV1beta1LabelSelectorCondition = "UNSPECIFIED"
 )
 
 // Defines values for CastaiRbacV1beta1LabelSelectorOperator.
 const (
-	LABELSELECTOROPERATORDOESNOTEXIST CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_DOES_NOT_EXIST"
-	LABELSELECTOROPERATOREXISTS       CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_EXISTS"
-	LABELSELECTOROPERATORIN           CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_IN"
-	LABELSELECTOROPERATORNOTIN        CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_NOT_IN"
-	LABELSELECTOROPERATORUNSPECIFIED  CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_UNSPECIFIED"
+	CastaiRbacV1beta1LabelSelectorOperatorDOESNOTEXIST CastaiRbacV1beta1LabelSelectorOperator = "DOES_NOT_EXIST"
+	CastaiRbacV1beta1LabelSelectorOperatorEXISTS       CastaiRbacV1beta1LabelSelectorOperator = "EXISTS"
+	CastaiRbacV1beta1LabelSelectorOperatorIN           CastaiRbacV1beta1LabelSelectorOperator = "IN"
+	CastaiRbacV1beta1LabelSelectorOperatorNOTIN        CastaiRbacV1beta1LabelSelectorOperator = "NOT_IN"
 )
 
 // Defines values for CastaiRbacV1beta1PoliciesState.
@@ -293,16 +292,16 @@ const (
 
 // Defines values for CostreportV1beta1AllocationGroupFilterLabelValueOperator.
 const (
-	CostreportV1beta1AllocationGroupFilterLabelValueOperatorDoesNotExist CostreportV1beta1AllocationGroupFilterLabelValueOperator = "DoesNotExist"
-	CostreportV1beta1AllocationGroupFilterLabelValueOperatorEqual        CostreportV1beta1AllocationGroupFilterLabelValueOperator = "Equal"
-	CostreportV1beta1AllocationGroupFilterLabelValueOperatorExists       CostreportV1beta1AllocationGroupFilterLabelValueOperator = "Exists"
-	CostreportV1beta1AllocationGroupFilterLabelValueOperatorNotEqual     CostreportV1beta1AllocationGroupFilterLabelValueOperator = "NotEqual"
+	DoesNotExist CostreportV1beta1AllocationGroupFilterLabelValueOperator = "DoesNotExist"
+	Equal        CostreportV1beta1AllocationGroupFilterLabelValueOperator = "Equal"
+	Exists       CostreportV1beta1AllocationGroupFilterLabelValueOperator = "Exists"
+	NotEqual     CostreportV1beta1AllocationGroupFilterLabelValueOperator = "NotEqual"
 )
 
 // Defines values for CostreportV1beta1FilterOperator.
 const (
-	AND CostreportV1beta1FilterOperator = "AND"
-	OR  CostreportV1beta1FilterOperator = "OR"
+	CostreportV1beta1FilterOperatorAND CostreportV1beta1FilterOperator = "AND"
+	CostreportV1beta1FilterOperatorOR  CostreportV1beta1FilterOperator = "OR"
 )
 
 // Defines values for CostreportV1beta1NoDataReason.
@@ -3206,11 +3205,29 @@ type CastaiRbacV1beta1OrganizationScope struct {
 
 // CastaiRbacV1beta1PermissionGroup PermissionGroup represents a named group of permissions.
 type CastaiRbacV1beta1PermissionGroup struct {
+	// CategoryDescription Description of the category.
+	CategoryDescription *string `json:"categoryDescription,omitempty"`
+
+	// CategoryDisplayName Human-readable display name for the category.
+	CategoryDisplayName *string `json:"categoryDisplayName,omitempty"`
+
+	// Description Description of the permission group.
+	Description *string `json:"description,omitempty"`
+
+	// DisplayName Human-readable display name for the permission group.
+	DisplayName *string `json:"displayName,omitempty"`
+
 	// Name Name of the permission group.
 	Name *string `json:"name,omitempty"`
 
 	// Permissions List of permissions in this group.
 	Permissions *[]CastaiRbacV1beta1Permissions `json:"permissions,omitempty"`
+
+	// ResourceDescription Description of the resource.
+	ResourceDescription *string `json:"resourceDescription,omitempty"`
+
+	// ResourceDisplayName Human-readable display name for the resource.
+	ResourceDisplayName *string `json:"resourceDisplayName,omitempty"`
 }
 
 // CastaiRbacV1beta1Permissions defines model for castai.rbac.v1beta1.Permissions.
@@ -3831,6 +3848,9 @@ type CastaiUsersV1beta1CurrentUserProfileResponse struct {
 	// Email User email.
 	Email     *string `json:"email,omitempty"`
 	EmailHash *string `json:"emailHash,omitempty"`
+
+	// Fingerprint Fingerprint is a unique identifier for the user's device or browser.
+	Fingerprint *string `json:"fingerprint"`
 
 	// FirstLogin User first login.
 	FirstLogin *bool `json:"firstLogin,omitempty"`

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -227,17 +227,18 @@ const (
 
 // Defines values for CastaiRbacV1beta1LabelSelectorCondition.
 const (
-	CastaiRbacV1beta1LabelSelectorConditionAND         CastaiRbacV1beta1LabelSelectorCondition = "AND"
-	CastaiRbacV1beta1LabelSelectorConditionOR          CastaiRbacV1beta1LabelSelectorCondition = "OR"
-	CastaiRbacV1beta1LabelSelectorConditionUNSPECIFIED CastaiRbacV1beta1LabelSelectorCondition = "UNSPECIFIED"
+	LABELSELECTORCONDITIONAND         CastaiRbacV1beta1LabelSelectorCondition = "LABEL_SELECTOR_CONDITION_AND"
+	LABELSELECTORCONDITIONOR          CastaiRbacV1beta1LabelSelectorCondition = "LABEL_SELECTOR_CONDITION_OR"
+	LABELSELECTORCONDITIONUNSPECIFIED CastaiRbacV1beta1LabelSelectorCondition = "LABEL_SELECTOR_CONDITION_UNSPECIFIED"
 )
 
 // Defines values for CastaiRbacV1beta1LabelSelectorOperator.
 const (
-	CastaiRbacV1beta1LabelSelectorOperatorDOESNOTEXIST CastaiRbacV1beta1LabelSelectorOperator = "DOES_NOT_EXIST"
-	CastaiRbacV1beta1LabelSelectorOperatorEXISTS       CastaiRbacV1beta1LabelSelectorOperator = "EXISTS"
-	CastaiRbacV1beta1LabelSelectorOperatorIN           CastaiRbacV1beta1LabelSelectorOperator = "IN"
-	CastaiRbacV1beta1LabelSelectorOperatorNOTIN        CastaiRbacV1beta1LabelSelectorOperator = "NOT_IN"
+	LABELSELECTOROPERATORDOESNOTEXIST CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_DOES_NOT_EXIST"
+	LABELSELECTOROPERATOREXISTS       CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_EXISTS"
+	LABELSELECTOROPERATORIN           CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_IN"
+	LABELSELECTOROPERATORNOTIN        CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_NOT_IN"
+	LABELSELECTOROPERATORUNSPECIFIED  CastaiRbacV1beta1LabelSelectorOperator = "LABEL_SELECTOR_OPERATOR_UNSPECIFIED"
 )
 
 // Defines values for CastaiRbacV1beta1PoliciesState.
@@ -292,16 +293,16 @@ const (
 
 // Defines values for CostreportV1beta1AllocationGroupFilterLabelValueOperator.
 const (
-	DoesNotExist CostreportV1beta1AllocationGroupFilterLabelValueOperator = "DoesNotExist"
-	Equal        CostreportV1beta1AllocationGroupFilterLabelValueOperator = "Equal"
-	Exists       CostreportV1beta1AllocationGroupFilterLabelValueOperator = "Exists"
-	NotEqual     CostreportV1beta1AllocationGroupFilterLabelValueOperator = "NotEqual"
+	CostreportV1beta1AllocationGroupFilterLabelValueOperatorDoesNotExist CostreportV1beta1AllocationGroupFilterLabelValueOperator = "DoesNotExist"
+	CostreportV1beta1AllocationGroupFilterLabelValueOperatorEqual        CostreportV1beta1AllocationGroupFilterLabelValueOperator = "Equal"
+	CostreportV1beta1AllocationGroupFilterLabelValueOperatorExists       CostreportV1beta1AllocationGroupFilterLabelValueOperator = "Exists"
+	CostreportV1beta1AllocationGroupFilterLabelValueOperatorNotEqual     CostreportV1beta1AllocationGroupFilterLabelValueOperator = "NotEqual"
 )
 
 // Defines values for CostreportV1beta1FilterOperator.
 const (
-	CostreportV1beta1FilterOperatorAND CostreportV1beta1FilterOperator = "AND"
-	CostreportV1beta1FilterOperatorOR  CostreportV1beta1FilterOperator = "OR"
+	AND CostreportV1beta1FilterOperator = "AND"
+	OR  CostreportV1beta1FilterOperator = "OR"
 )
 
 // Defines values for CostreportV1beta1NoDataReason.
@@ -3205,29 +3206,11 @@ type CastaiRbacV1beta1OrganizationScope struct {
 
 // CastaiRbacV1beta1PermissionGroup PermissionGroup represents a named group of permissions.
 type CastaiRbacV1beta1PermissionGroup struct {
-	// CategoryDescription Description of the category.
-	CategoryDescription *string `json:"categoryDescription,omitempty"`
-
-	// CategoryDisplayName Human-readable display name for the category.
-	CategoryDisplayName *string `json:"categoryDisplayName,omitempty"`
-
-	// Description Description of the permission group.
-	Description *string `json:"description,omitempty"`
-
-	// DisplayName Human-readable display name for the permission group.
-	DisplayName *string `json:"displayName,omitempty"`
-
 	// Name Name of the permission group.
 	Name *string `json:"name,omitempty"`
 
 	// Permissions List of permissions in this group.
 	Permissions *[]CastaiRbacV1beta1Permissions `json:"permissions,omitempty"`
-
-	// ResourceDescription Description of the resource.
-	ResourceDescription *string `json:"resourceDescription,omitempty"`
-
-	// ResourceDisplayName Human-readable display name for the resource.
-	ResourceDisplayName *string `json:"resourceDisplayName,omitempty"`
 }
 
 // CastaiRbacV1beta1Permissions defines model for castai.rbac.v1beta1.Permissions.
@@ -3848,9 +3831,6 @@ type CastaiUsersV1beta1CurrentUserProfileResponse struct {
 	// Email User email.
 	Email     *string `json:"email,omitempty"`
 	EmailHash *string `json:"emailHash,omitempty"`
-
-	// Fingerprint Fingerprint is a unique identifier for the user's device or browser.
-	Fingerprint *string `json:"fingerprint"`
 
 	// FirstLogin User first login.
 	FirstLogin *bool `json:"firstLogin,omitempty"`

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -7985,10 +7985,14 @@ type PoliciesV1SpotInterruptionPredictions struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// Type SpotInterruptionPredictionsType defines the type of the SPOT interruption predictions to enable.
+	//
+	//  - AWSRebalanceRecommendations: Deprecated: Switch to Cast AI ML Interruption predictions instead.
 	Type *PoliciesV1SpotInterruptionPredictionsType `json:"type,omitempty"`
 }
 
 // PoliciesV1SpotInterruptionPredictionsType SpotInterruptionPredictionsType defines the type of the SPOT interruption predictions to enable.
+//
+//   - AWSRebalanceRecommendations: Deprecated: Switch to Cast AI ML Interruption predictions instead.
 type PoliciesV1SpotInterruptionPredictionsType string
 
 // PoliciesV1UnschedulablePodsPolicy Policy defining autoscaler's behavior when unscedulable pods were detected.

--- a/docs/resources/autoscaler.md
+++ b/docs/resources/autoscaler.md
@@ -164,7 +164,7 @@ Optional:
 Optional:
 
 - `enabled` (Boolean) enable/disable spot interruption predictions.
-- `spot_interruption_predictions_type` (String) define the type of the spot interruption prediction to handle. Allowed values are AWSRebalanceRecommendations, CASTAIInterruptionPredictions.
+- `spot_interruption_predictions_type` (String, Deprecated) define the type of the spot interruption prediction to handle. The value "AWSRebalanceRecommendations" is deprecated; use "CASTAIInterruptionPredictions".
 
 
 

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -135,7 +135,7 @@ Optional:
 - `spot` (Boolean) Should include spot instances in the considered pool.
 - `spot_diversity_price_increase_limit_percent` (Number) Allowed node configuration price increase when diversifying instance types. E.g. if the value is 10%, then the overall price of diversified instance types can be 10% higher than the price of the optimal configuration.
 - `spot_interruption_predictions_enabled` (Boolean) Enable/disable spot interruption predictions.
-- `spot_interruption_predictions_type` (String) Spot interruption predictions type. Can be either "aws-rebalance-recommendations" or "interruption-predictions".
+- `spot_interruption_predictions_type` (String, Deprecated) Spot interruption predictions type. Only "interruption-predictions" is supported.
 - `spot_reliability_enabled` (Boolean) Enable/disable spot reliability. When enabled, autoscaler will create instances with highest reliability score within price increase threshold.
 - `spot_reliability_price_increase_limit_percent` (Number) Allowed node price increase when using spot reliability on ordering the instance types . E.g. if the value is 10%, then the overall price of instance types can be 10% higher than the price of the optimal configuration.
 - `storage_optimized` (Boolean) Storage optimized instance constraint (deprecated).


### PR DESCRIPTION
This MR deprecates AWS Rebalancing Recommendation option `aws-rebalance-recommendations` for Resource Node Template, making Cast AI ML the only option: `interruption-predictions`.

---
### Kimchi Summary
### What changed
Deprecates the legacy AWS rebalance-recommendation spot interruption prediction type and makes Cast AI ML predictions the default across the provider. Existing configurations using the old value continue to work but are normalized internally, and Terraform diffs are suppressed when the old and new values map to the same underlying prediction type.

### Why
Cast AI ML predictions are now used for all spot interruption prediction, so the legacy `AWSRebalanceRecommendations` / `aws-rebalance-recommendations` option is obsolete. Smoothing the transition avoids forcing immediate state migrations while guiding users to the supported setting.

### Key changes

- `castai/resource_autoscaler.go`
  - Changed the default for `spot_interruption_predictions_type` from `AWSRebalanceRecommendations` to `CASTAIInterruptionPredictions`.
  - Marked the old value as deprecated.
  - Added `DiffSuppressFunc` to treat `AWSRebalanceRecommendations` as equivalent to `CASTAIInterruptionPredictions`.

- `castai/resource_node_template.go`
  - Added a default value of `interruption-predictions` for `FieldNodeTemplateSpotInterruptionPredictionsType`.
  - Deprecated `aws-rebalance-recommendations` and updated the description.
  - Added `DiffSuppressFunc` to suppress diffs between the deprecated and normalized values.
  - Updated `flattenConstraints` and `toTemplateConstraints` to normalize the deprecated value via `normalizeSpotInterruptionPredictionsType`.
  - Added `normalizeSpotInterruptionPredictionsType` helper.

- `castai/resource_node_template_test.go`
  - Added unit tests for normalization, read/write path normalization, and diff suppression behavior.

- `docs/resources/autoscaler.md` and `docs/resources/node_template.md`
  - Updated documentation to reflect deprecation and the new default.

### Impact

- Existing Terraform configs that explicitly set the deprecated value will continue to plan/apply cleanly because the diff suppression and normalization treat both values as equivalent.
- The effective default prediction type changes to Cast AI ML predictions (`CASTAIInterruptionPredictions` / `interruption-predictations`). For most users this is transparent, but plans may show a one-time suppressed update if the previous default was recorded.
- The deprecated values remain valid in `ValidateDiagFunc` for backward compatibility; they will be removed in a future major version.