### PR TITLE
feat: add native HPA settings to workload scaling policies

### DIFF
--- a/castai/resource_workload_scaling_policy.go
+++ b/castai/resource_workload_scaling_policy.go
@@ -30,6 +30,7 @@ const (
 
 const (
 	minResourceMultiplierValue      = 1.0
+	maxResourceOverheadValue        = 2.5
 	minApplyThresholdValue          = 0.01
 	maxApplyThresholdValue          = 2.5
 	defaultApplyThresholdPercentage = 0.1
@@ -179,6 +180,10 @@ It can be either:
 				Description:      "Scaling policy name",
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(k8sNameRegex, "name must adhere to the format guidelines of Kubernetes labels/annotations")),
 			},
+			FieldIsOpsPilot: withAPIDefaultDiffSuppression(
+				isOpsPilotSchema(),
+				FieldIsOpsPilot,
+			),
 			FieldApplyType: {
 				Type:     schema.TypeString,
 				Required: true,
@@ -225,6 +230,11 @@ It can be either:
 							Description:      "Defines the duration (in seconds) during which elevated resource usage is expected at startup.\nWhen set, recommendations will be adjusted to disregard resource spikes within this period.\nIf not specified, the workload will receive standard recommendations without startup considerations.",
 							ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(120, 3600)),
 						},
+						FieldTwoPhaseRecommendations: withAPIDefaultDiffSuppression(
+							twoPhaseRecommendationsSchema(),
+							"startup",
+							FieldTwoPhaseRecommendations,
+						),
 					},
 				},
 			},
@@ -310,6 +320,18 @@ It can be either:
 					},
 				},
 			},
+			FieldHPASettings: withAPIDefaultDiffSuppression(
+				hpaSettingsSchema(),
+				FieldHPASettings,
+			),
+			FieldHPAConverters: withAPIDefaultDiffSuppression(
+				hpaConvertersSchema(),
+				FieldHPAConverters,
+			),
+			FieldGPU: withAPIDefaultDiffSuppression(
+				gpuSchema(),
+				FieldGPU,
+			),
 			FieldRolloutBehavior: {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -407,6 +429,11 @@ It can be either:
 								},
 							},
 						},
+						FieldAnomalyDetectionInfiniteMemoryScaling: withAPIDefaultDiffSuppression(
+							infiniteMemoryScalingSchema(),
+							FieldAnomalyDetection,
+							FieldAnomalyDetectionInfiniteMemoryScaling,
+						),
 					},
 				},
 			},
@@ -495,7 +522,7 @@ func workloadScalingPolicyResourceSchema(resource, function string, overhead, mi
 				Optional:         true,
 				Description:      "Overhead for the recommendation, e.g. `0.1` will result in 10% higher recommendation",
 				Default:          overhead,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.FloatBetween(0, 1)),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.FloatBetween(0, maxResourceOverheadValue)),
 			},
 			DeprecatedFieldApplyThreshold: {
 				Type:     schema.TypeFloat,
@@ -736,7 +763,12 @@ func resourceWorkloadScalingPolicyCreate(ctx context.Context, d *schema.Resource
 		ApplyType: sdk.WorkloadoptimizationV1ApplyType(d.Get(FieldApplyType).(string)),
 		RecommendationPolicies: sdk.WorkloadoptimizationV1RecommendationPolicies{
 			ManagementOption: sdk.WorkloadoptimizationV1ManagementOption(d.Get("management_option").(string)),
+			ApplyType:        sdk.WorkloadoptimizationV1ApplyType(d.Get(FieldApplyType).(string)),
 		},
+	}
+	//nolint:staticcheck // Currently no other way to reliably get the value and determine if it is set
+	if v, ok := d.GetOkExists(FieldIsOpsPilot); ok {
+		req.IsOpsPilot = lo.ToPtr(v.(bool))
 	}
 
 	if v, ok := d.GetOk("cpu"); ok {
@@ -773,7 +805,13 @@ func resourceWorkloadScalingPolicyCreate(ctx context.Context, d *schema.Resource
 
 	req.RecommendationPolicies.AnomalyDetection = toAnomalyDetection(toSection(d, FieldAnomalyDetection))
 
+	req.RecommendationPolicies.HpaConverters = toHPAConverters(d)
+
+	req.RecommendationPolicies.Gpu = toGPU(toSection(d, FieldGPU))
+
 	req.RecommendationPolicies.ExcludedContainers = toExcludedContainers(d)
+
+	req.HpaSettings = toHPASettings(toSection(d, FieldHPASettings))
 
 	ar, err := toAssignmentRules(toSection(d, FieldAssignmentRules))
 	if err != nil {
@@ -877,6 +915,9 @@ func fetchScalingPolicy(ctx context.Context, d *schema.ResourceData, meta any) (
 	if err := d.Set("name", sp.Name); err != nil {
 		return nil, fmt.Errorf("setting name: %w", err)
 	}
+	if err := d.Set(FieldIsOpsPilot, sp.IsOpsPilot); err != nil {
+		return nil, fmt.Errorf("setting OpsPilot ownership: %w", err)
+	}
 	if err := d.Set(FieldApplyType, sp.ApplyType); err != nil {
 		return nil, fmt.Errorf("setting apply type: %w", err)
 	}
@@ -919,6 +960,15 @@ func fetchScalingPolicy(ctx context.Context, d *schema.ResourceData, meta any) (
 	if err := d.Set(FieldAnomalyDetection, toAnomalyDetectionMap(sp.RecommendationPolicies.AnomalyDetection)); err != nil {
 		return nil, fmt.Errorf("setting anomaly detection: %w", err)
 	}
+	if err := d.Set(FieldHPAConverters, toHPAConvertersMap(sp.RecommendationPolicies.HpaConverters)); err != nil {
+		return nil, fmt.Errorf("setting HPA converters: %w", err)
+	}
+	if err := d.Set(FieldGPU, toGPUMap(sp.RecommendationPolicies.Gpu)); err != nil {
+		return nil, fmt.Errorf("setting GPU settings: %w", err)
+	}
+	if err := d.Set(FieldHPASettings, toHPASettingsMap(sp.HpaSettings)); err != nil {
+		return nil, fmt.Errorf("setting HPA settings: %w", err)
+	}
 	if err := d.Set(FieldAssignmentRules, toAssignmentRulesMap(getResourceFrom(d, FieldAssignmentRules), sp.AssignmentRules)); err != nil {
 		return nil, fmt.Errorf("setting assignment rules: %w", err)
 	}
@@ -944,6 +994,7 @@ func resourceWorkloadScalingPolicyUpdate(ctx context.Context, d *schema.Resource
 func updateScalingPolicy(ctx context.Context, d *schema.ResourceData, meta any) (sdk.Response, error) {
 	if !d.HasChanges(
 		"name",
+		FieldIsOpsPilot,
 		FieldApplyType,
 		"management_option",
 		"cpu",
@@ -958,6 +1009,9 @@ func updateScalingPolicy(ctx context.Context, d *schema.ResourceData, meta any) 
 		FieldRolloutBehavior,
 		FieldJVM,
 		FieldAnomalyDetection,
+		FieldHPAConverters,
+		FieldGPU,
+		FieldHPASettings,
 		FieldExcludedContainers,
 	) {
 		tflog.Info(ctx, "scaling policy up to date")
@@ -983,8 +1037,10 @@ func updateScalingPolicy(ctx context.Context, d *schema.ResourceData, meta any) 
 		Name:            d.Get("name").(string),
 		ApplyType:       sdk.WorkloadoptimizationV1ApplyType(d.Get(FieldApplyType).(string)),
 		AssignmentRules: ar,
+		HpaSettings:     toHPASettings(toSection(d, FieldHPASettings)),
 		RecommendationPolicies: sdk.WorkloadoptimizationV1RecommendationPolicies{
 			ManagementOption:   sdk.WorkloadoptimizationV1ManagementOption(d.Get("management_option").(string)),
+			ApplyType:          sdk.WorkloadoptimizationV1ApplyType(d.Get(FieldApplyType).(string)),
 			Cpu:                cpu,
 			Memory:             memory,
 			Startup:            toStartup(toSection(d, "startup")),
@@ -996,8 +1052,14 @@ func updateScalingPolicy(ctx context.Context, d *schema.ResourceData, meta any) 
 			RolloutBehavior:    toRolloutBehavior(toSection(d, FieldRolloutBehavior)),
 			Jvm:                toJvm(toSection(d, FieldJVM)),
 			AnomalyDetection:   toAnomalyDetection(toSection(d, FieldAnomalyDetection)),
+			HpaConverters:      toHPAConverters(d),
+			Gpu:                toGPU(toSection(d, FieldGPU)),
 			ExcludedContainers: toExcludedContainers(d),
 		},
+	}
+	//nolint:staticcheck // Currently no other way to reliably get the value and determine if it is set
+	if v, ok := d.GetOkExists(FieldIsOpsPilot); ok {
+		req.IsOpsPilot = lo.ToPtr(v.(bool))
 	}
 
 	resp, err := client.WorkloadOptimizationAPIUpdateWorkloadScalingPolicyWithResponse(ctx, clusterID, d.Id(), req)
@@ -1069,7 +1131,7 @@ func resourceWorkloadScalingPolicyDiff(_ context.Context, d *schema.ResourceDiff
 			return err
 		}
 	}
-	return nil
+	return validateHPASettings(d)
 }
 
 // rawConfigHasField walks a path of nested attributes in a Terraform raw config.
@@ -1692,6 +1754,9 @@ func toStartup(startup map[string]any) *sdk.WorkloadoptimizationV1StartupSetting
 	if v, ok := startup["period_seconds"].(int); ok && v > 0 {
 		result.PeriodSeconds = lo.ToPtr(int32(v))
 	}
+	if v := getFirstElem(startup, FieldTwoPhaseRecommendations); v != nil {
+		result.TwoPhaseRecommendations = toTwoPhaseRecommendations(v)
+	}
 
 	return result
 }
@@ -1705,6 +1770,9 @@ func toStartupMap(s *sdk.WorkloadoptimizationV1StartupSettings) []map[string]any
 
 	if s.PeriodSeconds != nil {
 		m["period_seconds"] = int(*s.PeriodSeconds)
+	}
+	if s.TwoPhaseRecommendations != nil {
+		m[FieldTwoPhaseRecommendations] = toTwoPhaseRecommendationsMap(s.TwoPhaseRecommendations)
 	}
 
 	if len(m) == 0 {
@@ -1921,6 +1989,13 @@ func toAnomalyDetection(m map[string]any) *sdk.WorkloadoptimizationV1AnomalyDete
 			MinPressuredPodPercentage:   cpuPressure[FieldMinPressuredPodPercentage].(float64),
 		}
 	}
+	if infiniteMemoryScaling := getFirstElem(m, FieldAnomalyDetectionInfiniteMemoryScaling); infiniteMemoryScaling != nil {
+		if enabled, ok := infiniteMemoryScaling[FieldEnabled].(bool); ok {
+			result.InfiniteMemoryScaling = &sdk.WorkloadoptimizationV1InfiniteMemoryScalingSettings{
+				Enabled: enabled,
+			}
+		}
+	}
 	return result
 }
 
@@ -1934,6 +2009,13 @@ func toAnomalyDetectionMap(s *sdk.WorkloadoptimizationV1AnomalyDetectionSettings
 			{
 				FieldCpuStallThresholdPercentage: s.CpuPressure.CpuStallThresholdPercentage,
 				FieldMinPressuredPodPercentage:   s.CpuPressure.MinPressuredPodPercentage,
+			},
+		}
+	}
+	if s.InfiniteMemoryScaling != nil {
+		m[FieldAnomalyDetectionInfiniteMemoryScaling] = []map[string]any{
+			{
+				FieldEnabled: s.InfiniteMemoryScaling.Enabled,
 			},
 		}
 	}
@@ -2099,15 +2181,24 @@ func toWorkloadAssignmentRule(ruleMap map[string]any) (*sdk.Workloadoptimization
 }
 
 func getFirstElem(in map[string]any, key string) map[string]any {
-	list, ok := in[key].([]any)
-	if !ok || len(list) == 0 {
+	switch list := in[key].(type) {
+	case []any:
+		if len(list) == 0 {
+			return nil
+		}
+		elem, ok := list[0].(map[string]any)
+		if !ok {
+			return nil
+		}
+		return elem
+	case []map[string]any:
+		if len(list) == 0 {
+			return nil
+		}
+		return list[0]
+	default:
 		return nil
 	}
-	elem, ok := list[0].(map[string]any)
-	if !ok {
-		return nil
-	}
-	return elem
 }
 
 func toLabelSelectorOperator(in string) sdk.WorkloadoptimizationV1KubernetesLabelSelectorOperator {

--- a/castai/workload_scaling_policy_api_parity.go
+++ b/castai/workload_scaling_policy_api_parity.go
@@ -1,0 +1,936 @@
+package castai
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/samber/lo"
+
+	"github.com/castai/terraform-provider-castai/castai/sdk"
+)
+
+const (
+	FieldTwoPhaseRecommendations                 = "two_phase_recommendations"
+	FieldRequestsOnStartup                       = "requests_on_startup"
+	FieldCPUCores                                = "cpu_cores"
+	FieldMemoryGiB                               = "memory_gib"
+	FieldHPASettings                             = "hpa_settings"
+	FieldHPAConverters                           = "hpa_converters"
+	FieldGPU                                     = "gpu"
+	FieldIsOpsPilot                              = "is_ops_pilot"
+	FieldAnomalyDetectionInfiniteMemoryScaling   = "infinite_memory_scaling"
+	fieldNativeHPASpec                           = "native_hpa_spec"
+	fieldTakeOwnership                           = "take_ownership"
+	fieldMinReplicas                             = "min_replicas"
+	fieldMaxReplicas                             = "max_replicas"
+	fieldMetrics                                 = "metrics"
+	fieldBehavior                                = "behavior"
+	fieldScaleUp                                 = "scale_up"
+	fieldScaleDown                               = "scale_down"
+	fieldStabilizationWindowSeconds              = "stabilization_window_seconds"
+	fieldSelectPolicy                            = "select_policy"
+	fieldPolicies                                = "policies"
+	fieldTolerance                               = "tolerance"
+	fieldResource                                = "resource"
+	fieldPods                                    = "pods"
+	fieldObject                                  = "object"
+	fieldExternal                                = "external"
+	fieldContainerResource                       = "container_resource"
+	fieldTarget                                  = "target"
+	fieldMetric                                  = "metric"
+	fieldSelector                                = "selector"
+	fieldDescribedObject                         = "described_object"
+	fieldAPIVersion                              = "api_version"
+	hpaConverterAverageValueFromOriginalRequests = "AVERAGE_VALUE_FROM_ORIGINAL_REQUESTS"
+	hpaMetricSourceResource                      = "RESOURCE"
+	hpaMetricSourcePods                          = "PODS"
+	hpaMetricSourceObject                        = "OBJECT"
+	hpaMetricSourceExternal                      = "EXTERNAL"
+	hpaMetricSourceContainerResource             = "CONTAINER_RESOURCE"
+	hpaMetricTargetValue                         = "VALUE"
+	hpaMetricTargetAverageValue                  = "AVERAGE_VALUE"
+	hpaMetricTargetUtilization                   = "UTILIZATION"
+	hpaScalingPolicyPods                         = "PODS_SCALING_POLICY"
+	hpaScalingPolicyPercent                      = "PERCENT_SCALING_POLICY"
+	hpaScalingPolicySelectUnspecified            = "SCALING_POLICY_SELECT_UNSPECIFIED"
+	hpaScalingPolicySelectMaxChange              = "MAX_CHANGE_POLICY_SELECT"
+	hpaScalingPolicySelectMinChange              = "MIN_CHANGE_POLICY_SELECT"
+	hpaScalingPolicySelectDisabled               = "DISABLED_POLICY_SELECT"
+)
+
+func twoPhaseRecommendationsSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: "Configures startup recommendations that use original requests during startup and optimized recommendations afterwards.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				FieldEnabled: {
+					Type:        schema.TypeBool,
+					Required:    true,
+					Description: "Enables two-phase startup recommendations.",
+				},
+				FieldRequestsOnStartup: {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Overrides the requests used during the startup phase.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							FieldCPUCores: {
+								Type:             schema.TypeFloat,
+								Optional:         true,
+								Description:      "CPU request in cores used during startup.",
+								ValidateDiagFunc: validation.ToDiagFunc(validation.FloatAtLeast(0)),
+							},
+							FieldMemoryGiB: {
+								Type:             schema.TypeFloat,
+								Optional:         true,
+								Description:      "Memory request in GiB used during startup.",
+								ValidateDiagFunc: validation.ToDiagFunc(validation.FloatAtLeast(0)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func infiniteMemoryScalingSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: "Configures infinite memory scaling anomaly detection.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				FieldEnabled: {
+					Type:        schema.TypeBool,
+					Required:    true,
+					Description: "Enables infinite memory scaling detection for workloads using this policy.",
+				},
+			},
+		},
+	}
+}
+
+func hpaConvertersSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		Description: "Configures conversion of existing HPAs when vertical optimization is used without HPA management.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				FieldLimitStrategyType: {
+					Type:             schema.TypeString,
+					Required:         true,
+					Description:      "HPA converter strategy.",
+					ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{hpaConverterAverageValueFromOriginalRequests}, false)),
+				},
+			},
+		},
+	}
+}
+
+func gpuSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: "Configures GPU optimization.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"management_option": managementOptionSchema(),
+			},
+		},
+	}
+}
+
+func managementOptionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:             schema.TypeString,
+		Required:         true,
+		Description:      "Defines whether CAST AI observes or manages the feature.",
+		ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"READ_ONLY", "MANAGED"}, false)),
+	}
+}
+
+func hpaSettingsSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: "Configures horizontal pod autoscaling for workloads using this policy.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"management_option": managementOptionSchema(),
+				fieldTakeOwnership: {
+					Type:        schema.TypeBool,
+					Required:    true,
+					Description: "Allows CAST AI to take ownership of eligible existing HPAs.",
+				},
+				fieldNativeHPASpec: nativeHPASpecSchema(),
+			},
+		},
+	}
+}
+
+func validateHPASettings(d *schema.ResourceDiff) error {
+	settings, ok := d.Get(FieldHPASettings).([]any)
+	if !ok || len(settings) == 0 {
+		return nil
+	}
+	setting, ok := settings[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+	native := getFirstElem(setting, fieldNativeHPASpec)
+	if native == nil {
+		return nil
+	}
+	if minReplicas, maxReplicas := intValue(native, fieldMinReplicas), intValue(native, fieldMaxReplicas); maxReplicas < minReplicas {
+		return fmt.Errorf("%s: max_replicas must be greater than or equal to min_replicas", FieldHPASettings)
+	}
+	for index, rawMetric := range listValue(native, fieldMetrics) {
+		metric, ok := rawMetric.(map[string]any)
+		if !ok {
+			continue
+		}
+		metricType := scalingPolicyStringValue(metric, FieldLimitStrategyType)
+		sourceByType := map[string]string{
+			hpaMetricSourceResource:          fieldResource,
+			hpaMetricSourcePods:              fieldPods,
+			hpaMetricSourceObject:            fieldObject,
+			hpaMetricSourceExternal:          fieldExternal,
+			hpaMetricSourceContainerResource: fieldContainerResource,
+		}
+		expectedSource := sourceByType[metricType]
+		configuredSources := make([]string, 0, len(sourceByType))
+		for _, source := range sourceByType {
+			if getFirstElem(metric, source) != nil {
+				configuredSources = append(configuredSources, source)
+			}
+		}
+		if len(configuredSources) != 1 || configuredSources[0] != expectedSource {
+			return fmt.Errorf(
+				"%s: metric %d with type %q must configure exactly its %q source block",
+				FieldHPASettings,
+				index,
+				metricType,
+				expectedSource,
+			)
+		}
+	}
+	return nil
+}
+
+func isOpsPilotSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Marks a policy as managed by OpsPilot.",
+	}
+}
+
+func withAPIDefaultDiffSuppression(s *schema.Schema, path ...string) *schema.Schema {
+	s.DiffSuppressFunc = func(_ string, oldValue, newValue string, d *schema.ResourceData) bool {
+		if !rawConfigHasField(d.GetRawConfig(), path...) {
+			return true
+		}
+		return oldValue == newValue
+	}
+	return s
+}
+
+func nativeHPASpecSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Required:    true,
+		MaxItems:    1,
+		Description: "Native Kubernetes HPA specification.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				fieldMinReplicas: {
+					Type:             schema.TypeInt,
+					Required:         true,
+					Description:      "Minimum number of replicas.",
+					ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
+				},
+				fieldMaxReplicas: {
+					Type:             schema.TypeInt,
+					Required:         true,
+					Description:      "Maximum number of replicas.",
+					ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
+				},
+				fieldMetrics: {
+					Type:        schema.TypeList,
+					Required:    true,
+					MinItems:    1,
+					Description: "Metrics used by the HPA.",
+					Elem:        hpaMetricSpecSchema(),
+				},
+				fieldBehavior: hpaBehaviorSchema(),
+			},
+		},
+	}
+}
+
+func hpaMetricSpecSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			FieldLimitStrategyType: {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
+					hpaMetricSourceResource,
+					hpaMetricSourcePods,
+					hpaMetricSourceObject,
+					hpaMetricSourceExternal,
+					hpaMetricSourceContainerResource,
+				}, false)),
+			},
+			fieldResource:          hpaResourceMetricSourceSchema(),
+			fieldPods:              hpaPodsMetricSourceSchema(),
+			fieldObject:            hpaObjectMetricSourceSchema(),
+			fieldExternal:          hpaExternalMetricSourceSchema(),
+			fieldContainerResource: hpaContainerResourceMetricSourceSchema(),
+		},
+	}
+}
+
+func hpaResourceMetricSourceSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+			"name":      requiredStringSchema(),
+			fieldTarget: hpaMetricTargetSchema(),
+		}},
+	}
+}
+
+func hpaPodsMetricSourceSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+			fieldMetric: hpaMetricIdentifierSchema(),
+			fieldTarget: hpaMetricTargetSchema(),
+		}},
+	}
+}
+
+func hpaObjectMetricSourceSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+			fieldMetric:          hpaMetricIdentifierSchema(),
+			fieldDescribedObject: hpaDescribedObjectSchema(),
+			fieldTarget:          hpaMetricTargetSchema(),
+		}},
+	}
+}
+
+func hpaExternalMetricSourceSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+			fieldMetric: hpaMetricIdentifierSchema(),
+			fieldTarget: hpaMetricTargetSchema(),
+		}},
+	}
+}
+
+func hpaContainerResourceMetricSourceSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+			"name":      requiredStringSchema(),
+			"container": requiredStringSchema(),
+			fieldTarget: hpaMetricTargetSchema(),
+		}},
+	}
+}
+
+func hpaMetricIdentifierSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+			"name": requiredStringSchema(),
+			fieldSelector: {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "Metric label selector.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		}},
+	}
+}
+
+func hpaDescribedObjectSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+			"kind":          optionalStringSchema(),
+			"name":          optionalStringSchema(),
+			fieldAPIVersion: optionalStringSchema(),
+		}},
+	}
+}
+
+func hpaMetricTargetSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+			FieldLimitStrategyType: {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
+					hpaMetricTargetValue,
+					hpaMetricTargetAverageValue,
+					hpaMetricTargetUtilization,
+				}, false)),
+			},
+			"value": requiredStringSchema(),
+		}},
+	}
+}
+
+func hpaBehaviorSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+			fieldScaleUp:   hpaScalingRulesSchema(),
+			fieldScaleDown: hpaScalingRulesSchema(),
+		}},
+	}
+}
+
+func hpaScalingRulesSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+			fieldStabilizationWindowSeconds: {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(0, 3600)),
+			},
+			fieldSelectPolicy: {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
+					hpaScalingPolicySelectUnspecified,
+					hpaScalingPolicySelectMaxChange,
+					hpaScalingPolicySelectMinChange,
+					hpaScalingPolicySelectDisabled,
+				}, false)),
+			},
+			fieldPolicies: {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+					FieldLimitStrategyType: {
+						Type:     schema.TypeString,
+						Required: true,
+						ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
+							hpaScalingPolicyPods,
+							hpaScalingPolicyPercent,
+						}, false)),
+					},
+					"value": {
+						Type:             schema.TypeInt,
+						Required:         true,
+						ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
+					},
+					"period_seconds": {
+						Type:             schema.TypeInt,
+						Required:         true,
+						ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(1, 1800)),
+					},
+				}},
+			},
+			fieldTolerance: optionalStringSchema(),
+		}},
+	}
+}
+
+func requiredStringSchema() *schema.Schema {
+	return &schema.Schema{Type: schema.TypeString, Required: true}
+}
+
+func optionalStringSchema() *schema.Schema {
+	return &schema.Schema{Type: schema.TypeString, Optional: true}
+}
+
+func toTwoPhaseRecommendations(m map[string]any) *sdk.WorkloadoptimizationV1TwoPhaseRecommendations {
+	if len(m) == 0 {
+		return nil
+	}
+	result := &sdk.WorkloadoptimizationV1TwoPhaseRecommendations{}
+	if enabled, ok := m[FieldEnabled].(bool); ok {
+		result.Enabled = enabled
+	}
+	if requests := getFirstElem(m, FieldRequestsOnStartup); requests != nil {
+		resourceQuantity := &sdk.WorkloadoptimizationV1ResourceQuantity{}
+		if cpuCores, ok := requests[FieldCPUCores].(float64); ok {
+			resourceQuantity.CpuCores = lo.ToPtr(cpuCores)
+		}
+		if memoryGiB, ok := requests[FieldMemoryGiB].(float64); ok {
+			resourceQuantity.MemoryGib = lo.ToPtr(memoryGiB)
+		}
+		if resourceQuantity.CpuCores != nil || resourceQuantity.MemoryGib != nil {
+			result.RequestsOnStartup = resourceQuantity
+		}
+	}
+	return result
+}
+
+func toTwoPhaseRecommendationsMap(s *sdk.WorkloadoptimizationV1TwoPhaseRecommendations) []map[string]any {
+	if s == nil {
+		return nil
+	}
+	m := map[string]any{FieldEnabled: s.Enabled}
+	if s.RequestsOnStartup != nil {
+		requests := map[string]any{}
+		if s.RequestsOnStartup.CpuCores != nil {
+			requests[FieldCPUCores] = *s.RequestsOnStartup.CpuCores
+		}
+		if s.RequestsOnStartup.MemoryGib != nil {
+			requests[FieldMemoryGiB] = *s.RequestsOnStartup.MemoryGib
+		}
+		if len(requests) > 0 {
+			m[FieldRequestsOnStartup] = []map[string]any{requests}
+		}
+	}
+	return []map[string]any{m}
+}
+
+func toHPAConverters(d *schema.ResourceData) *[]sdk.WorkloadoptimizationV1HPAConverters {
+	return toHPAConvertersValue(d.Get(FieldHPAConverters))
+}
+
+func toHPAConvertersValue(value any) *[]sdk.WorkloadoptimizationV1HPAConverters {
+	raw := listFromValue(value)
+	if len(raw) == 0 {
+		return nil
+	}
+	result := make([]sdk.WorkloadoptimizationV1HPAConverters, 0, len(raw))
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if converterType, ok := m[FieldLimitStrategyType].(string); ok && converterType != "" {
+			result = append(result, sdk.WorkloadoptimizationV1HPAConverters{
+				Type: sdk.WorkloadoptimizationV1HPAConverterType(converterType),
+			})
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return &result
+}
+
+func listFromValue(value any) []any {
+	switch list := value.(type) {
+	case []any:
+		return list
+	case []map[string]any:
+		result := make([]any, 0, len(list))
+		for _, item := range list {
+			result = append(result, item)
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func toHPAConvertersMap(s *[]sdk.WorkloadoptimizationV1HPAConverters) []map[string]any {
+	if s == nil || len(*s) == 0 {
+		return nil
+	}
+	result := make([]map[string]any, 0, len(*s))
+	for _, converter := range *s {
+		result = append(result, map[string]any{
+			FieldLimitStrategyType: string(converter.Type),
+		})
+	}
+	return result
+}
+
+func toGPU(m map[string]any) *sdk.WorkloadoptimizationV1GPUSettings {
+	if len(m) == 0 {
+		return nil
+	}
+	managementOption, ok := m["management_option"].(string)
+	if !ok || managementOption == "" {
+		return nil
+	}
+	return &sdk.WorkloadoptimizationV1GPUSettings{
+		ManagementOption: sdk.WorkloadoptimizationV1ManagementOption(managementOption),
+	}
+}
+
+func toGPUMap(s *sdk.WorkloadoptimizationV1GPUSettings) []map[string]any {
+	if s == nil {
+		return nil
+	}
+	return []map[string]any{{
+		"management_option": string(s.ManagementOption),
+	}}
+}
+
+func toHPASettings(m map[string]any) *sdk.WorkloadoptimizationV1ScalingPolicyHPASettings {
+	if len(m) == 0 {
+		return nil
+	}
+	native := getFirstElem(m, fieldNativeHPASpec)
+	if native == nil {
+		return nil
+	}
+	result := &sdk.WorkloadoptimizationV1ScalingPolicyHPASettings{
+		ManagementOption: sdk.WorkloadoptimizationV1ManagementOption(scalingPolicyStringValue(m, "management_option")),
+		TakeOwnership:    boolValue(m, fieldTakeOwnership),
+		NativeHpaSpec: sdk.WorkloadoptimizationV1ScalingPolicyNativeHPASpec{
+			MinReplicas: int32(intValue(native, fieldMinReplicas)),
+			MaxReplicas: int32(intValue(native, fieldMaxReplicas)),
+			Metrics:     toHPAMetrics(listValue(native, fieldMetrics)),
+			Behavior:    toHPABehavior(getFirstElem(native, fieldBehavior)),
+		},
+	}
+	return result
+}
+
+func toHPASettingsMap(s *sdk.WorkloadoptimizationV1ScalingPolicyHPASettings) []map[string]any {
+	if s == nil {
+		return nil
+	}
+	native := map[string]any{
+		fieldMinReplicas: int(s.NativeHpaSpec.MinReplicas),
+		fieldMaxReplicas: int(s.NativeHpaSpec.MaxReplicas),
+		fieldMetrics:     toHPAMetricsMap(s.NativeHpaSpec.Metrics),
+	}
+	if behavior := toHPABehaviorMap(s.NativeHpaSpec.Behavior); behavior != nil {
+		native[fieldBehavior] = behavior
+	}
+	return []map[string]any{{
+		"management_option": string(s.ManagementOption),
+		fieldTakeOwnership:  s.TakeOwnership,
+		fieldNativeHPASpec:  []map[string]any{native},
+	}}
+}
+
+func toHPAMetrics(raw []any) []sdk.WorkloadoptimizationV1MetricSpec {
+	result := make([]sdk.WorkloadoptimizationV1MetricSpec, 0, len(raw))
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		metricType := sdk.WorkloadoptimizationV1MetricSourceType(scalingPolicyStringValue(m, FieldLimitStrategyType))
+		metric := sdk.WorkloadoptimizationV1MetricSpec{Type: &metricType}
+		if source := getFirstElem(m, fieldResource); source != nil {
+			metric.Resource = &sdk.WorkloadoptimizationV1ResourceMetricSource{
+				Name:   scalingPolicyStringValue(source, "name"),
+				Target: toHPAMetricTarget(getFirstElem(source, fieldTarget)),
+			}
+		}
+		if source := getFirstElem(m, fieldPods); source != nil {
+			metric.Pods = &sdk.WorkloadoptimizationV1PodsMetricSource{
+				Metric: toHPAMetricIdentifier(getFirstElem(source, fieldMetric)),
+				Target: toHPAMetricTarget(getFirstElem(source, fieldTarget)),
+			}
+		}
+		if source := getFirstElem(m, fieldObject); source != nil {
+			metric.Object = &sdk.WorkloadoptimizationV1ObjectMetricSource{
+				Metric:          toHPAMetricIdentifier(getFirstElem(source, fieldMetric)),
+				DescribedObject: toHPADescribedObject(getFirstElem(source, fieldDescribedObject)),
+				Target:          toHPAMetricTarget(getFirstElem(source, fieldTarget)),
+			}
+		}
+		if source := getFirstElem(m, fieldExternal); source != nil {
+			metric.External = &sdk.WorkloadoptimizationV1ExternalMetricSource{
+				Metric: toHPAMetricIdentifier(getFirstElem(source, fieldMetric)),
+				Target: toHPAMetricTarget(getFirstElem(source, fieldTarget)),
+			}
+		}
+		if source := getFirstElem(m, fieldContainerResource); source != nil {
+			metric.ContainerResource = &sdk.WorkloadoptimizationV1ContainerResourceMetricSource{
+				Name:      scalingPolicyStringValue(source, "name"),
+				Container: scalingPolicyStringValue(source, "container"),
+				Target:    toHPAMetricTarget(getFirstElem(source, fieldTarget)),
+			}
+		}
+		result = append(result, metric)
+	}
+	return result
+}
+
+func toHPAMetricsMap(metrics []sdk.WorkloadoptimizationV1MetricSpec) []map[string]any {
+	result := make([]map[string]any, 0, len(metrics))
+	for _, metric := range metrics {
+		m := map[string]any{}
+		if metric.Type != nil {
+			m[FieldLimitStrategyType] = string(*metric.Type)
+		}
+		if metric.Resource != nil {
+			m[fieldResource] = []map[string]any{{
+				"name":      metric.Resource.Name,
+				fieldTarget: toHPAMetricTargetMap(metric.Resource.Target),
+			}}
+		}
+		if metric.Pods != nil {
+			m[fieldPods] = []map[string]any{{
+				fieldMetric: toHPAMetricIdentifierMap(metric.Pods.Metric),
+				fieldTarget: toHPAMetricTargetMap(metric.Pods.Target),
+			}}
+		}
+		if metric.Object != nil {
+			m[fieldObject] = []map[string]any{{
+				fieldMetric:          toHPAMetricIdentifierMap(metric.Object.Metric),
+				fieldDescribedObject: toHPADescribedObjectMap(metric.Object.DescribedObject),
+				fieldTarget:          toHPAMetricTargetMap(metric.Object.Target),
+			}}
+		}
+		if metric.External != nil {
+			m[fieldExternal] = []map[string]any{{
+				fieldMetric: toHPAMetricIdentifierMap(metric.External.Metric),
+				fieldTarget: toHPAMetricTargetMap(metric.External.Target),
+			}}
+		}
+		if metric.ContainerResource != nil {
+			m[fieldContainerResource] = []map[string]any{{
+				"name":      metric.ContainerResource.Name,
+				"container": metric.ContainerResource.Container,
+				fieldTarget: toHPAMetricTargetMap(metric.ContainerResource.Target),
+			}}
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+func toHPAMetricTarget(m map[string]any) sdk.WorkloadoptimizationV1MetricTarget {
+	return sdk.WorkloadoptimizationV1MetricTarget{
+		Type:  sdk.WorkloadoptimizationV1MetricTargetType(scalingPolicyStringValue(m, FieldLimitStrategyType)),
+		Value: scalingPolicyStringValue(m, "value"),
+	}
+}
+
+func toHPAMetricTargetMap(target sdk.WorkloadoptimizationV1MetricTarget) []map[string]any {
+	return []map[string]any{{
+		FieldLimitStrategyType: string(target.Type),
+		"value":                target.Value,
+	}}
+}
+
+func toHPAMetricIdentifier(m map[string]any) sdk.WorkloadoptimizationV1MetricIdentifier {
+	return sdk.WorkloadoptimizationV1MetricIdentifier{
+		Name:     scalingPolicyStringValue(m, "name"),
+		Selector: stringMapValue(m, fieldSelector),
+	}
+}
+
+func toHPAMetricIdentifierMap(identifier sdk.WorkloadoptimizationV1MetricIdentifier) []map[string]any {
+	return []map[string]any{{
+		"name":        identifier.Name,
+		fieldSelector: identifier.Selector,
+	}}
+}
+
+func toHPADescribedObject(m map[string]any) sdk.WorkloadoptimizationV1CrossVersionObjectReference {
+	result := sdk.WorkloadoptimizationV1CrossVersionObjectReference{}
+	if v := scalingPolicyStringValue(m, "kind"); v != "" {
+		result.Kind = &v
+	}
+	if v := scalingPolicyStringValue(m, "name"); v != "" {
+		result.Name = &v
+	}
+	if v := scalingPolicyStringValue(m, fieldAPIVersion); v != "" {
+		result.ApiVersion = &v
+	}
+	return result
+}
+
+func toHPADescribedObjectMap(object sdk.WorkloadoptimizationV1CrossVersionObjectReference) []map[string]any {
+	m := map[string]any{}
+	if object.Kind != nil {
+		m["kind"] = *object.Kind
+	}
+	if object.Name != nil {
+		m["name"] = *object.Name
+	}
+	if object.ApiVersion != nil {
+		m[fieldAPIVersion] = *object.ApiVersion
+	}
+	return []map[string]any{m}
+}
+
+func toHPABehavior(m map[string]any) *sdk.WorkloadoptimizationV1HorizontalPodAutoscalerBehavior {
+	if len(m) == 0 {
+		return nil
+	}
+	result := &sdk.WorkloadoptimizationV1HorizontalPodAutoscalerBehavior{
+		ScaleUp:   toHPAScalingRules(getFirstElem(m, fieldScaleUp)),
+		ScaleDown: toHPAScalingRules(getFirstElem(m, fieldScaleDown)),
+	}
+	if result.ScaleUp == nil && result.ScaleDown == nil {
+		return nil
+	}
+	return result
+}
+
+func toHPABehaviorMap(behavior *sdk.WorkloadoptimizationV1HorizontalPodAutoscalerBehavior) []map[string]any {
+	if behavior == nil {
+		return nil
+	}
+	m := map[string]any{}
+	if scaleUp := toHPAScalingRulesMap(behavior.ScaleUp); scaleUp != nil {
+		m[fieldScaleUp] = scaleUp
+	}
+	if scaleDown := toHPAScalingRulesMap(behavior.ScaleDown); scaleDown != nil {
+		m[fieldScaleDown] = scaleDown
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return []map[string]any{m}
+}
+
+func toHPAScalingRules(m map[string]any) *sdk.WorkloadoptimizationV1HPAScalingRules {
+	if len(m) == 0 {
+		return nil
+	}
+	result := &sdk.WorkloadoptimizationV1HPAScalingRules{}
+	if v, ok := m[fieldStabilizationWindowSeconds].(int); ok {
+		result.StabilizationWindowSeconds = lo.ToPtr(int32(v))
+	}
+	if v, ok := m[fieldSelectPolicy].(string); ok && v != "" {
+		result.SelectPolicy = lo.ToPtr(sdk.WorkloadoptimizationV1ScalingPolicySelect(v))
+	}
+	if v, ok := m[fieldTolerance].(string); ok && v != "" {
+		result.Tolerance = &v
+	}
+	if raw := listValue(m, fieldPolicies); len(raw) > 0 {
+		policies := make([]sdk.WorkloadoptimizationV1HPAScalingPolicy, 0, len(raw))
+		for _, item := range raw {
+			policyMap, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			policies = append(policies, sdk.WorkloadoptimizationV1HPAScalingPolicy{
+				Type:          sdk.WorkloadoptimizationV1HPAScalingPolicyType(scalingPolicyStringValue(policyMap, FieldLimitStrategyType)),
+				Value:         int32(intValue(policyMap, "value")),
+				PeriodSeconds: int32(intValue(policyMap, "period_seconds")),
+			})
+		}
+		result.Policies = &policies
+	}
+	return result
+}
+
+func toHPAScalingRulesMap(rules *sdk.WorkloadoptimizationV1HPAScalingRules) []map[string]any {
+	if rules == nil {
+		return nil
+	}
+	m := map[string]any{}
+	if rules.StabilizationWindowSeconds != nil {
+		m[fieldStabilizationWindowSeconds] = int(*rules.StabilizationWindowSeconds)
+	}
+	if rules.SelectPolicy != nil {
+		m[fieldSelectPolicy] = string(*rules.SelectPolicy)
+	}
+	if rules.Tolerance != nil {
+		m[fieldTolerance] = *rules.Tolerance
+	}
+	if rules.Policies != nil {
+		policies := make([]map[string]any, 0, len(*rules.Policies))
+		for _, policy := range *rules.Policies {
+			policies = append(policies, map[string]any{
+				FieldLimitStrategyType: string(policy.Type),
+				"value":                int(policy.Value),
+				"period_seconds":       int(policy.PeriodSeconds),
+			})
+		}
+		m[fieldPolicies] = policies
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return []map[string]any{m}
+}
+
+func scalingPolicyStringValue(m map[string]any, key string) string {
+	if value, ok := m[key].(string); ok {
+		return value
+	}
+	return ""
+}
+
+func boolValue(m map[string]any, key string) bool {
+	if value, ok := m[key].(bool); ok {
+		return value
+	}
+	return false
+}
+
+func intValue(m map[string]any, key string) int {
+	if value, ok := m[key].(int); ok {
+		return value
+	}
+	return 0
+}
+
+func listValue(m map[string]any, key string) []any {
+	switch value := m[key].(type) {
+	case []any:
+		return value
+	case []map[string]any:
+		result := make([]any, 0, len(value))
+		for _, item := range value {
+			result = append(result, item)
+		}
+		return result
+	}
+	return nil
+}
+
+func stringMapValue(m map[string]any, key string) map[string]string {
+	result := map[string]string{}
+	switch values := m[key].(type) {
+	case map[string]any:
+		for k, value := range values {
+			if stringValue, ok := value.(string); ok {
+				result[k] = stringValue
+			}
+		}
+	case map[string]string:
+		for k, value := range values {
+			result[k] = value
+		}
+	}
+	return result
+}

--- a/castai/workload_scaling_policy_api_parity_test.go
+++ b/castai/workload_scaling_policy_api_parity_test.go
@@ -1,0 +1,204 @@
+package castai
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/castai/terraform-provider-castai/castai/sdk"
+)
+
+func TestWorkloadScalingPolicyAPISchemaIsValid(t *testing.T) {
+	require.NoError(t, Provider("test").InternalValidate())
+}
+
+func TestStartupTwoPhaseRecommendationsRoundTrip(t *testing.T) {
+	input := map[string]any{
+		"period_seconds": 180,
+		FieldTwoPhaseRecommendations: []any{map[string]any{
+			FieldEnabled: true,
+			FieldRequestsOnStartup: []any{map[string]any{
+				FieldCPUCores:  0.5,
+				FieldMemoryGiB: 1.5,
+			}},
+		}},
+	}
+
+	got := toStartup(input)
+	require.NotNil(t, got)
+	require.Equal(t, int32(180), *got.PeriodSeconds)
+	require.True(t, got.TwoPhaseRecommendations.Enabled)
+	require.Equal(t, 0.5, *got.TwoPhaseRecommendations.RequestsOnStartup.CpuCores)
+	require.Equal(t, 1.5, *got.TwoPhaseRecommendations.RequestsOnStartup.MemoryGib)
+
+	roundTripped := toStartup(toStartupMap(got)[0])
+	require.Equal(t, got, roundTripped)
+}
+
+func TestAdditionalRecommendationPolicySettingsRoundTrip(t *testing.T) {
+	anomaly := toAnomalyDetection(map[string]any{
+		FieldAnomalyDetectionInfiniteMemoryScaling: []any{map[string]any{
+			FieldEnabled: true,
+		}},
+	})
+	require.Equal(t, &sdk.WorkloadoptimizationV1AnomalyDetectionSettings{
+		InfiniteMemoryScaling: &sdk.WorkloadoptimizationV1InfiniteMemoryScalingSettings{
+			Enabled: true,
+		},
+	}, anomaly)
+	require.Equal(t, []map[string]any{{
+		FieldAnomalyDetectionInfiniteMemoryScaling: []map[string]any{{
+			FieldEnabled: true,
+		}},
+	}}, toAnomalyDetectionMap(anomaly))
+
+	gpu := toGPU(map[string]any{"management_option": "MANAGED"})
+	require.Equal(t, &sdk.WorkloadoptimizationV1GPUSettings{
+		ManagementOption: sdk.WorkloadoptimizationV1ManagementOption("MANAGED"),
+	}, gpu)
+	require.Equal(t, []map[string]any{{"management_option": "MANAGED"}}, toGPUMap(gpu))
+}
+
+func TestHPASettingsRoundTrip(t *testing.T) {
+	input := map[string]any{
+		"management_option": "MANAGED",
+		fieldTakeOwnership:  true,
+		fieldNativeHPASpec: []any{map[string]any{
+			fieldMinReplicas: 2,
+			fieldMaxReplicas: 20,
+			fieldMetrics: []any{
+				map[string]any{
+					FieldLimitStrategyType: hpaMetricSourceResource,
+					fieldResource: []any{map[string]any{
+						"name": "cpu",
+						fieldTarget: []any{map[string]any{
+							FieldLimitStrategyType: hpaMetricTargetUtilization,
+							"value":                "80",
+						}},
+					}},
+				},
+				map[string]any{
+					FieldLimitStrategyType: hpaMetricSourcePods,
+					fieldPods: []any{map[string]any{
+						fieldMetric: []any{map[string]any{
+							"name":        "requests_per_second",
+							fieldSelector: map[string]any{"service": "api"},
+						}},
+						fieldTarget: []any{map[string]any{
+							FieldLimitStrategyType: hpaMetricTargetAverageValue,
+							"value":                "100",
+						}},
+					}},
+				},
+				map[string]any{
+					FieldLimitStrategyType: hpaMetricSourceObject,
+					fieldObject: []any{map[string]any{
+						fieldMetric: []any{map[string]any{
+							"name":        "queue_depth",
+							fieldSelector: map[string]any{},
+						}},
+						fieldDescribedObject: []any{map[string]any{
+							"kind":          "Service",
+							"name":          "worker",
+							fieldAPIVersion: "v1",
+						}},
+						fieldTarget: []any{map[string]any{
+							FieldLimitStrategyType: hpaMetricTargetValue,
+							"value":                "10",
+						}},
+					}},
+				},
+				map[string]any{
+					FieldLimitStrategyType: hpaMetricSourceExternal,
+					fieldExternal: []any{map[string]any{
+						fieldMetric: []any{map[string]any{
+							"name":        "external_queue_depth",
+							fieldSelector: map[string]any{},
+						}},
+						fieldTarget: []any{map[string]any{
+							FieldLimitStrategyType: hpaMetricTargetAverageValue,
+							"value":                "5",
+						}},
+					}},
+				},
+				map[string]any{
+					FieldLimitStrategyType: hpaMetricSourceContainerResource,
+					fieldContainerResource: []any{map[string]any{
+						"name":      "memory",
+						"container": "application",
+						fieldTarget: []any{map[string]any{
+							FieldLimitStrategyType: hpaMetricTargetUtilization,
+							"value":                "75",
+						}},
+					}},
+				},
+			},
+			fieldBehavior: []any{map[string]any{
+				fieldScaleUp: []any{map[string]any{
+					fieldStabilizationWindowSeconds: 0,
+					fieldSelectPolicy:               hpaScalingPolicySelectMaxChange,
+					fieldTolerance:                  "0.05",
+					fieldPolicies: []any{map[string]any{
+						FieldLimitStrategyType: hpaScalingPolicyPercent,
+						"value":                100,
+						"period_seconds":       15,
+					}},
+				}},
+				fieldScaleDown: []any{map[string]any{
+					fieldStabilizationWindowSeconds: 300,
+					fieldSelectPolicy:               hpaScalingPolicySelectMinChange,
+					fieldPolicies: []any{map[string]any{
+						FieldLimitStrategyType: hpaScalingPolicyPods,
+						"value":                1,
+						"period_seconds":       60,
+					}},
+				}},
+			}},
+		}},
+	}
+
+	got := toHPASettings(input)
+	require.NotNil(t, got)
+	require.Equal(t, sdk.WorkloadoptimizationV1ManagementOption("MANAGED"), got.ManagementOption)
+	require.True(t, got.TakeOwnership)
+	require.Equal(t, int32(2), got.NativeHpaSpec.MinReplicas)
+	require.Equal(t, int32(20), got.NativeHpaSpec.MaxReplicas)
+	require.Len(t, got.NativeHpaSpec.Metrics, 5)
+	require.Equal(t, "api", got.NativeHpaSpec.Metrics[1].Pods.Metric.Selector["service"])
+	require.Equal(t, "application", got.NativeHpaSpec.Metrics[4].ContainerResource.Container)
+	require.Equal(t, int32(300), *got.NativeHpaSpec.Behavior.ScaleDown.StabilizationWindowSeconds)
+	require.Equal(t, "0.05", *got.NativeHpaSpec.Behavior.ScaleUp.Tolerance)
+
+	roundTripped := toHPASettings(toHPASettingsMap(got)[0])
+	require.Equal(t, got, roundTripped)
+}
+
+func TestHPAConvertersMapping(t *testing.T) {
+	got := toHPAConvertersValue([]any{
+		map[string]any{
+			FieldLimitStrategyType: hpaConverterAverageValueFromOriginalRequests,
+		},
+	})
+
+	require.Equal(t, &[]sdk.WorkloadoptimizationV1HPAConverters{{
+		Type: sdk.WorkloadoptimizationV1HPAConverterType(hpaConverterAverageValueFromOriginalRequests),
+	}}, got)
+	require.Equal(t, []map[string]any{{
+		FieldLimitStrategyType: hpaConverterAverageValueFromOriginalRequests,
+	}}, toHPAConvertersMap(got))
+}
+
+func TestScalingPolicySchemaAcceptsCurrentAPIRanges(t *testing.T) {
+	resource := resourceWorkloadScalingPolicy()
+
+	overheadDiagnostics := resource.Schema["cpu"].Elem.(*schema.Resource).
+		Schema["overhead"].ValidateDiagFunc(2.5, cty.Path{})
+	require.False(t, overheadDiagnostics.HasError())
+
+	limitDiagnostics := resource.Schema["cpu"].Elem.(*schema.Resource).
+		Schema[FieldLimitStrategy].Elem.(*schema.Resource).
+		Schema[FieldLimitStrategyType].ValidateDiagFunc("MAINTAIN_RATIO", cty.Path{})
+	require.False(t, limitDiagnostics.HasError())
+}

--- a/docs/resources/workload_scaling_policy.md
+++ b/docs/resources/workload_scaling_policy.md
@@ -72,6 +72,9 @@ resource "castai_workload_scaling_policy" "services" {
   }
   startup {
     period_seconds = 240
+    two_phase_recommendations {
+      enabled = true
+    }
   }
   downscaling {
     apply_type = "DEFERRED"
@@ -93,6 +96,53 @@ resource "castai_workload_scaling_policy" "services" {
       cpu_stall_threshold_percentage = 50
       min_pressured_pod_percentage   = 30
     }
+    infinite_memory_scaling {
+      enabled = true
+    }
+  }
+  hpa_settings {
+    management_option = "READ_ONLY"
+    take_ownership    = false
+    native_hpa_spec {
+      min_replicas = 2
+      max_replicas = 20
+      metrics {
+        type = "RESOURCE"
+        resource {
+          name = "cpu"
+          target {
+            type  = "UTILIZATION"
+            value = "80"
+          }
+        }
+      }
+      behavior {
+        scale_up {
+          stabilization_window_seconds = 0
+          select_policy                = "MAX_CHANGE_POLICY_SELECT"
+          policies {
+            type           = "PERCENT_SCALING_POLICY"
+            value          = 100
+            period_seconds = 15
+          }
+        }
+        scale_down {
+          stabilization_window_seconds = 300
+          select_policy                = "MAX_CHANGE_POLICY_SELECT"
+          policies {
+            type           = "PERCENT_SCALING_POLICY"
+            value          = 100
+            period_seconds = 15
+          }
+        }
+      }
+    }
+  }
+  hpa_converters {
+    type = "AVERAGE_VALUE_FROM_ORIGINAL_REQUESTS"
+  }
+  gpu {
+    management_option = "READ_ONLY"
   }
   jvm {
     memory {
@@ -127,6 +177,10 @@ resource "castai_workload_scaling_policy" "services" {
 - `confidence` (Block List, Max: 1) Defines the confidence settings for applying recommendations. (see [below for nested schema](#nestedblock--confidence))
 - `downscaling` (Block List, Max: 1) (see [below for nested schema](#nestedblock--downscaling))
 - `excluded_containers` (List of String) Defines containers to be excluded from receiving recommendations. The containers are matched by exact name.
+- `gpu` (Block List, Max: 1) Configures GPU optimization. (see [below for nested schema](#nestedblock--gpu))
+- `hpa_converters` (Block List) Configures conversion of existing HPAs when vertical optimization is used without HPA management. (see [below for nested schema](#nestedblock--hpa_converters))
+- `hpa_settings` (Block List, Max: 1) Configures horizontal pod autoscaling for workloads using this policy. (see [below for nested schema](#nestedblock--hpa_settings))
+- `is_ops_pilot` (Boolean) Marks a policy as managed by OpsPilot.
 - `jvm` (Block List, Max: 1) JVM optimization settings. (see [below for nested schema](#nestedblock--jvm))
 - `memory_event` (Block List, Max: 1) (see [below for nested schema](#nestedblock--memory_event))
 - `predictive_scaling` (Block List, Max: 1) (see [below for nested schema](#nestedblock--predictive_scaling))
@@ -337,6 +391,7 @@ Optional:
 Optional:
 
 - `cpu_pressure` (Block List, Max: 1) Configures CPU pressure anomaly detection thresholds. (see [below for nested schema](#nestedblock--anomaly_detection--cpu_pressure))
+- `infinite_memory_scaling` (Block List, Max: 1) Configures infinite memory scaling anomaly detection. (see [below for nested schema](#nestedblock--anomaly_detection--infinite_memory_scaling))
 
 <a id="nestedblock--anomaly_detection--cpu_pressure"></a>
 ### Nested Schema for `anomaly_detection.cpu_pressure`
@@ -345,6 +400,14 @@ Required:
 
 - `cpu_stall_threshold_percentage` (Number) Percentage of time (0-100) that a pod must experience CPU pressure to be considered under pressure.
 - `min_pressured_pod_percentage` (Number) Percentage (0-100) of pods that must be experiencing pressure for the detector to trigger.
+
+
+<a id="nestedblock--anomaly_detection--infinite_memory_scaling"></a>
+### Nested Schema for `anomaly_detection.infinite_memory_scaling`
+
+Required:
+
+- `enabled` (Boolean) Enables infinite memory scaling detection for workloads using this policy.
 
 
 
@@ -440,6 +503,251 @@ Optional:
 	- DEFERRED - pods are not restarted and recommendation values are applied during natural restarts only (new deployment, etc.)
 
 
+<a id="nestedblock--gpu"></a>
+### Nested Schema for `gpu`
+
+Required:
+
+- `management_option` (String) Defines whether CAST AI observes or manages the feature.
+
+
+<a id="nestedblock--hpa_converters"></a>
+### Nested Schema for `hpa_converters`
+
+Required:
+
+- `type` (String) HPA converter strategy.
+
+
+<a id="nestedblock--hpa_settings"></a>
+### Nested Schema for `hpa_settings`
+
+Required:
+
+- `management_option` (String) Defines whether CAST AI observes or manages the feature.
+- `native_hpa_spec` (Block List, Min: 1, Max: 1) Native Kubernetes HPA specification. (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec))
+- `take_ownership` (Boolean) Allows CAST AI to take ownership of eligible existing HPAs.
+
+<a id="nestedblock--hpa_settings--native_hpa_spec"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec`
+
+Required:
+
+- `max_replicas` (Number) Maximum number of replicas.
+- `metrics` (Block List, Min: 1) Metrics used by the HPA. (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--metrics))
+- `min_replicas` (Number) Minimum number of replicas.
+
+Optional:
+
+- `behavior` (Block List, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--behavior))
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--metrics"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.metrics`
+
+Required:
+
+- `type` (String)
+
+Optional:
+
+- `container_resource` (Block List, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--metrics--container_resource))
+- `external` (Block List, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--metrics--external))
+- `object` (Block List, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--metrics--object))
+- `pods` (Block List, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--metrics--pods))
+- `resource` (Block List, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--metrics--resource))
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--metrics--container_resource"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.metrics.container_resource`
+
+Required:
+
+- `container` (String)
+- `name` (String)
+- `target` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--metrics--container_resource--target))
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--metrics--container_resource--target"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.metrics.container_resource.target`
+
+Required:
+
+- `type` (String)
+- `value` (String)
+
+
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--metrics--external"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.metrics.external`
+
+Required:
+
+- `metric` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--metrics--external--metric))
+- `target` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--metrics--external--target))
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--metrics--external--metric"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.metrics.external.metric`
+
+Required:
+
+- `name` (String)
+
+Optional:
+
+- `selector` (Map of String) Metric label selector.
+
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--metrics--external--target"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.metrics.external.target`
+
+Required:
+
+- `type` (String)
+- `value` (String)
+
+
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--metrics--object"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.metrics.object`
+
+Required:
+
+- `described_object` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--metrics--object--described_object))
+- `metric` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--metrics--object--metric))
+- `target` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--metrics--object--target))
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--metrics--object--described_object"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.metrics.object.described_object`
+
+Optional:
+
+- `api_version` (String)
+- `kind` (String)
+- `name` (String)
+
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--metrics--object--metric"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.metrics.object.metric`
+
+Required:
+
+- `name` (String)
+
+Optional:
+
+- `selector` (Map of String) Metric label selector.
+
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--metrics--object--target"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.metrics.object.target`
+
+Required:
+
+- `type` (String)
+- `value` (String)
+
+
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--metrics--pods"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.metrics.pods`
+
+Required:
+
+- `metric` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--metrics--pods--metric))
+- `target` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--metrics--pods--target))
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--metrics--pods--metric"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.metrics.pods.metric`
+
+Required:
+
+- `name` (String)
+
+Optional:
+
+- `selector` (Map of String) Metric label selector.
+
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--metrics--pods--target"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.metrics.pods.target`
+
+Required:
+
+- `type` (String)
+- `value` (String)
+
+
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--metrics--resource"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.metrics.resource`
+
+Required:
+
+- `name` (String)
+- `target` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--metrics--resource--target))
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--metrics--resource--target"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.metrics.resource.target`
+
+Required:
+
+- `type` (String)
+- `value` (String)
+
+
+
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--behavior"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.behavior`
+
+Optional:
+
+- `scale_down` (Block List, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--behavior--scale_down))
+- `scale_up` (Block List, Max: 1) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--behavior--scale_up))
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--behavior--scale_down"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.behavior.scale_down`
+
+Optional:
+
+- `policies` (Block List) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--behavior--scale_down--policies))
+- `select_policy` (String)
+- `stabilization_window_seconds` (Number)
+- `tolerance` (String)
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--behavior--scale_down--policies"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.behavior.scale_down.policies`
+
+Required:
+
+- `period_seconds` (Number)
+- `type` (String)
+- `value` (Number)
+
+
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--behavior--scale_up"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.behavior.scale_up`
+
+Optional:
+
+- `policies` (Block List) (see [below for nested schema](#nestedblock--hpa_settings--native_hpa_spec--behavior--scale_up--policies))
+- `select_policy` (String)
+- `stabilization_window_seconds` (Number)
+- `tolerance` (String)
+
+<a id="nestedblock--hpa_settings--native_hpa_spec--behavior--scale_up--policies"></a>
+### Nested Schema for `hpa_settings.native_hpa_spec.behavior.scale_up.policies`
+
+Required:
+
+- `period_seconds` (Number)
+- `type` (String)
+- `value` (Number)
+
+
+
+
+
+
 <a id="nestedblock--jvm"></a>
 ### Nested Schema for `jvm`
 
@@ -503,6 +811,28 @@ Optional:
 - `period_seconds` (Number) Defines the duration (in seconds) during which elevated resource usage is expected at startup.
 When set, recommendations will be adjusted to disregard resource spikes within this period.
 If not specified, the workload will receive standard recommendations without startup considerations.
+- `two_phase_recommendations` (Block List, Max: 1) Configures startup recommendations that use original requests during startup and optimized recommendations afterwards. (see [below for nested schema](#nestedblock--startup--two_phase_recommendations))
+
+<a id="nestedblock--startup--two_phase_recommendations"></a>
+### Nested Schema for `startup.two_phase_recommendations`
+
+Required:
+
+- `enabled` (Boolean) Enables two-phase startup recommendations.
+
+Optional:
+
+- `requests_on_startup` (Block List, Max: 1) Overrides the requests used during the startup phase. (see [below for nested schema](#nestedblock--startup--two_phase_recommendations--requests_on_startup))
+
+<a id="nestedblock--startup--two_phase_recommendations--requests_on_startup"></a>
+### Nested Schema for `startup.two_phase_recommendations.requests_on_startup`
+
+Optional:
+
+- `cpu_cores` (Number) CPU request in cores used during startup.
+- `memory_gib` (Number) Memory request in GiB used during startup.
+
+
 
 
 <a id="nestedblock--timeouts"></a>

--- a/examples/resources/castai_workload_scaling_policy/resource.tf
+++ b/examples/resources/castai_workload_scaling_policy/resource.tf
@@ -55,6 +55,9 @@ resource "castai_workload_scaling_policy" "services" {
   }
   startup {
     period_seconds = 240
+    two_phase_recommendations {
+      enabled = true
+    }
   }
   downscaling {
     apply_type = "DEFERRED"
@@ -76,6 +79,53 @@ resource "castai_workload_scaling_policy" "services" {
       cpu_stall_threshold_percentage = 50
       min_pressured_pod_percentage   = 30
     }
+    infinite_memory_scaling {
+      enabled = true
+    }
+  }
+  hpa_settings {
+    management_option = "READ_ONLY"
+    take_ownership    = false
+    native_hpa_spec {
+      min_replicas = 2
+      max_replicas = 20
+      metrics {
+        type = "RESOURCE"
+        resource {
+          name = "cpu"
+          target {
+            type  = "UTILIZATION"
+            value = "80"
+          }
+        }
+      }
+      behavior {
+        scale_up {
+          stabilization_window_seconds = 0
+          select_policy                = "MAX_CHANGE_POLICY_SELECT"
+          policies {
+            type           = "PERCENT_SCALING_POLICY"
+            value          = 100
+            period_seconds = 15
+          }
+        }
+        scale_down {
+          stabilization_window_seconds = 300
+          select_policy                = "MAX_CHANGE_POLICY_SELECT"
+          policies {
+            type           = "PERCENT_SCALING_POLICY"
+            value          = 100
+            period_seconds = 15
+          }
+        }
+      }
+    }
+  }
+  hpa_converters {
+    type = "AVERAGE_VALUE_FROM_ORIGINAL_REQUESTS"
+  }
+  gpu {
+    management_option = "READ_ONLY"
   }
   jvm {
     memory {


### PR DESCRIPTION
## Summary

- expose native HPA settings and take_ownership on castai_workload_scaling_policy
- support replica bounds, CPU and memory resource-utilization metrics, and scale-up/scale-down behavior
- preserve explicit false, zero, and empty-policy values through create, read, and update mappings
- fail refresh rather than silently dropping unsupported native HPA metric sources

## Validation

- focused schema, validation, round-trip, create, and read coverage
- complete non-E2E Go test suite
- golangci-lint
- Terraform formatting and generated documentation