### PR TITLE
feat: add support for EKS ena_queue_count_per_interface in Node Config

### DIFF
--- a/castai/resource_node_configuration.go
+++ b/castai/resource_node_configuration.go
@@ -319,6 +319,12 @@ func resourceNodeConfiguration() *schema.Resource {
 								},
 							},
 						},
+						"ena_queue_count_per_interface": {
+							Type:             schema.TypeInt,
+							Optional:         true,
+							Description:      "Number of ENA queues per network interface.",
+							ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
+						},
 					},
 				},
 			},
@@ -1025,6 +1031,10 @@ func toEKSConfig(obj map[string]interface{}) *sdk.NodeconfigV1EKSConfig {
 		out.ImageFamily = toEKSImageFamily(v)
 	}
 
+	if v, ok := obj["ena_queue_count_per_interface"].(int); ok && v != 0 {
+		out.EnaQueueCountPerInterface = toPtr(int32(v))
+	}
+
 	return out
 }
 
@@ -1119,6 +1129,10 @@ func flattenEKSConfig(config *sdk.NodeconfigV1EKSConfig) []map[string]interface{
 
 	if v := config.ImageFamily; v != nil {
 		m[FieldNodeConfigurationEKSImageFamily] = fromEKSImageFamily(*v)
+	}
+
+	if v := config.EnaQueueCountPerInterface; v != nil {
+		m["ena_queue_count_per_interface"] = *config.EnaQueueCountPerInterface
 	}
 
 	return []map[string]interface{}{m}

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -7985,10 +7985,14 @@ type PoliciesV1SpotInterruptionPredictions struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// Type SpotInterruptionPredictionsType defines the type of the SPOT interruption predictions to enable.
+	//
+	//  - AWSRebalanceRecommendations: Deprecated: Switch to Cast AI ML Interruption predictions instead.
 	Type *PoliciesV1SpotInterruptionPredictionsType `json:"type,omitempty"`
 }
 
 // PoliciesV1SpotInterruptionPredictionsType SpotInterruptionPredictionsType defines the type of the SPOT interruption predictions to enable.
+//
+//   - AWSRebalanceRecommendations: Deprecated: Switch to Cast AI ML Interruption predictions instead.
 type PoliciesV1SpotInterruptionPredictionsType string
 
 // PoliciesV1UnschedulablePodsPolicy Policy defining autoscaler's behavior when unscedulable pods were detected.

--- a/docs/resources/node_configuration.md
+++ b/docs/resources/node_configuration.md
@@ -158,6 +158,7 @@ Optional:
 
 - `dns_cluster_ip` (String) IP address to use for DNS queries within the cluster
 - `eks_image_family` (String) Image OS Family to use when provisioning node in EKS. If both image and family are provided, the system will use provided image and provisioning logic for given family. If only image family is provided, the system will attempt to resolve the latest image from that family based on kubernetes version and node architecture. If image family is omitted, a default family (based on cloud provider) will be used. See Cast.ai documentation for details. Possible values: (al2,al2023,bottlerocket)
+- `ena_queue_count_per_interface` (Number) Number of ENA queues per network interface.
 - `imds_hop_limit` (Number) Allow configure the IMDSv2 hop limit, the default is 2. Setting to 1 disables access to most pods except pods running on host network.
 - `imds_v1` (Boolean) When the value is true both IMDSv1 and IMDSv2 are enabled. Setting the value to false disables permanently IMDSv1 and might affect legacy workloads running on the node created with this configuration. The default is true if the flag isn't provided
 - `ips_per_prefix` (Number) Number of IPs per prefix to be used for calculating max pods. For IPv4 it should be 16. More info: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-prefix-eni.html#ec2-prefix-basics


### PR DESCRIPTION
Adding support for the EKS `ena_queue_count_per_interface` setting in Node Configurations.

## Proof of Work

Tested with one of the examples.

Created a Node Configuration without setting `ena_queue_count_per_interface`, it resulted in the following settings:
```json
            "eks": {
                "securityGroups": [
                    "sg-071d957d477537bd7",
                    "sg-07908c05dbeca01b2",
                    "sg-002d67ea5d72aa2d1"
                ],
                // ...
                "targetGroups": [],
                "nodeGroupArn": ""
            },
```

The added the setting, it results in the correct plan:

<img width="1078" height="270" alt="2026-07-09_13-42" src="https://github.com/user-attachments/assets/49c49485-dfdd-4e07-b3cf-d8855212236a" />

And after applying it's added to the Node Configuration:

```json
            "eks": {
                "securityGroups": [
                    "sg-071d957d477537bd7",
                    "sg-07908c05dbeca01b2",
                    "sg-002d67ea5d72aa2d1"
                ],
                // ...
                "targetGroups": [],
                "nodeGroupArn": "",
                "enaQueueCountPerInterface": 2 // <-------------- Added here
            },
```

Removing from the Terraform configuration also results in the expected plan:

<img width="1091" height="265" alt="2026-07-09_13-44" src="https://github.com/user-attachments/assets/be091511-30a7-4b6e-9ce8-d3bb4078f7df" />

And after applying the value is removed from the Node Config:

```json
            "eks": {
                "securityGroups": [
                    "sg-071d957d477537bd7",
                    "sg-07908c05dbeca01b2",
                    "sg-002d67ea5d72aa2d1"
                ],
                // ...
                "targetGroups": [],
                "nodeGroupArn": ""
            },
```