### PR TITLE
KUBE-1439: Remove ec2:CreateKeyPair permission

### DIFF
--- a/castai/policies/iam-policy.json
+++ b/castai/policies/iam-policy.json
@@ -28,7 +28,6 @@
       "Effect": "Allow",
       "Action": [
         "iam:CreateServiceLinkedRole",
-        "ec2:CreateKeyPair",
         "ec2:CreateTags",
         "ec2:DeleteKeyPair",
         "ec2:DescribeCapacityReservations",

--- a/examples/eks/eks_cluster_optional_readonly/iam.tf
+++ b/examples/eks/eks_cluster_optional_readonly/iam.tf
@@ -126,7 +126,6 @@ resource "aws_iam_role_policy" "inline_role_policy" {
         Effect = "Allow",
         Action = [
           "ec2:CreateTags",
-          "ec2:CreateKeyPair",
           "ec2:DeleteKeyPair",
           "ec2:CreateTags",
           "ec2:ImportKeyPair",

--- a/examples/eks/eks_cluster_optional_readonly/iam.tf
+++ b/examples/eks/eks_cluster_optional_readonly/iam.tf
@@ -127,7 +127,6 @@ resource "aws_iam_role_policy" "inline_role_policy" {
         Action = [
           "ec2:CreateTags",
           "ec2:DeleteKeyPair",
-          "ec2:CreateTags",
           "ec2:ImportKeyPair",
         ],
         Resource = "*"


### PR DESCRIPTION
**What changed**

Removed the ec2:CreateKeyPair permission from the IAM Policy.

**Why**

The ec2:CreateKeyPair permission was never actually used via an SDK API call . It was only listed as an IAM permission string in managed policies and onboarding scripts. Several customers raised concerns about its inclusion in the EKS cross-role policy for no apparent reason, so it was cleaned up.

**Impact**

No functional change, this permission was never exercised by any SDK call.
No impact on ec2:DeleteKeyPair and ec2:ImportKeyPair, those remain because they are actually used via the AWS SDK in the key pair lifecycle.

**Proof of work**

After the testing of EKS successfully onboarded cluster, we can see the Role doesn't contains anymore the ecs:CreateKeyPair permission. Import key-pair functionality was not altered, see attached images of SSH public key added from the Console for an onboarded cluster and how it's imported on EC2 Key-pairs:

```
{
    "Statement": [
        {
            "Action": "iam:PassRole",
            "Condition": {
                "StringEquals": {
                    "iam:PassedToService": "ec2.amazonaws.com"
                }
            },
            "Effect": "Allow",
            "Resource": "arn:aws:iam::*:role/*",
            "Sid": "PassRoleEC2"
        },
        {
            "Action": "iam:PassRole",
            "Condition": {
                "StringEquals": {
                    "iam:PassedToService": "eks.amazonaws.com"
                }
            },
            "Effect": "Allow",
            "Resource": "arn:aws:iam::*:role/*",
            "Sid": "PassRoleEKS"
        },
        {
            "Action": [
                "iam:CreateServiceLinkedRole",
                "ec2:CreateKeyPair",
                "ec2:CreateTags",
                "ec2:DeleteKeyPair",
                "ec2:DescribeCapacityReservations",
                "ec2:ImportKeyPair"
            ],
            "Effect": "Allow",
            "Resource": "*",
            "Sid": "NonResourcePermissions"
        },
        {
            "Action": "ec2:RunInstances",
            "Effect": "Allow",
            "Resource": [
                "arn:aws:ec2:*:148761655444:capacity-reservation/*",
                "arn:aws:ec2:*:148761655444:key-pair/*",
                "arn:aws:ec2:*:148761655444:network-interface/*",
                "arn:aws:ec2:*:148761655444:security-group/*",
                "arn:aws:ec2:*:148761655444:volume/*",
                "arn:aws:ec2:*::image/*"
            ],
            "Sid": "RunInstancesPermissions"
        }
    ],
    "Version": "2012-10-17"
}
```

<img width="2536" height="694" alt="image" src="https://github.com/user-attachments/assets/61ccc20c-b9d2-44cc-89b6-6582c713adf6" />
<img width="1638" height="1164" alt="image_2" src="https://github.com/user-attachments/assets/ffca6495-aa84-4b5d-9941-3b9bfe6a0a30" />
<img width="1699" height="883" alt="Screenshot 2026-07-03 at 15 55 57" src="https://github.com/user-attachments/assets/556d0af5-fd8b-41b4-8512-3c516fb1ef8c" />

<img width="1699" height="883" alt="Screenshot 2026-07-03 at 15 56 55" src="https://github.com/user-attachments/assets/b74e58d9-b055-472e-a557-9e5ed131b806" />

---
### Kimchi Summary
### What changed
Removes the `ec2:CreateKeyPair` permission from the CAST AI IAM policy and the optional readonly EKS example IAM configuration.

### Why
This permission is no longer required by CAST AI components, so removing it reduces the IAM role's privileges to follow the principle of least privilege.

### Key changes
- `castai/policies/iam-policy.json`: Removed `ec2:CreateKeyPair` from the allowed EC2 actions.
- `examples/eks/eks_cluster_optional_readonly/iam.tf`: Removed `ec2:CreateKeyPair` from the inline role policy.

### Impact
Existing IAM roles must be updated to drop this permission; no functional behavior changes if key pair creation is no longer used.

---
### Kimchi Summary
### What changed
Removed the `ec2:CreateKeyPair` permission from CAST AI IAM policy definitions and the optional readonly EKS example.

### Why
`ec2:CreateKeyPair` is no longer required for CAST AI-managed cluster operations, so the permission can be dropped to follow least-privilege access.

### Key changes
- `castai/policies/iam-policy.json`: removed `ec2:CreateKeyPair` from the allowed action list.
- `examples/eks/eks_cluster_optional_readonly/iam.tf`: removed `ec2:CreateKeyPair` and a duplicate `ec2:CreateTags` entry from the inline role policy.

### Impact
Reduces the IAM permission scope. Existing deployments that previously relied on this policy should verify they no longer require `ec2:CreateKeyPair` before applying the updated policy.