### PR TITLE
docs: explain configuring the automatic and semi-automatic modes in TF

### DIFF
--- a/castai/resource_workload_scaling_policy.go
+++ b/castai/resource_workload_scaling_policy.go
@@ -589,14 +589,24 @@ func workloadScalingPolicyResourceLimitSchema() *schema.Resource {
 				ValidateDiagFunc: validation.ToDiagFunc(validation.FloatAtLeast(minResourceMultiplierValue)),
 			},
 			FieldLimitStrategyOnlyIfOriginalExist: {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Apply the strategy only when the original resource has limits defined.",
+				Type:     schema.TypeBool,
+				Optional: true,
+				Description: `When set to true, limits will only be set if the workload originally had limits defined in its manifest. 
+	If the original workload has no limits specified, no limits will be added.
+	
+	This flag allows conditional limit management based on the original workload configuration.
+	
+	Only applicable when the type is set to multiplier.`,
 			},
 			FieldLimitStrategyOnlyIfOriginalLower: {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Use the original resource limits if they are higher than recommended values.",
+				Type:     schema.TypeBool,
+				Optional: true,
+				Description: `When set to true, limits will only be updated if the original limits are lower than the calculated value (requests × multiplier). 
+	If the original limits are already higher than the calculated value, they remain unchanged.
+	
+	This flag prevents reducing existing limits and ensures limits only increase when beneficial.
+	
+	Only applicable when the type is set to multiplier.`,
 			},
 		},
 	}

--- a/docs/resources/workload_scaling_policy.md
+++ b/docs/resources/workload_scaling_policy.md
@@ -536,14 +536,14 @@ cpu {
 
   limit {
     type                   = "MULTIPLIER"
-    multiplier             = 1.5
+    multiplier             = 100
     only_if_original_exist = true
     only_if_original_lower = true
   }
 }
 ```
 
-This configuration updates an existing CPU limit only when it is lower than `1.5` times the recommended request. Workloads without an existing CPU limit are left unchanged.
+This configuration updates an existing CPU limit only when it is lower than `100` times the recommended request. Workloads without an existing CPU limit are left unchanged.
 
 ### Memory: Automatic
 

--- a/docs/resources/workload_scaling_policy.md
+++ b/docs/resources/workload_scaling_policy.md
@@ -495,6 +495,73 @@ Optional:
 - `read` (String)
 - `update` (String)
 
+## Resource limit mapping
+
+The CAST AI console exposes simplified options such as **Automatic** and **Semi-automatic**. Terraform does not provide these labels directly. Instead, the same behavior is configured by explicitly setting the `limit` block or omitting it.
+
+Use the Terraform attributes `only_if_original_exist` and `only_if_original_lower` inside the `limit` block when configuring conditional limit updates.
+
+### CPU: Semi-automatic
+
+To configure **CPU: Semi-automatic**, define an explicit multiplier and enable both conditional flags:
+
+```terraform
+cpu {
+  function                 = "QUANTILE"
+  args                     = ["0.9"]
+  look_back_period_seconds = 86400
+  min                      = 0.1
+  max                      = 6
+  overhead                 = 0.1
+
+  limit {
+    type                   = "MULTIPLIER"
+    multiplier             = 1.5
+    only_if_original_exist = true
+    only_if_original_lower = true
+  }
+}
+```
+
+This configuration updates an existing CPU limit only when it is lower than `1.5` times the recommended request. Workloads without an existing CPU limit are left unchanged.
+
+### Memory: Automatic
+
+To configure **Memory: Automatic**, you can either:
+
+- Omit the `memory.limit` block:
+ 
+   ```terraform
+   memory {
+     function                 = "MAX"
+     look_back_period_seconds = 86400
+     min                      = 1024
+     max                      = 15360
+     overhead                 = 0.1
+   }
+   ```
+
+- Or configure it explicitly using the default multiplier and conditional flags:
+
+   ```terraform
+   memory {
+     function                 = "MAX"
+     look_back_period_seconds = 86400
+     min                      = 1024
+     max                      = 15360
+     overhead                 = 0.1
+   
+     limit {
+       type                   = "MULTIPLIER"
+       multiplier             = 1.5
+       only_if_original_exist = true
+       only_if_original_lower = true
+     }
+   }
+   ```
+
+Both configurations result in the same **Automatic** behavior shown in the CAST AI console. The second form makes the underlying behavior explicit: update an existing memory limit only when it is lower than `1.5` times the recommended request, while leaving workloads without an existing memory limit unchanged.
+
 ## Importing
 
 For each connected cluster, a default scaling policy is created. An existing scaling policy can be imported into the

--- a/docs/resources/workload_scaling_policy.md
+++ b/docs/resources/workload_scaling_policy.md
@@ -222,8 +222,18 @@ Required:
 Optional:
 
 - `multiplier` (Number) Multiplier used to calculate the resource limit. It must be defined for the MULTIPLIER strategy.
-- `only_if_original_exist` (Boolean) Apply the strategy only when the original resource has limits defined.
-- `only_if_original_lower` (Boolean) Use the original resource limits if they are higher than recommended values.
+- `only_if_original_exist` (Boolean) When set to true, limits will only be set if the workload originally had limits defined in its manifest. 
+	If the original workload has no limits specified, no limits will be added.
+	
+	This flag allows conditional limit management based on the original workload configuration.
+	
+	Only applicable when the type is set to multiplier.
+- `only_if_original_lower` (Boolean) When set to true, limits will only be updated if the original limits are lower than the calculated value (requests × multiplier). 
+	If the original limits are already higher than the calculated value, they remain unchanged.
+	
+	This flag prevents reducing existing limits and ensures limits only increase when beneficial.
+	
+	Only applicable when the type is set to multiplier.
 
 
 
@@ -306,8 +316,18 @@ Required:
 Optional:
 
 - `multiplier` (Number) Multiplier used to calculate the resource limit. It must be defined for the MULTIPLIER strategy.
-- `only_if_original_exist` (Boolean) Apply the strategy only when the original resource has limits defined.
-- `only_if_original_lower` (Boolean) Use the original resource limits if they are higher than recommended values.
+- `only_if_original_exist` (Boolean) When set to true, limits will only be set if the workload originally had limits defined in its manifest. 
+	If the original workload has no limits specified, no limits will be added.
+	
+	This flag allows conditional limit management based on the original workload configuration.
+	
+	Only applicable when the type is set to multiplier.
+- `only_if_original_lower` (Boolean) When set to true, limits will only be updated if the original limits are lower than the calculated value (requests × multiplier). 
+	If the original limits are already higher than the calculated value, they remain unchanged.
+	
+	This flag prevents reducing existing limits and ensures limits only increase when beneficial.
+	
+	Only applicable when the type is set to multiplier.
 
 
 

--- a/templates/resources/workload_scaling_policy.md.tmpl
+++ b/templates/resources/workload_scaling_policy.md.tmpl
@@ -18,6 +18,73 @@ simultaneously or create custom policies with different settings and apply them 
 
 {{ .SchemaMarkdown | trimspace }}
 
+## Resource limit mapping
+
+The CAST AI console exposes simplified options such as **Automatic** and **Semi-automatic**. Terraform does not provide these labels directly. Instead, the same behavior is configured by explicitly setting the `limit` block or omitting it.
+
+Use the Terraform attributes `only_if_original_exist` and `only_if_original_lower` inside the `limit` block when configuring conditional limit updates.
+
+### CPU: Semi-automatic
+
+To configure **CPU: Semi-automatic**, define an explicit multiplier and enable both conditional flags:
+
+```terraform
+cpu {
+  function                 = "QUANTILE"
+  args                     = ["0.9"]
+  look_back_period_seconds = 86400
+  min                      = 0.1
+  max                      = 6
+  overhead                 = 0.1
+
+  limit {
+    type                   = "MULTIPLIER"
+    multiplier             = 1.5
+    only_if_original_exist = true
+    only_if_original_lower = true
+  }
+}
+```
+
+This configuration updates an existing CPU limit only when it is lower than `1.5` times the recommended request. Workloads without an existing CPU limit are left unchanged.
+
+### Memory: Automatic
+
+To configure **Memory: Automatic**, you can either:
+
+- Omit the `memory.limit` block:
+ 
+   ```terraform
+   memory {
+     function                 = "MAX"
+     look_back_period_seconds = 86400
+     min                      = 1024
+     max                      = 15360
+     overhead                 = 0.1
+   }
+   ```
+
+- Or configure it explicitly using the default multiplier and conditional flags:
+
+   ```terraform
+   memory {
+     function                 = "MAX"
+     look_back_period_seconds = 86400
+     min                      = 1024
+     max                      = 15360
+     overhead                 = 0.1
+   
+     limit {
+       type                   = "MULTIPLIER"
+       multiplier             = 1.5
+       only_if_original_exist = true
+       only_if_original_lower = true
+     }
+   }
+   ```
+
+Both configurations result in the same **Automatic** behavior shown in the CAST AI console. The second form makes the underlying behavior explicit: update an existing memory limit only when it is lower than `1.5` times the recommended request, while leaving workloads without an existing memory limit unchanged.
+
 ## Importing
 
 For each connected cluster, a default scaling policy is created. An existing scaling policy can be imported into the

--- a/templates/resources/workload_scaling_policy.md.tmpl
+++ b/templates/resources/workload_scaling_policy.md.tmpl
@@ -39,14 +39,14 @@ cpu {
 
   limit {
     type                   = "MULTIPLIER"
-    multiplier             = 1.5
+    multiplier             = 100
     only_if_original_exist = true
     only_if_original_lower = true
   }
 }
 ```
 
-This configuration updates an existing CPU limit only when it is lower than `1.5` times the recommended request. Workloads without an existing CPU limit are left unchanged.
+This configuration updates an existing CPU limit only when it is lower than `100` times the recommended request. Workloads without an existing CPU limit are left unchanged.
 
 ### Memory: Automatic
 


### PR DESCRIPTION
The UI != API. `semi-automatic ` and `automatic` are just human-friendly labels used in the UI. They are not actual API values. Terraform maps directly to the API representation.



<table>
<tr>
<td> explicit </td> <td> no-mem limit </td>
</tr>
<tr>
<td>

<img width="3232" height="2330" alt="image" src="https://github.com/user-attachments/assets/197767a6-0fac-4249-8199-dfcbce9b9c54" />

</td>
<td>

<img width="3554" height="2126" alt="image" src="https://github.com/user-attachments/assets/0a3c76a0-840e-4301-b4e7-890ea0f1d73e" />

</td>
</tr>
</table>



