### PR TITLE
feat(evictor_advanced_config): support pod_selector.replicas_min

### DIFF
--- a/castai/resource_eviction_config.go
+++ b/castai/resource_eviction_config.go
@@ -411,6 +411,8 @@ func toPodSelector(in interface{}) (*sdk.CastaiEvictorV1PodSelector, error) {
 			}
 		case FieldPodSelectorReplicasMin:
 			if replicasMin, ok := v.(int); ok {
+				// 0 and unset both mean "no minimum enforced" to the evictor, so treating
+				// 0 as unset avoids Terraform's int zero-value/unset ambiguity without changing behavior.
 				if replicasMin == 0 {
 					continue
 				}

--- a/castai/resource_eviction_config.go
+++ b/castai/resource_eviction_config.go
@@ -27,6 +27,7 @@ const (
 	FieldEvictionOptionDisposable = "disposable"
 	FieldPodSelectorKind          = "kind"
 	FieldPodSelectorNamespace     = "namespace"
+	FieldPodSelectorReplicasMin   = "replicas_min"
 	FieldMatchLabels              = "match_labels"
 	FieldMatchExpressions         = "match_expressions"
 	FieldMatchExpressionKey       = "key"
@@ -72,6 +73,11 @@ func resourceEvictionConfig() *schema.Resource {
 									FieldPodSelectorKind: {
 										Type:     schema.TypeString,
 										Optional: true,
+									},
+									FieldPodSelectorReplicasMin: {
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Description: "Minimum number of pod replicas to keep running when evicting matched pods",
 									},
 									FieldMatchLabels: {
 										Type:     schema.TypeMap,
@@ -403,6 +409,15 @@ func toPodSelector(in interface{}) (*sdk.CastaiEvictorV1PodSelector, error) {
 			} else {
 				return nil, fmt.Errorf("expecting bool, got %T", v)
 			}
+		case FieldPodSelectorReplicasMin:
+			if replicasMin, ok := v.(int); ok {
+				if replicasMin == 0 {
+					continue
+				}
+				out.ReplicasMin = lo.ToPtr(int32(replicasMin))
+			} else {
+				return nil, fmt.Errorf("expecting int, got %T", v)
+			}
 		case FieldMatchExpressions:
 			if mes, ok := v.([]interface{}); ok {
 				me, err := toMatchExpressions(mes)
@@ -506,6 +521,9 @@ func flattenPodSelector(ps *sdk.CastaiEvictorV1PodSelector) []map[string]any {
 	}
 	if ps.Namespace != nil {
 		out[FieldPodSelectorNamespace] = *ps.Namespace
+	}
+	if ps.ReplicasMin != nil {
+		out[FieldPodSelectorReplicasMin] = int(*ps.ReplicasMin)
 	}
 	if ps.LabelSelector != nil {
 		if ps.LabelSelector.MatchLabels != nil {

--- a/castai/resource_eviction_config_test.go
+++ b/castai/resource_eviction_config_test.go
@@ -102,6 +102,17 @@ func TestEvictionConfig_ReadContext(t *testing.T) {
 				r.Equal("value1", nodeSelectorLabelValue)
 			},
 		},
+		"should read pod_selector replicas_min": {
+			data: `{"evictionConfig":[{"podSelector":{"kind":"Deployment","replicasMin":2,"labelSelector":{"matchLabels":{"key1":"value1"}}},"settings":{"aggressive":{"enabled":true}}}]}`,
+			testFunc: func(t *testing.T, res diag.Diagnostics, data *schema.ResourceData) {
+				r := require.New(t)
+				r.Nil(res)
+				r.False(res.HasError())
+				replicasMin, isOK := data.GetOk(fmt.Sprintf("%s.0.%s.0.%s", FieldEvictorAdvancedConfig, FieldPodSelector, FieldPodSelectorReplicasMin))
+				r.True(isOK)
+				r.Equal(2, replicasMin)
+			},
+		},
 		"should handle label expressions": {
 			data: `{"evictionConfig":[ {"podSelector":{"kind":"Job","labelSelector":{"matchExpressions":[{"key":"value1", "operator":"In", "values":["v1", "v2"]}]}},"settings":{"aggressive":{"enabled":true}}} ]}`,
 			testFunc: func(t *testing.T, res diag.Diagnostics, data *schema.ResourceData) {
@@ -222,6 +233,88 @@ func TestEvictionConfig_CreateContext(t *testing.T) {
 	r.True(isOK)
 	r.NotNil(podSelectorKind)
 	r.Equal("Job", podSelectorKind)
+}
+
+func TestEvictionConfig_CreateContext_ReplicasMin(t *testing.T) {
+	r := require.New(t)
+	mockctrl := gomock.NewController(t)
+	mockClient := mock_sdk.NewMockClientInterface(mockctrl)
+
+	ctx := context.Background()
+	provider := &ProviderConfig{
+		api: &sdk.ClientWithResponses{
+			ClientInterface: mockClient,
+		},
+	}
+	clusterId := "b6bfc074-a267-400f-b8f1-db0850c369b1"
+	evictionConfigResponse := `{
+  "evictionConfig": [
+    {
+      "podSelector": {
+        "kind": "Deployment",
+        "labelSelector": {
+          "matchLabels": {
+            "key1": "value1"
+          }
+        },
+		"replicasMin": 2
+      },
+      "settings": {
+        "aggressive": {
+          "enabled": true
+        }
+      }
+    }
+  ]
+}`
+
+	resource := resourceEvictionConfig()
+
+	val := cty.ObjectVal(map[string]cty.Value{
+		FieldClusterId: cty.StringVal(clusterId),
+		FieldEvictorAdvancedConfig: cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"pod_selector": cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+					"kind":         cty.StringVal("Deployment"),
+					"replicas_min": cty.NumberIntVal(2),
+					"match_labels": cty.MapVal(map[string]cty.Value{
+						"key1": cty.StringVal("value1"),
+					}),
+				}),
+				}),
+				"aggressive": cty.BoolVal(true),
+			}),
+		}),
+	})
+
+	state := terraform.NewInstanceStateShimmedFromValue(val, 0)
+	data := resource.Data(state)
+
+	mockClient.EXPECT().EvictorAPIUpsertAdvancedConfigWithBody(gomock.Any(), clusterId, "application/json", gomock.Any()).
+		DoAndReturn(func(ctx context.Context, clusterId string, contentType string, body io.Reader) (*http.Response, error) {
+
+			got, _ := io.ReadAll(body)
+			expected := []byte(evictionConfigResponse)
+
+			eq, err := JSONBytesEqual(got, expected)
+			r.NoError(err)
+			r.True(eq, fmt.Sprintf("got:      %v\n"+
+				"expected: %v\n", string(got), string(expected)))
+
+			return &http.Response{
+				StatusCode: 200,
+				Header:     map[string][]string{"Content-Type": {"json"}},
+				Body:       io.NopCloser(bytes.NewReader([]byte(evictionConfigResponse))),
+			}, nil
+		}).Times(1)
+
+	result := resource.CreateContext(ctx, data, provider)
+
+	r.Nil(result)
+	r.False(result.HasError())
+	replicasMin, isOK := data.GetOk(fmt.Sprintf("%s.0.%s.0.%s", FieldEvictorAdvancedConfig, FieldPodSelector, FieldPodSelectorReplicasMin))
+	r.True(isOK)
+	r.Equal(2, replicasMin)
 }
 
 func TestEvictionConfig_UpdateContext(t *testing.T) {

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -3177,11 +3177,29 @@ type CastaiRbacV1beta1OrganizationScope struct {
 
 // CastaiRbacV1beta1PermissionGroup PermissionGroup represents a named group of permissions.
 type CastaiRbacV1beta1PermissionGroup struct {
+	// CategoryDescription Description of the category.
+	CategoryDescription *string `json:"categoryDescription,omitempty"`
+
+	// CategoryDisplayName Human-readable display name for the category.
+	CategoryDisplayName *string `json:"categoryDisplayName,omitempty"`
+
+	// Description Description of the permission group.
+	Description *string `json:"description,omitempty"`
+
+	// DisplayName Human-readable display name for the permission group.
+	DisplayName *string `json:"displayName,omitempty"`
+
 	// Name Name of the permission group.
 	Name *string `json:"name,omitempty"`
 
 	// Permissions List of permissions in this group.
 	Permissions *[]CastaiRbacV1beta1Permissions `json:"permissions,omitempty"`
+
+	// ResourceDescription Description of the resource.
+	ResourceDescription *string `json:"resourceDescription,omitempty"`
+
+	// ResourceDisplayName Human-readable display name for the resource.
+	ResourceDisplayName *string `json:"resourceDisplayName,omitempty"`
 }
 
 // CastaiRbacV1beta1Permissions defines model for castai.rbac.v1beta1.Permissions.
@@ -3802,6 +3820,9 @@ type CastaiUsersV1beta1CurrentUserProfileResponse struct {
 	// Email User email.
 	Email     *string `json:"email,omitempty"`
 	EmailHash *string `json:"emailHash,omitempty"`
+
+	// Fingerprint Fingerprint is a unique identifier for the user's device or browser.
+	Fingerprint *string `json:"fingerprint"`
 
 	// FirstLogin User first login.
 	FirstLogin *bool `json:"firstLogin,omitempty"`

--- a/docs/resources/evictor_advanced_config.md
+++ b/docs/resources/evictor_advanced_config.md
@@ -17,10 +17,11 @@ resource "castai_evictor_advanced_config" "config" {
   cluster_id = castai_eks_cluster.test.id
   evictor_advanced_config {
     pod_selector {
-      kind      = "Job"
-      namespace = "test"
+      kind         = "Deployment"
+      namespace    = "test"
+      replicas_min = 2
       match_labels = {
-        "job" = "test"
+        "app" = "test"
       }
     }
     aggressive = true
@@ -86,6 +87,7 @@ Optional:
 - `match_expressions` (Block List) (see [below for nested schema](#nestedblock--evictor_advanced_config--pod_selector--match_expressions))
 - `match_labels` (Map of String)
 - `namespace` (String)
+- `replicas_min` (Number) Minimum number of pod replicas to keep running when evicting matched pods
 
 <a id="nestedblock--evictor_advanced_config--pod_selector--match_expressions"></a>
 ### Nested Schema for `evictor_advanced_config.pod_selector.match_expressions`

--- a/examples/resources/castai_evictor_advanced_config/resource.tf
+++ b/examples/resources/castai_evictor_advanced_config/resource.tf
@@ -2,10 +2,11 @@ resource "castai_evictor_advanced_config" "config" {
   cluster_id = castai_eks_cluster.test.id
   evictor_advanced_config {
     pod_selector {
-      kind      = "Job"
-      namespace = "test"
+      kind         = "Deployment"
+      namespace    = "test"
+      replicas_min = 2
       match_labels = {
-        "job" = "test"
+        "app" = "test"
       }
     }
     aggressive = true


### PR DESCRIPTION
## Summary

This PR is a mirror of the customer-contributed PR #735, opened from an internal branch so that CI can run against the actual cluster (required due to fork permission restrictions).

Original PR: #735 by @martin-kulich-whalebone (Whalebone)

- Adds `replicas_min` field to `pod_selector` block in `castai_evictor_advanced_config`
- Prevents aggressive eviction of workloads with few replicas by letting operators set a minimum replica count per pod selector
- Setting `replicas_min = 0` or omitting it is backward-compatible with existing configs

## Changes
- `castai/resource_eviction_config.go` — added `FieldPodSelectorReplicasMin` constant, schema field, and conversion logic
- `castai/resource_eviction_config_test.go` — added read/create test cases for `replicas_min`
- `castai/sdk/api.gen.go` — regenerated SDK
- `docs/resources/evictor_advanced_config.md` — documented new argument
- `examples/resources/castai_evictor_advanced_config/resource.tf` — example usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Kimchi Summary
### What changed
Adds an optional `replicas_min` field to `pod_selector` in the `castai_evictor_advanced_config` resource, letting users specify the minimum number of pod replicas the evictor should keep running for matched workloads.

### Why
This lets operators protect critical workloads by ensuring a configurable minimum replica count is preserved during eviction, instead of relying only on workload-level defaults.

### Key changes
- `castai/resource_eviction_config.go`
  - Added `FieldPodSelectorReplicasMin` constant and `replicas_min` integer schema field.
  - Updated `toPodSelector` to translate `replicas_min` to `*int32` and to treat `0` as unset, avoiding Terraform's zero-value ambiguity.
  - Updated `flattenPodSelector` to read `ReplicasMin` back into state.
- `castai/resource_eviction_config_test.go`
  - Added read and create test cases covering `replicas_min` round-tripping.
- `docs/resources/evictor_advanced_config.md` and `examples/resources/castai_evictor_advanced_config/resource.tf`
  - Updated documentation and example to show `replicas_min = 2`.

### Impact
- Fully additive: existing configurations without `replicas_min` continue to behave identically.
- Setting `replicas_min = 0` is treated as unset (no minimum enforced), matching the evictor's behavior for absent values.