### PR TITLE
feat: support storage optimization in node templates

### DIFF
--- a/castai/resource_node_template.go
+++ b/castai/resource_node_template.go
@@ -58,6 +58,7 @@ const (
 	FieldNodeTemplateRebalancingConfigMinNodes                = "rebalancing_config_min_nodes"
 	FieldNodeTemplateShouldTaint                              = "should_taint"
 	FieldNodeTemplateSpot                                     = "spot"
+	FieldNodeTemplateStopEnabled                              = "stop_enabled"
 	FieldNodeTemplateSpotDiversityPriceIncreaseLimitPercent   = "spot_diversity_price_increase_limit_percent"
 	FieldNodeTemplateSpotReliabilityEnabled                   = "spot_reliability_enabled"
 	FieldNodeTemplateSpotReliabilityPriceIncreaseLimitPercent = "spot_reliability_price_increase_limit_percent"
@@ -221,6 +222,12 @@ func resourceNodeTemplate() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Marks whether the templated nodes will have a taint.",
+			},
+			FieldNodeTemplateStopEnabled: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Marks whether Storage Optimization (STOP) should be enabled for nodes created from this template.",
 			},
 			FieldNodeTemplateConstraints: {
 				Type:     schema.TypeList,
@@ -910,6 +917,9 @@ func resourceNodeTemplateRead(ctx context.Context, d *schema.ResourceData, meta 
 	if err := d.Set(FieldNodeTemplateShouldTaint, nodeTemplate.ShouldTaint); err != nil {
 		return diag.FromErr(fmt.Errorf("setting should taint: %w", err))
 	}
+	if err := d.Set(FieldNodeTemplateStopEnabled, nodeTemplate.StopEnabled); err != nil {
+		return diag.FromErr(fmt.Errorf("setting stop enabled: %w", err))
+	}
 	if nodeTemplate.RebalancingConfig != nil {
 		if err := d.Set(FieldNodeTemplateRebalancingConfigMinNodes, nodeTemplate.RebalancingConfig.MinNodes); err != nil {
 			return diag.FromErr(fmt.Errorf("setting configuration id: %w", err))
@@ -1323,6 +1333,7 @@ func updateNodeTemplate(ctx context.Context, d *schema.ResourceData, meta any, s
 	if !skipChangeCheck && !d.HasChanges(
 		FieldNodeTemplateName,
 		FieldNodeTemplateShouldTaint,
+		FieldNodeTemplateStopEnabled,
 		FieldNodeTemplateConfigurationId,
 		FieldNodeTemplateRebalancingConfigMinNodes,
 		FieldNodeTemplateCustomLabels,
@@ -1381,6 +1392,10 @@ func updateNodeTemplate(ctx context.Context, d *schema.ResourceData, meta any, s
 
 	if v, _ := d.GetOk(FieldNodeTemplateShouldTaint); v != nil {
 		req.ShouldTaint = toPtr(v.(bool))
+	}
+
+	if v, _ := d.GetOk(FieldNodeTemplateStopEnabled); v != nil {
+		req.StopEnabled = lo.ToPtr(v.(bool))
 	}
 
 	if v, ok := d.Get(FieldNodeTemplateCustomTaints).([]any); ok && len(v) > 0 {
@@ -1461,6 +1476,7 @@ func resourceNodeTemplateCreate(ctx context.Context, d *schema.ResourceData, met
 		ConfigurationId: lo.ToPtr(d.Get(FieldNodeTemplateConfigurationId).(string)),
 		ShouldTaint:     lo.ToPtr(d.Get(FieldNodeTemplateShouldTaint).(bool)),
 		ClmEnabled:      lo.ToPtr(d.Get(FieldNodeTemplateClmEnabled).(bool)),
+		StopEnabled:     lo.ToPtr(d.Get(FieldNodeTemplateStopEnabled).(bool)),
 	}
 
 	if v, ok := d.Get(FieldNodeTemplateEdgeLocationIDs).([]any); ok && len(v) > 0 {

--- a/castai/resource_node_template.go
+++ b/castai/resource_node_template.go
@@ -58,6 +58,7 @@ const (
 	FieldNodeTemplateRebalancingConfigMinNodes                = "rebalancing_config_min_nodes"
 	FieldNodeTemplateShouldTaint                              = "should_taint"
 	FieldNodeTemplateSpot                                     = "spot"
+	FieldNodeTemplateStopEnabled                              = "stop_enabled"
 	FieldNodeTemplateSpotDiversityPriceIncreaseLimitPercent   = "spot_diversity_price_increase_limit_percent"
 	FieldNodeTemplateSpotReliabilityEnabled                   = "spot_reliability_enabled"
 	FieldNodeTemplateSpotReliabilityPriceIncreaseLimitPercent = "spot_reliability_price_increase_limit_percent"
@@ -248,6 +249,12 @@ func resourceNodeTemplate() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Marks whether the templated nodes will have a taint.",
+			},
+			FieldNodeTemplateStopEnabled: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Marks whether Storage Optimization (STOP) should be enabled for nodes created from this template.",
 			},
 			FieldNodeTemplateConstraints: {
 				Type:     schema.TypeList,
@@ -955,6 +962,9 @@ func resourceNodeTemplateRead(ctx context.Context, d *schema.ResourceData, meta 
 	if err := d.Set(FieldNodeTemplateShouldTaint, nodeTemplate.ShouldTaint); err != nil {
 		return diag.FromErr(fmt.Errorf("setting should taint: %w", err))
 	}
+	if err := d.Set(FieldNodeTemplateStopEnabled, nodeTemplate.StopEnabled); err != nil {
+		return diag.FromErr(fmt.Errorf("setting stop enabled: %w", err))
+	}
 	if nodeTemplate.RebalancingConfig != nil {
 		if err := d.Set(FieldNodeTemplateRebalancingConfigMinNodes, nodeTemplate.RebalancingConfig.MinNodes); err != nil {
 			return diag.FromErr(fmt.Errorf("setting configuration id: %w", err))
@@ -1386,6 +1396,7 @@ func updateNodeTemplate(ctx context.Context, d *schema.ResourceData, meta any, s
 	if !skipChangeCheck && !d.HasChanges(
 		FieldNodeTemplateName,
 		FieldNodeTemplateShouldTaint,
+		FieldNodeTemplateStopEnabled,
 		FieldNodeTemplateConfigurationId,
 		FieldNodeTemplateRebalancingConfigMinNodes,
 		FieldNodeTemplateCustomLabels,
@@ -1444,6 +1455,10 @@ func updateNodeTemplate(ctx context.Context, d *schema.ResourceData, meta any, s
 
 	if v, _ := d.GetOk(FieldNodeTemplateShouldTaint); v != nil {
 		req.ShouldTaint = toPtr(v.(bool))
+	}
+
+	if v, _ := d.GetOk(FieldNodeTemplateStopEnabled); v != nil {
+		req.StopEnabled = lo.ToPtr(v.(bool))
 	}
 
 	if v, ok := d.Get(FieldNodeTemplateCustomTaints).([]any); ok && len(v) > 0 {
@@ -1524,6 +1539,7 @@ func resourceNodeTemplateCreate(ctx context.Context, d *schema.ResourceData, met
 		ConfigurationId: lo.ToPtr(d.Get(FieldNodeTemplateConfigurationId).(string)),
 		ShouldTaint:     lo.ToPtr(d.Get(FieldNodeTemplateShouldTaint).(bool)),
 		ClmEnabled:      lo.ToPtr(d.Get(FieldNodeTemplateClmEnabled).(bool)),
+		StopEnabled:     lo.ToPtr(d.Get(FieldNodeTemplateStopEnabled).(bool)),
 	}
 
 	if v, ok := d.Get(FieldNodeTemplateEdgeLocationIDs).([]any); ok && len(v) > 0 {

--- a/castai/resource_node_template_test.go
+++ b/castai/resource_node_template_test.go
@@ -47,6 +47,7 @@ func TestNodeTemplateResourceReadContext(t *testing.T) {
 				"configurationId": "7dc4f922-29c9-4377-889c-0c8c5fb8d497",
 				"configurationName": "default",
 				"isEnabled": true,
+				"stopEnabled": true,
 			   "gpu": {
 				 "enableTimeSharing": true,
 				 "defaultSharedClientsPerGpu": 10,
@@ -282,6 +283,7 @@ rebalancing_config_min_nodes = 0
 should_taint = true
 Tainted = false
 clm_enabled = false
+stop_enabled = true
 edge_location_ids.# = 2
 edge_location_ids.0 = a1b2c3d4-e5f6-7890-abcd-ef1234567890
 edge_location_ids.1 = b2c3d4e5-f6a7-8901-bcde-f12345678901
@@ -588,6 +590,7 @@ func TestNodeTemplateResourceCreate_defaultNodeTemplate(t *testing.T) {
 				"isEnabled": true,
 				"isDefault": true,
 				"clmEnabled": false,
+				"stopEnabled": false,
 				"constraints": {
 				  "spot": false,
 				  "onDemand": true,
@@ -619,6 +622,10 @@ func TestNodeTemplateResourceCreate_defaultNodeTemplate(t *testing.T) {
 
 	mockClient.EXPECT().
 		NodeTemplatesAPIUpdateNodeTemplate(gomock.Any(), clusterId, "default-by-castai", gomock.Any()).
+		Do(func(_ context.Context, _, _ string, body sdk.NodeTemplatesAPIUpdateNodeTemplateJSONRequestBody) {
+			r.NotNil(body.StopEnabled)
+			r.False(*body.StopEnabled)
+		}).
 		Return(&http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader([]byte{}))}, nil)
 
 	resource := resourceNodeTemplate()
@@ -629,6 +636,7 @@ func TestNodeTemplateResourceCreate_defaultNodeTemplate(t *testing.T) {
 		FieldNodeTemplateCustomInstancesEnabled:                   cty.BoolVal(true),
 		FieldNodeTemplateCustomInstancesWithExtendedMemoryEnabled: cty.BoolVal(true),
 		FieldNodeTemplateClmEnabled:                               cty.BoolVal(false),
+		FieldNodeTemplateStopEnabled:                              cty.BoolVal(false),
 	})
 	state := sdkterraform.NewInstanceStateShimmedFromValue(val, 0)
 	state.ID = "default-by-castai"
@@ -660,6 +668,7 @@ func TestNodeTemplateResourceCreate_customNodeTemplate(t *testing.T) {
 		  "name": "custom-template",
 		  "isEnabled": false,
 		  "clmEnabled": true,
+		  "stopEnabled": true,
 		  "constraints": {
 		    "spot": false,
 		    "onDemand": true,
@@ -699,6 +708,10 @@ func TestNodeTemplateResourceCreate_customNodeTemplate(t *testing.T) {
 		Return(&http.Response{StatusCode: 200, Body: listBody, Header: map[string][]string{"Content-Type": {"json"}}}, nil)
 	mockClient.EXPECT().
 		NodeTemplatesAPICreateNodeTemplate(gomock.Any(), clusterId, gomock.Any()).
+		Do(func(_ context.Context, _ string, body sdk.NodeTemplatesAPICreateNodeTemplateJSONRequestBody) {
+			r.NotNil(body.StopEnabled)
+			r.True(*body.StopEnabled)
+		}).
 		Return(&http.Response{StatusCode: 200, Body: templateBody, Header: map[string][]string{"Content-Type": {"json"}}}, nil)
 
 	resource := resourceNodeTemplate()
@@ -710,6 +723,7 @@ func TestNodeTemplateResourceCreate_customNodeTemplate(t *testing.T) {
 		FieldNodeTemplateCustomInstancesEnabled:                   cty.BoolVal(true),
 		FieldNodeTemplateCustomInstancesWithExtendedMemoryEnabled: cty.BoolVal(true),
 		FieldNodeTemplateClmEnabled:                               cty.BoolVal(true),
+		FieldNodeTemplateStopEnabled:                              cty.BoolVal(true),
 	})
 	state := sdkterraform.NewInstanceStateShimmedFromValue(val, 0)
 	state.ID = name
@@ -808,6 +822,7 @@ func TestAccEKS_ResourceNodeTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "should_taint", "true"),
 					resource.TestCheckResourceAttr(resourceName, "clm_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "stop_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "custom_instances_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "custom_instances_with_extended_memory_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "custom_labels.%", "2"),
@@ -895,6 +910,7 @@ func TestAccEKS_ResourceNodeTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "should_taint", "true"),
 					resource.TestCheckResourceAttr(resourceName, "clm_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "stop_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "custom_instances_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "custom_instances_with_extended_memory_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "custom_labels.%", "2"),
@@ -987,6 +1003,7 @@ func testAccNodeTemplateConfig(rName, clusterName string) string {
 			configuration_id = castai_node_configuration.test.id
 			should_taint = true
 			clm_enabled = false
+			stop_enabled = true
 
 			custom_labels = {
 				%[1]s-label-key-1 = "%[1]s-label-value-1"
@@ -1160,6 +1177,7 @@ func testNodeTemplateUpdated(rName, clusterName string) string {
 			configuration_id = castai_node_configuration.test.id
 			should_taint = true
 			clm_enabled = true
+			stop_enabled = false
 			
 			custom_labels = {
 				%[1]s-label-key-1 = "%[1]s-label-value-1"

--- a/castai/resource_node_template_test.go
+++ b/castai/resource_node_template_test.go
@@ -47,6 +47,7 @@ func TestNodeTemplateResourceReadContext(t *testing.T) {
 				"configurationId": "7dc4f922-29c9-4377-889c-0c8c5fb8d497",
 				"configurationName": "default",
 				"isEnabled": true,
+				"stopEnabled": true,
 			   "gpu": {
 				 "enableTimeSharing": true,
 				 "defaultSharedClientsPerGpu": 10,
@@ -275,6 +276,7 @@ rebalancing_config_min_nodes = 0
 should_taint = true
 Tainted = false
 clm_enabled = false
+stop_enabled = true
 edge_location_ids.# = 2
 edge_location_ids.0 = a1b2c3d4-e5f6-7890-abcd-ef1234567890
 edge_location_ids.1 = b2c3d4e5-f6a7-8901-bcde-f12345678901
@@ -581,6 +583,7 @@ func TestNodeTemplateResourceCreate_defaultNodeTemplate(t *testing.T) {
 				"isEnabled": true,
 				"isDefault": true,
 				"clmEnabled": false,
+				"stopEnabled": false,
 				"constraints": {
 				  "spot": false,
 				  "onDemand": true,
@@ -612,6 +615,10 @@ func TestNodeTemplateResourceCreate_defaultNodeTemplate(t *testing.T) {
 
 	mockClient.EXPECT().
 		NodeTemplatesAPIUpdateNodeTemplate(gomock.Any(), clusterId, "default-by-castai", gomock.Any()).
+		Do(func(_ context.Context, _, _ string, body sdk.NodeTemplatesAPIUpdateNodeTemplateJSONRequestBody) {
+			r.NotNil(body.StopEnabled)
+			r.False(*body.StopEnabled)
+		}).
 		Return(&http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader([]byte{}))}, nil)
 
 	resource := resourceNodeTemplate()
@@ -622,6 +629,7 @@ func TestNodeTemplateResourceCreate_defaultNodeTemplate(t *testing.T) {
 		FieldNodeTemplateCustomInstancesEnabled:                   cty.BoolVal(true),
 		FieldNodeTemplateCustomInstancesWithExtendedMemoryEnabled: cty.BoolVal(true),
 		FieldNodeTemplateClmEnabled:                               cty.BoolVal(false),
+		FieldNodeTemplateStopEnabled:                              cty.BoolVal(false),
 	})
 	state := sdkterraform.NewInstanceStateShimmedFromValue(val, 0)
 	state.ID = "default-by-castai"
@@ -653,6 +661,7 @@ func TestNodeTemplateResourceCreate_customNodeTemplate(t *testing.T) {
 		  "name": "custom-template",
 		  "isEnabled": false,
 		  "clmEnabled": true,
+		  "stopEnabled": true,
 		  "constraints": {
 		    "spot": false,
 		    "onDemand": true,
@@ -692,6 +701,10 @@ func TestNodeTemplateResourceCreate_customNodeTemplate(t *testing.T) {
 		Return(&http.Response{StatusCode: 200, Body: listBody, Header: map[string][]string{"Content-Type": {"json"}}}, nil)
 	mockClient.EXPECT().
 		NodeTemplatesAPICreateNodeTemplate(gomock.Any(), clusterId, gomock.Any()).
+		Do(func(_ context.Context, _ string, body sdk.NodeTemplatesAPICreateNodeTemplateJSONRequestBody) {
+			r.NotNil(body.StopEnabled)
+			r.True(*body.StopEnabled)
+		}).
 		Return(&http.Response{StatusCode: 200, Body: templateBody, Header: map[string][]string{"Content-Type": {"json"}}}, nil)
 
 	resource := resourceNodeTemplate()
@@ -703,6 +716,7 @@ func TestNodeTemplateResourceCreate_customNodeTemplate(t *testing.T) {
 		FieldNodeTemplateCustomInstancesEnabled:                   cty.BoolVal(true),
 		FieldNodeTemplateCustomInstancesWithExtendedMemoryEnabled: cty.BoolVal(true),
 		FieldNodeTemplateClmEnabled:                               cty.BoolVal(true),
+		FieldNodeTemplateStopEnabled:                              cty.BoolVal(true),
 	})
 	state := sdkterraform.NewInstanceStateShimmedFromValue(val, 0)
 	state.ID = name
@@ -801,6 +815,7 @@ func TestAccEKS_ResourceNodeTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "should_taint", "true"),
 					resource.TestCheckResourceAttr(resourceName, "clm_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "stop_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "custom_instances_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "custom_instances_with_extended_memory_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "custom_labels.%", "2"),
@@ -888,6 +903,7 @@ func TestAccEKS_ResourceNodeTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "should_taint", "true"),
 					resource.TestCheckResourceAttr(resourceName, "clm_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "stop_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "custom_instances_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "custom_instances_with_extended_memory_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "custom_labels.%", "2"),
@@ -980,6 +996,7 @@ func testAccNodeTemplateConfig(rName, clusterName string) string {
 			configuration_id = castai_node_configuration.test.id
 			should_taint = true
 			clm_enabled = false
+			stop_enabled = true
 
 			custom_labels = {
 				%[1]s-label-key-1 = "%[1]s-label-value-1"
@@ -1153,6 +1170,7 @@ func testNodeTemplateUpdated(rName, clusterName string) string {
 			configuration_id = castai_node_configuration.test.id
 			should_taint = true
 			clm_enabled = true
+			stop_enabled = false
 			
 			custom_labels = {
 				%[1]s-label-key-1 = "%[1]s-label-value-1"

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -21,6 +21,7 @@ resource "castai_node_template" "default_by_castai" {
   is_enabled       = true
   configuration_id = castai_node_configuration.default.id
   should_taint     = true
+  stop_enabled     = true
 
   custom_labels = {
     env = "production"
@@ -91,6 +92,7 @@ resource "castai_node_template" "default_by_castai" {
 - `price_adjustment_configuration` (Block List, Max: 1) Configuration for adjusting instance type prices during autoscaling. Adjustments only affect placement decisions, not cost reporting. (see [below for nested schema](#nestedblock--price_adjustment_configuration))
 - `rebalancing_config_min_nodes` (Number) Minimum nodes that will be kept when rebalancing nodes using this node template.
 - `should_taint` (Boolean) Marks whether the templated nodes will have a taint.
+- `stop_enabled` (Boolean) Marks whether Storage Optimization (STOP) should be enabled for nodes created from this template.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/examples/resources/castai_node_template/resource.tf
+++ b/examples/resources/castai_node_template/resource.tf
@@ -6,6 +6,7 @@ resource "castai_node_template" "default_by_castai" {
   is_enabled       = true
   configuration_id = castai_node_configuration.default.id
   should_taint     = true
+  stop_enabled     = true
 
   custom_labels = {
     env = "production"


### PR DESCRIPTION
## Summary

- expose `stop_enabled` on `castai_node_template`
- map the setting through create, update, read, import/state refresh, and explicit `true` to `false` updates
- update focused unit/acceptance coverage, the resource example, and generated documentation
- refresh generated SDK types from the current public CAST AI OpenAPI specification, as required by the repository's SDK generation check

## Motivation

Terraform users should be able to declaratively manage the node-template Storage Optimization option already exposed by the public CAST AI API as `stopEnabled`.

## Validation

- full non-E2E Go test suite
- focused node-template create/update/read unit tests
- golangci-lint
- Terraform formatting check
- SDK regeneration (idempotent)
- documentation regeneration (idempotent)

The existing EKS node-template acceptance flow now covers create, import/read, and an explicit `true` to `false` update. It was not run locally because it requires live acceptance-test infrastructure.

Duplicate searches for Storage Optimization, `stopEnabled`, and `stop_enabled` found no existing issue or pull request.
