### PR TITLE
KUBE-1439: Update SDK version for Terraform provider

### DIFF
--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -6889,7 +6889,8 @@ type NodeconfigV1EC2VolumesConfig struct {
 // NodeconfigV1EKSConfig defines model for nodeconfig.v1.EKSConfig.
 type NodeconfigV1EKSConfig struct {
 	// DnsClusterIp Comma-separated IP addresses to use for DNS queries within the cluster. Defaults to 10.100.0.10 or 172.20.0.10 based on the primary interface's IP address.
-	DnsClusterIp *string `json:"dnsClusterIp"`
+	DnsClusterIp              *string `json:"dnsClusterIp"`
+	EnaQueueCountPerInterface *int32  `json:"enaQueueCountPerInterface"`
 
 	// ImageFamily List of supported image families (OSes) for EKS.
 	//


### PR DESCRIPTION
**What changed**

Update Cast API SDK to unblock pull request actions, because Check if SDK is up to date job it's failing. For example:

[Check if SDK is up to date](https://github.com/castai/terraform-provider-castai/actions/runs/28779344787/job/85330900325)

**Key changes**

NodeconfigV1EKSConfig:  Add enaQueueCountPerInterface field

**Impact**
No breaking changes. These are additive, generated model updates that mirror the latest API schema.