### PR TITLE
Add aks_cluster_workload_identity example

### DIFF
--- a/examples/aks/aks_cluster_workload_identity/README.MD
+++ b/examples/aks/aks_cluster_workload_identity/README.MD
@@ -4,7 +4,7 @@ This example shows how to connect an existing AKS cluster to CAST AI using Azure
 
 Workload Identity uses federated credentials, which means no client secrets are created or rotated. Permissions are scoped to the cluster's resource groups via a User-Assigned Managed Identity.
 
-> **Note:** This feature requires a feature flag to be enabled on your CAST AI account before `terraform apply` will succeed. `terraform plan` will complete without it, but `terraform apply` will fail with a 403 error. Contact CAST AI support to enable it.
+> **Note:** This feature requires a feature flag to be enabled before `terraform apply` will succeed. `terraform plan` will complete without it, but `terraform apply` will fail with a 403 error. Contact CAST AI support to have it enabled.
 
 The only difference from the standard [aks_cluster_existing](../aks_cluster_existing) example is `authentication_method = "workload_identity"` in the module block.
 

--- a/examples/aks/aks_cluster_workload_identity/README.MD
+++ b/examples/aks/aks_cluster_workload_identity/README.MD
@@ -1,0 +1,45 @@
+# Existing AKS cluster onboarded to CAST AI with Workload Identity
+
+This example shows how to connect an existing AKS cluster to CAST AI using Azure Workload Identity instead of the default App Registration (client secret) method.
+
+Workload Identity uses federated credentials, which means no client secrets are created or rotated. Permissions are scoped to the cluster's resource groups via a User-Assigned Managed Identity.
+
+> **Note:** This feature requires a feature flag to be enabled on your CAST AI account before `terraform apply` will succeed. `terraform plan` will complete without it, but `terraform apply` will fail with a 403 error. Contact CAST AI support to enable it.
+
+The only difference from the standard [aks_cluster_existing](../aks_cluster_existing) example is `authentication_method = "workload_identity"` in the module block.
+
+## What Terraform creates
+
+- A User-Assigned Managed Identity in the cluster's resource group
+- A federated identity credential on that managed identity
+- A `CastAKSRole` custom role definition
+- Role assignments scoped to both the cluster resource group and the node resource group (`MC_*`)
+
+## Migrating an existing cluster
+
+Clusters already onboarded via App Registration can switch to Workload Identity without disconnecting. Add `authentication_method = "workload_identity"` to the module block and run `terraform apply`.
+
+Terraform will destroy the App Registration resources and create the managed identity and federated credential as replacements. Role assignments are also replaced. CAST AI will be temporarily unable to authenticate during propagation — this typically resolves within a few minutes.
+
+## Example configuration order
+
+1. Connect existing AKS cluster to CAST AI with Workload Identity - `castai.tf`
+
+## Usage
+
+1. Copy `terraform.tfvars.example` to `terraform.tfvars`
+2. Update `terraform.tfvars` with your cluster name, resource group, region, subnets, and CAST AI API token.
+3. Initialize Terraform. Under example root folder run:
+```
+terraform init
+```
+4. Run Terraform apply:
+```
+terraform apply
+```
+5. To destroy resources created by this example:
+```
+terraform destroy
+```
+
+Please refer to this guide if you run into any issues https://docs.cast.ai/docs/terraform-troubleshooting

--- a/examples/aks/aks_cluster_workload_identity/castai.tf
+++ b/examples/aks/aks_cluster_workload_identity/castai.tf
@@ -1,0 +1,78 @@
+# Configure Data sources and providers required for CAST AI connection.
+data "azurerm_subscription" "current" {}
+
+data "azurerm_kubernetes_cluster" "example" {
+  name                = var.cluster_name
+  resource_group_name = var.resource_group
+}
+
+# Configure AKS cluster connection to CAST AI using CAST AI aks-cluster module with Workload Identity.
+# Workload Identity uses federated credentials instead of App Registration client secrets,
+# eliminating secret rotation and scoping permissions to the cluster's resource groups.
+module "castai_aks_cluster" {
+  source  = "castai/aks/castai"
+  version = "~> 10.3"
+
+  api_url                = var.castai_api_url
+  castai_api_token       = var.castai_api_token
+  grpc_url               = var.castai_grpc_url
+  wait_for_cluster_ready = true
+
+  aks_cluster_name           = var.cluster_name
+  aks_cluster_region         = var.cluster_region
+  node_resource_group        = data.azurerm_kubernetes_cluster.example.node_resource_group
+  resource_group             = data.azurerm_kubernetes_cluster.example.resource_group_name
+  delete_nodes_on_disconnect = var.delete_nodes_on_disconnect
+
+  subscription_id = data.azurerm_subscription.current.subscription_id
+  tenant_id       = data.azurerm_subscription.current.tenant_id
+
+  authentication_method = "workload_identity"
+
+  default_node_configuration = module.castai_aks_cluster.castai_node_configurations["default"]
+
+  node_configurations = {
+    default = {
+      min_disk_size  = 100
+      disk_cpu_ratio = 0
+      subnets        = var.subnets
+      tags           = var.tags
+    }
+  }
+
+  autoscaler_settings = {
+    enabled                                 = false
+    is_scoped_mode                          = false
+    node_templates_partial_matching_enabled = false
+
+    unschedulable_pods = {
+      enabled = false
+    }
+
+    node_downscaler = {
+      enabled = false
+
+      empty_nodes = {
+        enabled = false
+      }
+
+      evictor = {
+        aggressive_mode           = false
+        cycle_interval            = "60s"
+        dry_run                   = false
+        enabled                   = false
+        node_grace_period_minutes = 10
+        scoped_mode               = false
+      }
+    }
+
+    cluster_limits = {
+      enabled = false
+
+      cpu = {
+        max_cores = 200
+        min_cores = 1
+      }
+    }
+  }
+}

--- a/examples/aks/aks_cluster_workload_identity/providers.tf
+++ b/examples/aks/aks_cluster_workload_identity/providers.tf
@@ -1,0 +1,23 @@
+# Following providers required by AKS and Vnet resources.
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id # From Azure version 4.0, Specifying Subscription ID is Mandatory
+}
+
+provider "azuread" {
+  tenant_id = data.azurerm_subscription.current.tenant_id
+}
+
+provider "castai" {
+  api_url   = var.castai_api_url
+  api_token = var.castai_api_token
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = data.azurerm_kubernetes_cluster.example.kube_config.0.host
+    client_certificate     = base64decode(data.azurerm_kubernetes_cluster.example.kube_config.0.client_certificate)
+    client_key             = base64decode(data.azurerm_kubernetes_cluster.example.kube_config.0.client_key)
+    cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.example.kube_config.0.cluster_ca_certificate)
+  }
+}

--- a/examples/aks/aks_cluster_workload_identity/terraform.tfvars.example
+++ b/examples/aks/aks_cluster_workload_identity/terraform.tfvars.example
@@ -1,0 +1,6 @@
+cluster_name                = "<place-holder>"
+resource_group              = "<place-holder>"
+cluster_region              = "<place-holder>"
+castai_api_token            = "<place-holder>"
+subscription_id             = "<place-holder>"
+subnets                     = ["<place-holder>"]

--- a/examples/aks/aks_cluster_workload_identity/variables.tf
+++ b/examples/aks/aks_cluster_workload_identity/variables.tf
@@ -1,0 +1,55 @@
+# AKS  cluster variables.
+variable "cluster_name" {
+  type        = string
+  description = "Name of the AKS cluster, resources will be created for."
+}
+
+variable "resource_group" {
+  type        = string
+  description = "Resource Group of the AKS cluster, resources will be created for."
+}
+
+variable "subscription_id" {
+  type        = string
+  description = "Azure subscription ID"
+}
+
+variable "cluster_region" {
+  type        = string
+  description = "Region of the AKS cluster, resources will be created for."
+}
+
+variable "castai_api_url" {
+  type        = string
+  description = "URL of alternative CAST AI API to be used during development or testing"
+  default     = "https://api.cast.ai"
+}
+
+# Variables required for connecting EKS cluster to CAST AI
+variable "castai_api_token" {
+  type        = string
+  description = "CAST AI API token created in console.cast.ai API Access keys section"
+}
+
+variable "castai_grpc_url" {
+  type        = string
+  description = "CAST AI gRPC URL"
+  default     = "grpc.cast.ai:443"
+}
+
+variable "delete_nodes_on_disconnect" {
+  type        = bool
+  description = "Optional parameter, if set to true - CAST AI provisioned nodes will be deleted from cloud on cluster disconnection. For production use it is recommended to set it to false."
+  default     = true
+}
+
+variable "tags" {
+  type        = map(any)
+  description = "Optional tags for new cluster nodes. This parameter applies only to new nodes - tags for old nodes are not reconciled."
+  default     = {}
+}
+
+variable "subnets" {
+  type        = list(string)
+  description = "Cluster subnets"
+}

--- a/examples/aks/aks_cluster_workload_identity/variables.tf
+++ b/examples/aks/aks_cluster_workload_identity/variables.tf
@@ -25,10 +25,11 @@ variable "castai_api_url" {
   default     = "https://api.cast.ai"
 }
 
-# Variables required for connecting EKS cluster to CAST AI
+# Variables required for connecting AKS cluster to CAST AI
 variable "castai_api_token" {
   type        = string
   description = "CAST AI API token created in console.cast.ai API Access keys section"
+  sensitive   = true
 }
 
 variable "castai_grpc_url" {

--- a/examples/aks/aks_cluster_workload_identity/versions.tf
+++ b/examples/aks/aks_cluster_workload_identity/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    azuread = {
+      source = "hashicorp/azuread"
+    }
+    castai = {
+      source = "castai/castai"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+  }
+  required_version = ">= 1.3.2"
+}


### PR DESCRIPTION
## Summary

- Adds a new `aks_cluster_workload_identity` example under `examples/aks/`
- Based on `aks_cluster_existing` — assumes an existing AKS cluster
- The only functional difference is `authentication_method = "workload_identity"` in the module block
- README explains the feature flag requirement, what Azure resources are created, and the migration path from App Registration

## Context

Raised in [castai-docs PR #258](https://github.com/castai/castai-docs/pull/258) by Furkhat — the suggestion was to maintain examples in the provider repo and link to them from docs to avoid drift. This example is the canonical reference for the AKS workload identity onboarding doc.

## Test plan

- [x] `terraform init` succeeds in the example directory
- [x] `terraform plan` with a real AKS cluster shows `azurerm_user_assigned_identity` and `azurerm_federated_identity_credential` (not `azuread_application`)
- [x] `terraform apply` succeeds with the feature flag enabled
- [x] No App Registration created after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Kimchi Summary
### What changed
Adds a new Terraform example under `examples/aks/aks_cluster_workload_identity/` demonstrating how to connect an existing AKS cluster to CAST AI using Azure Workload Identity (federated credentials) instead of an App Registration with a client secret.

### Why
Workload Identity removes the need for client secret rotation and scopes Azure permissions to the cluster's resource groups via a User-Assigned Managed Identity. This example helps users adopt the preferred authentication method for AKS.

### Key changes
- `examples/aks/aks_cluster_workload_identity/castai.tf`: New module configuration using `castai/aks/castai` version `~> 10.3` with `authentication_method = "workload_identity"`.
- `examples/aks/aks_cluster_workload_identity/README.MD`: Documentation explaining Workload Identity setup, required feature flag, created resources, and migration path from App Registration.
- `examples/aks/aks_cluster_workload_identity/providers.tf`: Configures `azurerm`, `azuread`, `castai`, and `helm` providers.
- `examples/aks/aks_cluster_workload_identity/variables.tf`: Defines required input variables including cluster details and CAST AI API token.
- `examples/aks/aks_cluster_workload_identity/versions.tf`: Pins required providers and Terraform version `>= 1.3.2`.
- `examples/aks/aks_cluster_workload_identity/terraform.tfvars.example`: Provides a template for user-specific values.

### Impact
- Entirely additive; no changes to provider code or existing examples.
- Users must contact CAST AI support to enable a feature flag before `terraform apply` succeeds.