### PR TITLE
feat: add OIDC connector support for sso_connection resource

### DIFF
--- a/castai/resource_sso_connection.go
+++ b/castai/resource_sso_connection.go
@@ -188,6 +188,10 @@ func resourceSSOConnection() *schema.Resource {
 							Sensitive:        true,
 							Description:      "OIDC client secret",
 							ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
+							// The backend stores secrets as bcrypt hashes and returns them base64-encoded.
+							// On reads, oldValue is base64(bcrypt(secret)); newValue is the plaintext from config.
+							// bcrypt.CompareHashAndPassword is CPU-intensive by design; this cost is accepted
+							// on every plan, consistent with the aad and okta connector implementations.
 							DiffSuppressFunc: func(_, oldValue, newValue string, _ *schema.ResourceData) bool {
 								decodedSecret, err := base64.StdEncoding.DecodeString(oldValue)
 								if err != nil {
@@ -411,24 +415,22 @@ func checkSSOStatus(input *sdk.CastaiSsoV1beta1SSOConnection) error {
 }
 
 func resourceCastaiSSOConnectionDiff(_ context.Context, rd *schema.ResourceDiff, _ interface{}) error {
-	connectors := 0
-	if v, ok := rd.Get(FieldSSOConnectionAAD).([]any); ok && len(v) > 0 {
-		connectors++
-	}
-
-	if v, ok := rd.Get(FieldSSOConnectionOkta).([]any); ok && len(v) > 0 {
-		connectors++
-	}
-
-	if v, ok := rd.Get(FieldSSOConnectionOIDC).([]any); ok && len(v) > 0 {
-		connectors++
-	}
-
-	if connectors != 1 {
+	if countSSOConnectors(rd.Get) != 1 {
 		return errors.New("only 1 connector can be configured")
 	}
-
 	return nil
+}
+
+// countSSOConnectors counts how many connector blocks are non-empty.
+// Accepts a getter func so the logic can be tested independently of schema.ResourceDiff.
+func countSSOConnectors(get func(string) interface{}) int {
+	n := 0
+	for _, field := range []string{FieldSSOConnectionAAD, FieldSSOConnectionOkta, FieldSSOConnectionOIDC} {
+		if v, ok := get(field).([]any); ok && len(v) > 0 {
+			n++
+		}
+	}
+	return n
 }
 
 func toADConnector(obj map[string]any) *sdk.CastaiSsoV1beta1AzureAAD {

--- a/castai/resource_sso_connection.go
+++ b/castai/resource_sso_connection.go
@@ -31,6 +31,12 @@ const (
 	FieldSSOConnectionOktaDomain       = "okta_domain"
 	FieldSSOConnectionOktaClientID     = "client_id"
 	FieldSSOConnectionOktaClientSecret = "client_secret"
+
+	FieldSSOConnectionOIDC             = "oidc"
+	FieldSSOConnectionOIDCIssuerURL    = "issuer_url"
+	FieldSSOConnectionOIDCClientID     = "client_id"
+	FieldSSOConnectionOIDCClientSecret = "client_secret"
+	FieldSSOConnectionOIDCType         = "type"
 )
 
 func resourceSSOConnection() *schema.Resource {
@@ -156,6 +162,53 @@ func resourceSSOConnection() *schema.Resource {
 					},
 				},
 			},
+			FieldSSOConnectionOIDC: {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				MinItems:    1,
+				Optional:    true,
+				Description: "OIDC connector (e.g. Keycloak)",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						FieldSSOConnectionOIDCIssuerURL: {
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "Issuer URL of the OpenID Connect provider",
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
+						},
+						FieldSSOConnectionOIDCClientID: {
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "OIDC client ID",
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
+						},
+						FieldSSOConnectionOIDCClientSecret: {
+							Type:             schema.TypeString,
+							Required:         true,
+							Sensitive:        true,
+							Description:      "OIDC client secret",
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
+							DiffSuppressFunc: func(_, oldValue, newValue string, _ *schema.ResourceData) bool {
+								decodedSecret, err := base64.StdEncoding.DecodeString(oldValue)
+								if err != nil {
+									return false
+								}
+								return bcrypt.CompareHashAndPassword(decodedSecret, []byte(newValue)) == nil
+							},
+						},
+						FieldSSOConnectionOIDCType: {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     string(sdk.CastaiSsoV1beta1OIDCTypeTYPEBACKCHANNEL),
+							Description: "OIDC connection type (TYPE_BACK_CHANNEL or TYPE_FRONT_CHANNEL)",
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
+								string(sdk.CastaiSsoV1beta1OIDCTypeTYPEBACKCHANNEL),
+								string(sdk.CastaiSsoV1beta1OIDCTypeTYPEFRONTCHANNEL),
+							}, false)),
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -182,6 +235,10 @@ func resourceCastaiSSOConnectionCreate(ctx context.Context, data *schema.Resourc
 
 	if v, ok := data.Get(FieldSSOConnectionOkta).([]any); ok && len(v) > 0 {
 		req.Okta = toOktaConnector(v[0].(map[string]any))
+	}
+
+	if v, ok := data.Get(FieldSSOConnectionOIDC).([]any); ok && len(v) > 0 {
+		req.Oidc = toOIDCConnector(v[0].(map[string]any))
 	}
 
 	resp, err := client.SSOAPICreateSSOConnectionWithResponse(ctx, req)
@@ -254,6 +311,7 @@ func resourceCastaiSSOConnectionUpdate(ctx context.Context, data *schema.Resourc
 		FieldSSOConnectionAdditionalEmailDomains,
 		FieldSSOConnectionAAD,
 		FieldSSOConnectionOkta,
+		FieldSSOConnectionOIDC,
 		FieldSSOConnectionSynchronizeUserGroups,
 	) {
 		return nil
@@ -285,12 +343,17 @@ func resourceCastaiSSOConnectionUpdate(ctx context.Context, data *schema.Resourc
 		req.Okta = toOktaConnector(v[0].(map[string]any))
 	}
 
+	if v, ok := data.Get(FieldSSOConnectionOIDC).([]any); ok && len(v) > 0 {
+		req.Oidc = toOIDCConnector(v[0].(map[string]any))
+	}
+
 	if data.HasChanges(
 		FieldSSOConnectionName,
 		FieldSSOConnectionEmailDomain,
 		FieldSSOConnectionAdditionalEmailDomains,
 		FieldSSOConnectionAAD,
 		FieldSSOConnectionOkta,
+		FieldSSOConnectionOIDC,
 	) {
 		resp, err := client.SSOAPIUpdateSSOConnectionWithResponse(ctx, data.Id(), req)
 		if err := sdk.CheckOKResponse(resp, err); err != nil {
@@ -357,6 +420,10 @@ func resourceCastaiSSOConnectionDiff(_ context.Context, rd *schema.ResourceDiff,
 		connectors++
 	}
 
+	if v, ok := rd.Get(FieldSSOConnectionOIDC).([]any); ok && len(v) > 0 {
+		connectors++
+	}
+
 	if connectors != 1 {
 		return errors.New("only 1 connector can be configured")
 	}
@@ -397,6 +464,28 @@ func toOktaConnector(obj map[string]any) *sdk.CastaiSsoV1beta1Okta {
 	}
 	if v, ok := obj[FieldSSOConnectionOktaClientSecret].(string); ok {
 		out.ClientSecret = toPtr(v)
+	}
+
+	return out
+}
+
+func toOIDCConnector(obj map[string]any) *sdk.CastaiSsoV1beta1OIDC {
+	if obj == nil {
+		return nil
+	}
+
+	out := &sdk.CastaiSsoV1beta1OIDC{}
+	if v, ok := obj[FieldSSOConnectionOIDCIssuerURL].(string); ok {
+		out.IssuerUrl = v
+	}
+	if v, ok := obj[FieldSSOConnectionOIDCClientID].(string); ok {
+		out.ClientId = v
+	}
+	if v, ok := obj[FieldSSOConnectionOIDCClientSecret].(string); ok {
+		out.ClientSecret = toPtr(v)
+	}
+	if v, ok := obj[FieldSSOConnectionOIDCType].(string); ok {
+		out.Type = sdk.CastaiSsoV1beta1OIDCType(v)
 	}
 
 	return out

--- a/castai/resource_sso_connection_test.go
+++ b/castai/resource_sso_connection_test.go
@@ -3,6 +3,7 @@ package castai
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,6 +11,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/go-cty/cty"
@@ -1123,6 +1126,132 @@ func TestSSOConnection_UpdateOIDCConnector(t *testing.T) {
 	r.False(updateResult.HasError())
 	r.Equal("updated_name", data.Get(FieldSSOConnectionName))
 	equalOIDCConnector(t, r, data.Get(FieldSSOConnectionOIDC), "https://keycloak.example.com/realms/updated", "updated_client_id", "updated_client_secret", "TYPE_FRONT_CHANNEL")
+}
+
+func TestSSOConnection_OIDCSecretDiffSuppress(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	// Get the DiffSuppressFunc from the schema definition.
+	res := resourceSSOConnection()
+	suppress := res.Schema[FieldSSOConnectionOIDC].Elem.(*schema.Resource).Schema[FieldSSOConnectionOIDCClientSecret].DiffSuppressFunc
+
+	// Simulate a read response: backend returns base64(bcrypt(secret)).
+	plaintext := "super-secret"
+	hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcrypt.MinCost)
+	r.NoError(err)
+	encoded := base64.StdEncoding.EncodeToString(hash)
+
+	// Same plaintext as stored hash → suppress diff.
+	r.True(suppress(FieldSSOConnectionOIDCClientSecret, encoded, plaintext, nil))
+	// Different plaintext → do not suppress.
+	r.False(suppress(FieldSSOConnectionOIDCClientSecret, encoded, "wrong-secret", nil))
+	// Invalid base64 (e.g. first apply before any read) → do not suppress.
+	r.False(suppress(FieldSSOConnectionOIDCClientSecret, "not-valid-base64!!", plaintext, nil))
+}
+
+func TestSSOConnection_ConnectorMutualExclusivity(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	makeGetter := func(fields map[string][]any) func(string) interface{} {
+		return func(key string) interface{} {
+			if v, ok := fields[key]; ok {
+				return v
+			}
+			return []any{}
+		}
+	}
+
+	// Exactly one connector → valid.
+	r.Equal(1, countSSOConnectors(makeGetter(map[string][]any{
+		FieldSSOConnectionOIDC: {map[string]any{}},
+	})))
+	r.Equal(1, countSSOConnectors(makeGetter(map[string][]any{
+		FieldSSOConnectionAAD: {map[string]any{}},
+	})))
+
+	// Two connectors → invalid.
+	r.Equal(2, countSSOConnectors(makeGetter(map[string][]any{
+		FieldSSOConnectionOIDC: {map[string]any{}},
+		FieldSSOConnectionAAD:  {map[string]any{}},
+	})))
+
+	// Zero connectors → invalid.
+	r.Equal(0, countSSOConnectors(makeGetter(map[string][]any{})))
+}
+
+func TestSSOConnection_UpdateOIDCToAADConnector(t *testing.T) {
+	r := require.New(t)
+	mockClient := mock_sdk.NewMockClientInterface(gomock.NewController(t))
+
+	ctx := context.Background()
+	provider := &ProviderConfig{
+		api: &sdk.ClientWithResponses{
+			ClientInterface: mockClient,
+		},
+	}
+	connectionID := "b6bfc074-a267-400f-b8f1-db0850c369b1"
+
+	raw := make(map[string]interface{})
+	raw[FieldSSOConnectionName] = "updated_name"
+
+	resource := resourceSSOConnection()
+	data := schema.TestResourceDataRaw(t, resource.Schema, raw)
+	data.SetId(connectionID)
+	// Switch: remove OIDC, add AAD.
+	r.NoError(data.Set(FieldSSOConnectionAAD, []map[string]interface{}{
+		{
+			FieldSSOConnectionADDomain:       "new-ad-domain",
+			FieldSSOConnectionADClientID:     "new-client-id",
+			FieldSSOConnectionADClientSecret: "new-client-secret",
+		},
+	}))
+
+	mockClient.EXPECT().SSOAPIUpdateSSOConnection(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, body sdk.SSOAPIUpdateSSOConnectionJSONRequestBody) (*http.Response, error) {
+			got, err := json.Marshal(body)
+			r.NoError(err)
+
+			expected := []byte(`{
+  "aad": {
+    "adDomain": "new-ad-domain",
+    "clientId": "new-client-id",
+    "clientSecret": "new-client-secret"
+  },
+  "defaultRoleId": null,
+  "name": "updated_name"
+}`)
+			eq, err := JSONBytesEqual(got, expected)
+			r.NoError(err)
+			r.True(eq, fmt.Sprintf("got:      %v\nexpected: %v\n", string(got), string(expected)))
+
+			return &http.Response{
+				StatusCode: 200,
+				Header:     map[string][]string{"Content-Type": {"json"}},
+				Body:       io.NopCloser(bytes.NewReader([]byte(`{"status":"STATUS_ACTIVE","name":"updated_name"}`))),
+			}, nil
+		}).Times(1)
+
+	readBody := io.NopCloser(bytes.NewReader([]byte(`{"connection":{
+  "id": "b6bfc074-a267-400f-b8f1-db0850c369b1",
+  "name": "updated_name",
+  "emailDomain": "test_email",
+  "aad": {
+    "adDomain": "new-ad-domain",
+    "clientId": "new-client-id",
+    "clientSecret": "new-client-secret"
+  }
+}}`)))
+	mockClient.EXPECT().
+		SSOAPIGetSSOConnection(gomock.Any(), connectionID).
+		Return(&http.Response{StatusCode: 200, Body: readBody, Header: map[string][]string{"Content-Type": {"json"}}}, nil)
+
+	result := resource.UpdateContext(ctx, data, provider)
+	r.Nil(result)
+	r.False(result.HasError())
+	r.Empty(data.Get(FieldSSOConnectionOIDC))
+	equalADConnector(t, r, data.Get(FieldSSOConnectionAAD), "new-ad-domain", "new-client-id", "new-client-secret")
 }
 
 func equalOIDCConnector(t *testing.T, r *require.Assertions, in interface{}, expectedIssuerURL, expectedClientID, expectedClientSecret, expectedType string) {

--- a/castai/resource_sso_connection_test.go
+++ b/castai/resource_sso_connection_test.go
@@ -955,6 +955,200 @@ func testAccSSOConnectionConfigurationDestroy(s *terraform.State) error {
 	return nil
 }
 
+func TestSSOConnection_CreateOIDCConnector(t *testing.T) {
+	r := require.New(t)
+	mockClient := mock_sdk.NewMockClientInterface(gomock.NewController(t))
+
+	mockClient.EXPECT().
+		SSOAPICreateSSOConnection(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, body sdk.SSOAPICreateSSOConnectionJSONRequestBody) (*http.Response, error) {
+			got, err := json.Marshal(body)
+			r.NoError(err)
+
+			expected := []byte(`{
+  "oidc": {
+    "issuerUrl": "https://keycloak.example.com/realms/master",
+    "clientId": "test_client",
+    "clientSecret": "test_secret",
+    "type": "TYPE_BACK_CHANNEL"
+  },
+  "emailDomain": "test_email",
+  "defaultRoleId": null,
+  "name": "test_sso"
+}`)
+
+			equal, err := JSONBytesEqual(got, expected)
+			r.NoError(err)
+			r.True(equal, fmt.Sprintf("got:      %v\n"+
+				"expected: %v\n", string(got), string(expected)))
+
+			return &http.Response{
+				StatusCode: 200,
+				Header:     map[string][]string{"Content-Type": {"json"}},
+				Body:       io.NopCloser(bytes.NewReader([]byte(`{"id": "b6bfc074-a267-400f-b8f1-db0850c369b1", "status": "STATUS_ACTIVE"}`))),
+			}, nil
+		})
+
+	connectionID := "b6bfc074-a267-400f-b8f1-db0850c369b1"
+	readBody := io.NopCloser(bytes.NewReader([]byte(`{"connection":{
+  "id": "b6bfc074-a267-400f-b8f1-db0850c369b1",
+  "name": "test_sso",
+  "createdAt": "2023-11-02T10:49:14.376757Z",
+  "updatedAt": "2023-11-02T10:49:14.450828Z",
+  "emailDomain": "test_email",
+  "oidc": {
+    "issuerUrl": "https://keycloak.example.com/realms/master",
+    "clientId": "test_client",
+    "clientSecret": "test_secret",
+    "type": "TYPE_BACK_CHANNEL"
+  }
+}}`)))
+
+	mockClient.EXPECT().
+		SSOAPIGetSSOConnection(gomock.Any(), connectionID).
+		Return(&http.Response{StatusCode: 200, Body: readBody, Header: map[string][]string{"Content-Type": {"json"}}}, nil)
+
+	resource := resourceSSOConnection()
+	data := resource.Data(sdkterraform.NewInstanceStateShimmedFromValue(cty.ObjectVal(map[string]cty.Value{
+		FieldSSOConnectionName:        cty.StringVal("test_sso"),
+		FieldSSOConnectionEmailDomain: cty.StringVal("test_email"),
+		FieldSSOConnectionOIDC: cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				FieldSSOConnectionOIDCIssuerURL:    cty.StringVal("https://keycloak.example.com/realms/master"),
+				FieldSSOConnectionOIDCClientID:     cty.StringVal("test_client"),
+				FieldSSOConnectionOIDCClientSecret: cty.StringVal("test_secret"),
+				FieldSSOConnectionOIDCType:         cty.StringVal("TYPE_BACK_CHANNEL"),
+			}),
+		}),
+	}), 0))
+
+	result := resource.CreateContext(context.Background(), data, &ProviderConfig{
+		api: &sdk.ClientWithResponses{
+			ClientInterface: mockClient,
+		},
+	})
+
+	r.Nil(result)
+	r.False(result.HasError())
+	r.Equal("test_sso", data.Get(FieldSSOConnectionName))
+	r.Equal("test_email", data.Get(FieldSSOConnectionEmailDomain))
+	equalOIDCConnector(t, r, data.Get(FieldSSOConnectionOIDC), "https://keycloak.example.com/realms/master", "test_client", "test_secret", "TYPE_BACK_CHANNEL")
+}
+
+func TestSSOConnection_UpdateOIDCConnector(t *testing.T) {
+	r := require.New(t)
+	mockClient := mock_sdk.NewMockClientInterface(gomock.NewController(t))
+
+	ctx := context.Background()
+	provider := &ProviderConfig{
+		api: &sdk.ClientWithResponses{
+			ClientInterface: mockClient,
+		},
+	}
+	connectionID := "b6bfc074-a267-400f-b8f1-db0850c369b1"
+
+	raw := make(map[string]interface{})
+	raw[FieldSSOConnectionName] = "updated_name"
+
+	resource := resourceSSOConnection()
+	data := schema.TestResourceDataRaw(t, resource.Schema, raw)
+	data.SetId(connectionID)
+	r.NoError(data.Set(FieldSSOConnectionOIDC, []map[string]interface{}{
+		{
+			FieldSSOConnectionOIDCIssuerURL:    "https://keycloak.example.com/realms/updated",
+			FieldSSOConnectionOIDCClientID:     "updated_client_id",
+			FieldSSOConnectionOIDCClientSecret: "updated_client_secret",
+			FieldSSOConnectionOIDCType:         "TYPE_FRONT_CHANNEL",
+		},
+	}))
+
+	mockClient.EXPECT().SSOAPIUpdateSSOConnection(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, body sdk.SSOAPIUpdateSSOConnectionJSONRequestBody) (*http.Response, error) {
+			got, err := json.Marshal(body)
+			r.NoError(err)
+
+			expected := []byte(`{
+  "oidc": {
+    "issuerUrl": "https://keycloak.example.com/realms/updated",
+    "clientId": "updated_client_id",
+    "clientSecret": "updated_client_secret",
+    "type": "TYPE_FRONT_CHANNEL"
+  },
+  "defaultRoleId": null,
+  "name": "updated_name"
+}`)
+
+			eq, err := JSONBytesEqual(got, expected)
+			r.NoError(err)
+			r.True(eq, fmt.Sprintf("got:      %v\n"+
+				"expected: %v\n", string(got), string(expected)))
+
+			returnBody := []byte(`{
+  "oidc": {
+    "issuerUrl": "https://keycloak.example.com/realms/updated",
+    "clientId": "updated_client_id",
+    "clientSecret": "updated_client_secret",
+    "type": "TYPE_FRONT_CHANNEL"
+  },
+  "status": "STATUS_ACTIVE",
+  "name": "updated_name"
+}`)
+
+			return &http.Response{
+				StatusCode: 200,
+				Header:     map[string][]string{"Content-Type": {"json"}},
+				Body:       io.NopCloser(bytes.NewReader(returnBody)),
+			}, nil
+		}).Times(1)
+
+	readBody := io.NopCloser(bytes.NewReader([]byte(`{"connection":{
+  "id": "b6bfc074-a267-400f-b8f1-db0850c369b1",
+  "name": "updated_name",
+  "createdAt": "2023-11-02T10:49:14.376757Z",
+  "updatedAt": "2023-11-02T10:49:14.450828Z",
+  "emailDomain": "test_email",
+  "oidc": {
+    "issuerUrl": "https://keycloak.example.com/realms/updated",
+    "clientId": "updated_client_id",
+    "clientSecret": "updated_client_secret",
+    "type": "TYPE_FRONT_CHANNEL"
+  }
+}}`)))
+	mockClient.EXPECT().
+		SSOAPIGetSSOConnection(gomock.Any(), connectionID).
+		Return(&http.Response{StatusCode: 200, Body: readBody, Header: map[string][]string{"Content-Type": {"json"}}}, nil)
+
+	updateResult := resource.UpdateContext(ctx, data, provider)
+	r.Nil(updateResult)
+	r.False(updateResult.HasError())
+	r.Equal("updated_name", data.Get(FieldSSOConnectionName))
+	equalOIDCConnector(t, r, data.Get(FieldSSOConnectionOIDC), "https://keycloak.example.com/realms/updated", "updated_client_id", "updated_client_secret", "TYPE_FRONT_CHANNEL")
+}
+
+func equalOIDCConnector(t *testing.T, r *require.Assertions, in interface{}, expectedIssuerURL, expectedClientID, expectedClientSecret, expectedType string) {
+	t.Helper()
+	r.NotNil(in)
+
+	array, ok := in.([]interface{})
+	r.True(ok)
+	r.Len(array, 1)
+	values, ok := array[0].(map[string]interface{})
+	r.True(ok)
+
+	issuerURL, ok := values["issuer_url"]
+	r.True(ok)
+	r.Equal(expectedIssuerURL, issuerURL)
+	clientID, ok := values["client_id"]
+	r.True(ok)
+	r.Equal(expectedClientID, clientID)
+	clientSecret, ok := values["client_secret"]
+	r.True(ok)
+	r.Equal(expectedClientSecret, clientSecret)
+	oidcType, ok := values["type"]
+	r.True(ok)
+	r.Equal(expectedType, oidcType)
+}
+
 func equalOktaConnector(t *testing.T, r *require.Assertions, in interface{}, expectedDomain, expectedClientID, expectedClientSecret string) {
 	t.Helper()
 	r.NotNil(in)

--- a/docs/resources/sso_connection.md
+++ b/docs/resources/sso_connection.md
@@ -12,13 +12,23 @@ SSO Connection resource allows creating SSO trust relationship with CAST AI.
 ## Example Usage
 
 ```terraform
-resource "castai_sso_connection" "sso" {
+resource "castai_sso_connection" "aad" {
   name         = "aad_connection"
   email_domain = "aad_connection@test.com"
   aad {
     client_id     = azuread_application.castai_sso.client_id
     client_secret = azuread_application_password.castai_sso.value
     ad_domain     = azuread_application.castai_sso.publisher_domain
+  }
+}
+
+resource "castai_sso_connection" "keycloak" {
+  name         = "keycloak_connection"
+  email_domain = "example.com"
+  oidc {
+    issuer_url    = "https://keycloak.example.com/realms/my-realm"
+    client_id     = "castai"
+    client_secret = var.keycloak_client_secret
   }
 }
 ```
@@ -35,6 +45,7 @@ resource "castai_sso_connection" "sso" {
 
 - `aad` (Block List, Max: 1) Azure AD connector (see [below for nested schema](#nestedblock--aad))
 - `additional_email_domains` (List of String) Additional email domains that will be allowed to sign in via the connection
+- `oidc` (Block List, Max: 1) OIDC connector (e.g. Keycloak) (see [below for nested schema](#nestedblock--oidc))
 - `okta` (Block List, Max: 1) Okta connector (see [below for nested schema](#nestedblock--okta))
 - `synchronize_user_groups` (Boolean) When enabled, user groups from the identity provider will be synchronized with CAST AI. A sync auth token is generated on activation and stored in sync_auth_token.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
@@ -52,6 +63,20 @@ Required:
 - `ad_domain` (String) Azure AD domain
 - `client_id` (String) Azure AD client ID
 - `client_secret` (String, Sensitive) Azure AD client secret
+
+
+<a id="nestedblock--oidc"></a>
+### Nested Schema for `oidc`
+
+Required:
+
+- `client_id` (String) OIDC client ID
+- `client_secret` (String, Sensitive) OIDC client secret
+- `issuer_url` (String) Issuer URL of the OpenID Connect provider
+
+Optional:
+
+- `type` (String) OIDC connection type (TYPE_BACK_CHANNEL or TYPE_FRONT_CHANNEL)
 
 
 <a id="nestedblock--okta"></a>

--- a/examples/resources/sso_connection/resource.tf
+++ b/examples/resources/sso_connection/resource.tf
@@ -1,9 +1,19 @@
-resource "castai_sso_connection" "sso" {
+resource "castai_sso_connection" "aad" {
   name         = "aad_connection"
   email_domain = "aad_connection@test.com"
   aad {
     client_id     = azuread_application.castai_sso.client_id
     client_secret = azuread_application_password.castai_sso.value
     ad_domain     = azuread_application.castai_sso.publisher_domain
+  }
+}
+
+resource "castai_sso_connection" "keycloak" {
+  name         = "keycloak_connection"
+  email_domain = "example.com"
+  oidc {
+    issuer_url    = "https://keycloak.example.com/realms/my-realm"
+    client_id     = "castai"
+    client_secret = var.keycloak_client_secret
   }
 }


### PR DESCRIPTION
 ## Summary

  Adds OIDC as a third connector type for the `castai_sso_connection` resource,
  alongside the existing Azure AD and Okta connectors. This enables SSO integration
  with any OIDC-compatible identity provider, such as Keycloak.

  ### New `oidc` block fields

  | Field | Required | Description |
  |---|---|---|
  | `issuer_url` | yes | OpenID Connect discovery endpoint |
  | `client_id` | yes | OIDC client ID |
  | `client_secret` | yes | OIDC client secret (sensitive) |
  | `type` | no | `TYPE_BACK_CHANNEL` (default) or `TYPE_FRONT_CHANNEL` |

  ### Example

  ```hcl
  resource "castai_sso_connection" "keycloak" {
    name         = "keycloak"
    email_domain = "example.com"

    oidc {
      issuer_url    = "https://keycloak.example.com/realms/my-realm"
      client_id     = "castai"
      client_secret = var.keycloak_client_secret
    }
  }

  Testing

  - Unit tests added for create and update operations
  - Manually verified end-to-end against a live Keycloak instance

  Notes

  This implementation was developed with AI assistance (Claude by Anthropic).
  The OIDC type was already present in the SDK (CastaiSsoV1beta1OIDC) but not
  yet exposed as a Terraform resource.