### PR TITLE
fix: prefer apply_threshold_strategy over deprecated apply_threshold

### DIFF
--- a/castai/resource_workload_scaling_policy.go
+++ b/castai/resource_workload_scaling_policy.go
@@ -510,12 +510,12 @@ func workloadScalingPolicyResourceSchema(resource, function string, overhead, mi
 				Optional: true,
 				MaxItems: 1,
 				Description: "Resource apply threshold strategy settings. " +
-					"The default strategy is `PERCENTAGE` with percentage value set to 0.1.",
+					"The default strategy is `PERCENTAGE` with percentage value set to 0.1. " +
+					"When both apply_threshold and apply_threshold_strategy are set, apply_threshold_strategy takes precedence.",
 				Elem: workloadScalingPolicyResourceApplyThresholdStrategySchema(),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return suppressThresholdStrategyDefaultValueDiff(resource, old, new, d)
 				},
-				ConflictsWith: []string{fmt.Sprintf("%s.0.%s", resource, DeprecatedFieldApplyThreshold)},
 			},
 			"look_back_period_seconds": {
 				Type:             schema.TypeInt,
@@ -1243,15 +1243,19 @@ func toConstraintStrategy(obj map[string]any) (*sdk.WorkloadoptimizationV1Constr
 }
 
 func resolveApplyThresholdStrategy(obj map[string]any) (*sdk.WorkloadoptimizationV1ApplyThresholdStrategy, error) {
-	if v, ok := obj[DeprecatedFieldApplyThreshold].(float64); ok && v > 0 {
-		return toWorkloadResourcePercentageThresholdStrategy(v), nil
-	}
+	// Prefer apply_threshold_strategy when present. The eks-cluster module historically always
+	// sets deprecated apply_threshold (default 0.1); if strategy is also set, strategy wins.
 	if v, ok := obj[FieldApplyThresholdStrategy].([]any); ok && len(v) > 0 {
 		out, err := toWorkloadResourceApplyThresholdStrategy(v[0].(map[string]any))
 		if err != nil {
 			return nil, fmt.Errorf("field %q: %w", FieldApplyThresholdStrategy, err)
 		}
-		return out, nil
+		if out != nil {
+			return out, nil
+		}
+	}
+	if v, ok := obj[DeprecatedFieldApplyThreshold].(float64); ok && v > 0 {
+		return toWorkloadResourcePercentageThresholdStrategy(v), nil
 	}
 
 	return toWorkloadResourcePercentageThresholdStrategy(defaultApplyThresholdPercentage), nil

--- a/castai/resource_workload_scaling_policy_test.go
+++ b/castai/resource_workload_scaling_policy_test.go
@@ -682,6 +682,67 @@ func Test_validateResourcePolicy(t *testing.T) {
 	}
 }
 
+func Test_resolveApplyThresholdStrategy(t *testing.T) {
+	tests := map[string]struct {
+		args map[string]any
+		want func(t *testing.T, got *sdk.WorkloadoptimizationV1ApplyThresholdStrategy)
+	}{
+		"defaults to percentage 0.1 when neither is set": {
+			args: map[string]any{},
+			want: func(t *testing.T, got *sdk.WorkloadoptimizationV1ApplyThresholdStrategy) {
+				t.Helper()
+				require.NotNil(t, got.PercentageThreshold)
+				require.Equal(t, defaultApplyThresholdPercentage, got.PercentageThreshold.Percentage)
+				require.Nil(t, got.DefaultAdaptiveThreshold)
+			},
+		},
+		"uses deprecated apply_threshold when strategy is absent": {
+			args: map[string]any{
+				"apply_threshold": 0.25,
+			},
+			want: func(t *testing.T, got *sdk.WorkloadoptimizationV1ApplyThresholdStrategy) {
+				t.Helper()
+				require.NotNil(t, got.PercentageThreshold)
+				require.Equal(t, 0.25, got.PercentageThreshold.Percentage)
+			},
+		},
+		"uses DEFAULT_ADAPTIVE strategy when only strategy is set": {
+			args: map[string]any{
+				"apply_threshold_strategy": []any{
+					map[string]any{"type": "DEFAULT_ADAPTIVE"},
+				},
+			},
+			want: func(t *testing.T, got *sdk.WorkloadoptimizationV1ApplyThresholdStrategy) {
+				t.Helper()
+				require.NotNil(t, got.DefaultAdaptiveThreshold)
+				require.Nil(t, got.PercentageThreshold)
+			},
+		},
+		"prefers apply_threshold_strategy when both are set": {
+			args: map[string]any{
+				"apply_threshold": 0.1,
+				"apply_threshold_strategy": []any{
+					map[string]any{"type": "DEFAULT_ADAPTIVE"},
+				},
+			},
+			want: func(t *testing.T, got *sdk.WorkloadoptimizationV1ApplyThresholdStrategy) {
+				t.Helper()
+				require.NotNil(t, got.DefaultAdaptiveThreshold)
+				require.Nil(t, got.PercentageThreshold)
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := resolveApplyThresholdStrategy(tt.args)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			tt.want(t, got)
+		})
+	}
+}
+
 func Test_toWorkloadScalingPolicies_limit(t *testing.T) {
 	tests := map[string]struct {
 		args map[string]any

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -146,6 +146,21 @@ const (
 	CastaiInventoryV1beta1GCPFlexCUDCUDPlanTWELVEMONTH    CastaiInventoryV1beta1GCPFlexCUDCUDPlan = "TWELVE_MONTH"
 )
 
+// Defines values for CastaiInventoryV1beta1GCPReservationLocalSsdInterface.
+const (
+	GCPRESERVATIONLOCALSSDINTERFACENVME        CastaiInventoryV1beta1GCPReservationLocalSsdInterface = "GCP_RESERVATION_LOCAL_SSD_INTERFACE_NVME"
+	GCPRESERVATIONLOCALSSDINTERFACESCSI        CastaiInventoryV1beta1GCPReservationLocalSsdInterface = "GCP_RESERVATION_LOCAL_SSD_INTERFACE_SCSI"
+	GCPRESERVATIONLOCALSSDINTERFACEUNSPECIFIED CastaiInventoryV1beta1GCPReservationLocalSsdInterface = "GCP_RESERVATION_LOCAL_SSD_INTERFACE_UNSPECIFIED"
+)
+
+// Defines values for CastaiInventoryV1beta1GCPReservationShareType.
+const (
+	GCPRESERVATIONSHARETYPELOCAL            CastaiInventoryV1beta1GCPReservationShareType = "GCP_RESERVATION_SHARE_TYPE_LOCAL"
+	GCPRESERVATIONSHARETYPEORGANIZATION     CastaiInventoryV1beta1GCPReservationShareType = "GCP_RESERVATION_SHARE_TYPE_ORGANIZATION"
+	GCPRESERVATIONSHARETYPESPECIFICPROJECTS CastaiInventoryV1beta1GCPReservationShareType = "GCP_RESERVATION_SHARE_TYPE_SPECIFIC_PROJECTS"
+	GCPRESERVATIONSHARETYPEUNSPECIFIED      CastaiInventoryV1beta1GCPReservationShareType = "GCP_RESERVATION_SHARE_TYPE_UNSPECIFIED"
+)
+
 // Defines values for CastaiInventoryV1beta1GCPResourceCUDCUDPlan.
 const (
 	CastaiInventoryV1beta1GCPResourceCUDCUDPlanTHIRTYSIXMONTH CastaiInventoryV1beta1GCPResourceCUDCUDPlan = "THIRTY_SIX_MONTH"
@@ -189,6 +204,12 @@ const (
 	CastaiInventoryV1beta1NodeUsageAWSCapacityReservationTypeCAPACITYBLOCK                      CastaiInventoryV1beta1NodeUsageAWSCapacityReservationType = "CAPACITY_BLOCK"
 	CastaiInventoryV1beta1NodeUsageAWSCapacityReservationTypeCAPACITYRESERVATIONTYPEUNSPECIFIED CastaiInventoryV1beta1NodeUsageAWSCapacityReservationType = "CAPACITY_RESERVATION_TYPE_UNSPECIFIED"
 	CastaiInventoryV1beta1NodeUsageAWSCapacityReservationTypeONDEMANDCAPACITYRESERVATION        CastaiInventoryV1beta1NodeUsageAWSCapacityReservationType = "ON_DEMAND_CAPACITY_RESERVATION"
+)
+
+// Defines values for CastaiInventoryV1beta1NodeUsageGCPCapacityReservationType.
+const (
+	CastaiInventoryV1beta1NodeUsageGCPCapacityReservationTypeCAPACITYRESERVATIONTYPEUNSPECIFIED CastaiInventoryV1beta1NodeUsageGCPCapacityReservationType = "CAPACITY_RESERVATION_TYPE_UNSPECIFIED"
+	CastaiInventoryV1beta1NodeUsageGCPCapacityReservationTypeONDEMANDCAPACITYRESERVATION        CastaiInventoryV1beta1NodeUsageGCPCapacityReservationType = "ON_DEMAND_CAPACITY_RESERVATION"
 )
 
 // Defines values for CastaiInventoryV1beta1StorageDriver.
@@ -1151,13 +1172,13 @@ const (
 
 // Defines values for CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypes.
 const (
-	CAPACITYBLOCK               CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypes = "CAPACITY_BLOCK"
-	COMMITMENTTYPEUNSPECIFIED   CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypes = "COMMITMENT_TYPE_UNSPECIFIED"
-	FLEXCUD                     CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypes = "FLEX_CUD"
-	ONDEMANDCAPACITYRESERVATION CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypes = "ON_DEMAND_CAPACITY_RESERVATION"
-	RESERVEDINSTANCE            CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypes = "RESERVED_INSTANCE"
-	RESOURCECUD                 CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypes = "RESOURCE_CUD"
-	SAVINGSPLAN                 CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypes = "SAVINGS_PLAN"
+	CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypesCAPACITYBLOCK               CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypes = "CAPACITY_BLOCK"
+	CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypesCOMMITMENTTYPEUNSPECIFIED   CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypes = "COMMITMENT_TYPE_UNSPECIFIED"
+	CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypesFLEXCUD                     CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypes = "FLEX_CUD"
+	CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypesONDEMANDCAPACITYRESERVATION CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypes = "ON_DEMAND_CAPACITY_RESERVATION"
+	CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypesRESERVEDINSTANCE            CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypes = "RESERVED_INSTANCE"
+	CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypesRESOURCECUD                 CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypes = "RESOURCE_CUD"
+	CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypesSAVINGSPLAN                 CommitmentsAPIGetCommitmentUsageHistoryParamsCommitmentTypes = "SAVINGS_PLAN"
 )
 
 // Defines values for CommitmentsAPIImportAWSReservedInstancesParamsBehaviour.
@@ -2246,7 +2267,10 @@ type CastaiInventoryV1beta1EnaQueueInfo struct {
 
 // CastaiInventoryV1beta1GCPCapacityReservationContext defines model for castai.inventory.v1beta1.GCPCapacityReservationContext.
 type CastaiInventoryV1beta1GCPCapacityReservationContext struct {
-	AssuredInstanceCount *string `json:"assuredInstanceCount,omitempty"`
+	// Accelerators Accelerators (GPUs) that reserved VMs must match exactly (type and count)
+	// to consume this reservation.
+	Accelerators         *[]CastaiInventoryV1beta1GCPReservationAccelerator `json:"accelerators,omitempty"`
+	AssuredInstanceCount *string                                            `json:"assuredInstanceCount,omitempty"`
 
 	// EffectiveCount Effective instance count is the adjusted original commitment count based only on the portion remaining after out-of-cluster usage.
 	EffectiveCount *string `json:"effectiveCount,omitempty"`
@@ -2262,7 +2286,20 @@ type CastaiInventoryV1beta1GCPCapacityReservationContext struct {
 	InstanceTypeCpu       *string                                       `json:"instanceTypeCpu,omitempty"`
 	InstanceTypeMemoryMib *string                                       `json:"instanceTypeMemoryMib,omitempty"`
 	InstanceTypesUsage    *CastaiInventoryV1beta1InstanceTypeBasedUsage `json:"instanceTypesUsage,omitempty"`
-	ProjectId             *string                                       `json:"projectId,omitempty"`
+
+	// LocalSsds Local SSD disks that reserved VMs must match exactly (interface and size)
+	// to consume this reservation.
+	LocalSsds *[]CastaiInventoryV1beta1GCPReservationLocalSsd `json:"localSsds,omitempty"`
+
+	// MinCpuPlatform Minimum CPU platform the reserved VMs require (e.g. "Intel Cascade Lake").
+	// Empty when the reservation does not constrain the CPU platform. A VM can
+	// consume this reservation only if its minimum CPU platform matches.
+	MinCpuPlatform *string `json:"minCpuPlatform,omitempty"`
+	ProjectId      *string `json:"projectId,omitempty"`
+
+	// ShareSettings GCPReservationShareSettings represents the share_settings object on a GCP
+	// capacity reservation. It controls which projects can consume the reservation.
+	ShareSettings *CastaiInventoryV1beta1GCPReservationShareSettings `json:"shareSettings,omitempty"`
 
 	// SpecificReservationRequired If true, the reservation requires explicit reservation affinity to be used.
 	SpecificReservationRequired *bool   `json:"specificReservationRequired,omitempty"`
@@ -2311,6 +2348,63 @@ type CastaiInventoryV1beta1GCPFlexCUD struct {
 // CastaiInventoryV1beta1GCPFlexCUDCUDPlan - TWELVE_MONTH: 1 year commitment plan
 //   - THIRTY_SIX_MONTH: 3 year commitment plan
 type CastaiInventoryV1beta1GCPFlexCUDCUDPlan string
+
+// CastaiInventoryV1beta1GCPReservationAccelerator GCPReservationAccelerator describes a GPU type and count that a reserved VM
+// must match exactly to consume a GCP capacity reservation.
+type CastaiInventoryV1beta1GCPReservationAccelerator struct {
+	// AcceleratorCount Number of accelerators of this type per VM.
+	AcceleratorCount *string `json:"acceleratorCount,omitempty"`
+
+	// AcceleratorType Accelerator (GPU) type as the full GCP acceleratorType URL, e.g.
+	// "https://www.googleapis.com/compute/v1/projects/<p>/zones/<z>/acceleratorTypes/nvidia-tesla-t4".
+	AcceleratorType *string `json:"acceleratorType,omitempty"`
+}
+
+// CastaiInventoryV1beta1GCPReservationLocalSsd GCPReservationLocalSsd describes a local SSD disk that a reserved VM must
+// match exactly to consume a GCP capacity reservation.
+type CastaiInventoryV1beta1GCPReservationLocalSsd struct {
+	// DiskSizeGb Disk size in GB.
+	DiskSizeGb *string `json:"diskSizeGb,omitempty"`
+
+	// Interface GCPReservationLocalSsdInterface describes the disk interface of a local SSD
+	// attached to a GCP capacity reservation's reserved VMs.
+	//
+	//  - GCP_RESERVATION_LOCAL_SSD_INTERFACE_UNSPECIFIED: Interface not reported by GCP.
+	//  - GCP_RESERVATION_LOCAL_SSD_INTERFACE_SCSI: SCSI interface.
+	//  - GCP_RESERVATION_LOCAL_SSD_INTERFACE_NVME: NVME interface.
+	Interface *CastaiInventoryV1beta1GCPReservationLocalSsdInterface `json:"interface,omitempty"`
+}
+
+// CastaiInventoryV1beta1GCPReservationLocalSsdInterface GCPReservationLocalSsdInterface describes the disk interface of a local SSD
+// attached to a GCP capacity reservation's reserved VMs.
+//
+//   - GCP_RESERVATION_LOCAL_SSD_INTERFACE_UNSPECIFIED: Interface not reported by GCP.
+//   - GCP_RESERVATION_LOCAL_SSD_INTERFACE_SCSI: SCSI interface.
+//   - GCP_RESERVATION_LOCAL_SSD_INTERFACE_NVME: NVME interface.
+type CastaiInventoryV1beta1GCPReservationLocalSsdInterface string
+
+// CastaiInventoryV1beta1GCPReservationShareSettings GCPReservationShareSettings represents the share_settings object on a GCP
+// capacity reservation. It controls which projects can consume the reservation.
+type CastaiInventoryV1beta1GCPReservationShareSettings struct {
+	// ProjectIds Project IDs this reservation is shared with. Only valid when share_type is SPECIFIC_PROJECTS.
+	ProjectIds *[]string `json:"projectIds,omitempty"`
+
+	// ShareType GCPReservationShareType describes how a GCP capacity reservation is shared.
+	//
+	//  - GCP_RESERVATION_SHARE_TYPE_UNSPECIFIED: Unspecified share type.
+	//  - GCP_RESERVATION_SHARE_TYPE_LOCAL: Reservation is only usable by the owner project.
+	//  - GCP_RESERVATION_SHARE_TYPE_SPECIFIC_PROJECTS: Reservation is shared with specific projects listed in project_ids.
+	//  - GCP_RESERVATION_SHARE_TYPE_ORGANIZATION: Reservation is shared across the entire GCP organization.
+	ShareType *CastaiInventoryV1beta1GCPReservationShareType `json:"shareType,omitempty"`
+}
+
+// CastaiInventoryV1beta1GCPReservationShareType GCPReservationShareType describes how a GCP capacity reservation is shared.
+//
+//   - GCP_RESERVATION_SHARE_TYPE_UNSPECIFIED: Unspecified share type.
+//   - GCP_RESERVATION_SHARE_TYPE_LOCAL: Reservation is only usable by the owner project.
+//   - GCP_RESERVATION_SHARE_TYPE_SPECIFIC_PROJECTS: Reservation is shared with specific projects listed in project_ids.
+//   - GCP_RESERVATION_SHARE_TYPE_ORGANIZATION: Reservation is shared across the entire GCP organization.
+type CastaiInventoryV1beta1GCPReservationShareType string
 
 // CastaiInventoryV1beta1GCPResource defines model for castai.inventory.v1beta1.GCPResource.
 type CastaiInventoryV1beta1GCPResource struct {
@@ -2718,6 +2812,7 @@ type CastaiInventoryV1beta1NeuronInfo struct {
 // CastaiInventoryV1beta1NodeUsage defines model for castai.inventory.v1beta1.NodeUsage.
 type CastaiInventoryV1beta1NodeUsage struct {
 	Aws               *CastaiInventoryV1beta1NodeUsageAWS      `json:"aws,omitempty"`
+	Gcp               *CastaiInventoryV1beta1NodeUsageGCP      `json:"gcp,omitempty"`
 	NodeId            *string                                  `json:"nodeId,omitempty"`
 	UsageDistribution *CastaiInventoryV1beta1UsageDistribution `json:"usageDistribution,omitempty"`
 }
@@ -2736,6 +2831,19 @@ type CastaiInventoryV1beta1NodeUsageAWS struct {
 //   - ON_DEMAND_CAPACITY_RESERVATION: On-demand capacity reservation
 //   - CAPACITY_BLOCK: Capacity block
 type CastaiInventoryV1beta1NodeUsageAWSCapacityReservationType string
+
+// CastaiInventoryV1beta1NodeUsageGCP defines model for castai.inventory.v1beta1.NodeUsage.GCP.
+type CastaiInventoryV1beta1NodeUsageGCP struct {
+	CapacityReservationId *string `json:"capacityReservationId,omitempty"`
+
+	// CapacityReservationType - CAPACITY_RESERVATION_TYPE_UNSPECIFIED: Capacity reservation type not specified
+	//  - ON_DEMAND_CAPACITY_RESERVATION: On-demand reservation
+	CapacityReservationType *CastaiInventoryV1beta1NodeUsageGCPCapacityReservationType `json:"capacityReservationType,omitempty"`
+}
+
+// CastaiInventoryV1beta1NodeUsageGCPCapacityReservationType - CAPACITY_RESERVATION_TYPE_UNSPECIFIED: Capacity reservation type not specified
+//   - ON_DEMAND_CAPACITY_RESERVATION: On-demand reservation
+type CastaiInventoryV1beta1NodeUsageGCPCapacityReservationType string
 
 // CastaiInventoryV1beta1OrganizationUsageSummary Per-organization usage breakdown for enterprise commitments.
 type CastaiInventoryV1beta1OrganizationUsageSummary struct {
@@ -8679,6 +8787,10 @@ type ScheduledrebalancingV1RebalancingOptions struct {
 	// Deprecated:
 	KeepDrainTimeoutNodes *bool `json:"keepDrainTimeoutNodes"`
 
+	// MaxSimultaneousDrains Number of nodes to drain simultaniously.
+	// when unspecified, defaults to unlimited.
+	MaxSimultaneousDrains *int32 `json:"maxSimultaneousDrains"`
+
 	// MinNodes Minimum number of nodes that should be kept in the cluster after rebalancing.
 	MinNodes *int32 `json:"minNodes,omitempty"`
 }
@@ -11456,15 +11568,17 @@ type WorkloadoptimizationV1WorkloadThresholds struct {
 
 // WorkloadoptimizationV1WorkloadsSummaryMetrics defines model for workloadoptimization.v1.WorkloadsSummaryMetrics.
 type WorkloadoptimizationV1WorkloadsSummaryMetrics struct {
-	CpuOriginalRequestCores   float64   `json:"cpuOriginalRequestCores"`
-	CpuRecommendationCores    float64   `json:"cpuRecommendationCores"`
-	CpuRequestCores           float64   `json:"cpuRequestCores"`
-	CpuUsageCores             float64   `json:"cpuUsageCores"`
-	MemoryOriginalRequestGibs float64   `json:"memoryOriginalRequestGibs"`
-	MemoryRecommendationGibs  float64   `json:"memoryRecommendationGibs"`
-	MemoryRequestGibs         float64   `json:"memoryRequestGibs"`
-	MemoryUsageGibs           float64   `json:"memoryUsageGibs"`
-	Timestamp                 time.Time `json:"timestamp"`
+	CpuFirstSeenRequestCores   float64   `json:"cpuFirstSeenRequestCores"`
+	CpuOriginalRequestCores    float64   `json:"cpuOriginalRequestCores"`
+	CpuRecommendationCores     float64   `json:"cpuRecommendationCores"`
+	CpuRequestCores            float64   `json:"cpuRequestCores"`
+	CpuUsageCores              float64   `json:"cpuUsageCores"`
+	MemoryFirstSeenRequestGibs float64   `json:"memoryFirstSeenRequestGibs"`
+	MemoryOriginalRequestGibs  float64   `json:"memoryOriginalRequestGibs"`
+	MemoryRecommendationGibs   float64   `json:"memoryRecommendationGibs"`
+	MemoryRequestGibs          float64   `json:"memoryRequestGibs"`
+	MemoryUsageGibs            float64   `json:"memoryUsageGibs"`
+	Timestamp                  time.Time `json:"timestamp"`
 }
 
 // RbacServiceAPIListPermissionGroupsParams defines parameters for RbacServiceAPIListPermissionGroups.

--- a/docs/resources/workload_scaling_policy.md
+++ b/docs/resources/workload_scaling_policy.md
@@ -149,7 +149,7 @@ resource "castai_workload_scaling_policy" "services" {
 Optional:
 
 - `apply_threshold` (Number, Deprecated) The threshold of when to apply the recommendation. Recommendation will be applied when diff of current requests and new recommendation is greater than set value
-- `apply_threshold_strategy` (Block List, Max: 1) Resource apply threshold strategy settings. The default strategy is `PERCENTAGE` with percentage value set to 0.1. (see [below for nested schema](#nestedblock--cpu--apply_threshold_strategy))
+- `apply_threshold_strategy` (Block List, Max: 1) Resource apply threshold strategy settings. The default strategy is `PERCENTAGE` with percentage value set to 0.1. When both apply_threshold and apply_threshold_strategy are set, apply_threshold_strategy takes precedence. (see [below for nested schema](#nestedblock--cpu--apply_threshold_strategy))
 - `args` (List of String) The arguments for the function - i.e. for `QUANTILE` this should be a [0, 1] float. `MAX` doesn't accept any args
 - `constraints` (Block List, Max: 1) Defines min/max bounds for the recommendation using constraint strategies. (see [below for nested schema](#nestedblock--cpu--constraints))
 - `function` (String) The function used to calculate the resource recommendation. Supported values: `QUANTILE`, `MAX`
@@ -233,7 +233,7 @@ Optional:
 Optional:
 
 - `apply_threshold` (Number, Deprecated) The threshold of when to apply the recommendation. Recommendation will be applied when diff of current requests and new recommendation is greater than set value
-- `apply_threshold_strategy` (Block List, Max: 1) Resource apply threshold strategy settings. The default strategy is `PERCENTAGE` with percentage value set to 0.1. (see [below for nested schema](#nestedblock--memory--apply_threshold_strategy))
+- `apply_threshold_strategy` (Block List, Max: 1) Resource apply threshold strategy settings. The default strategy is `PERCENTAGE` with percentage value set to 0.1. When both apply_threshold and apply_threshold_strategy are set, apply_threshold_strategy takes precedence. (see [below for nested schema](#nestedblock--memory--apply_threshold_strategy))
 - `args` (List of String) The arguments for the function - i.e. for `QUANTILE` this should be a [0, 1] float. `MAX` doesn't accept any args
 - `constraints` (Block List, Max: 1) Defines min/max bounds for the recommendation using constraint strategies. (see [below for nested schema](#nestedblock--memory--constraints))
 - `function` (String) The function used to calculate the resource recommendation. Supported values: `QUANTILE`, `MAX`


### PR DESCRIPTION
## Summary
- Remove `ConflictsWith` between `apply_threshold` and `apply_threshold_strategy` on workload scaling policy CPU/memory resources.
- When both are set, prefer `apply_threshold_strategy` (needed because `castai/eks-cluster` historically always sets deprecated `apply_threshold = 0.1`, which blocked Dynamic/`DEFAULT_ADAPTIVE` configs).
- Existing single-field and neither-set behavior is unchanged (default remains Percentage 0.1).

## Test plan
- [x] Unit tests: `Test_resolveApplyThresholdStrategy` (neither / threshold-only / strategy-only / both)
- [x] Local provider validate: both fields set succeeds (no conflict)
- [x] Registry provider: both fields set still fails with conflict (baseline)
- [x] Live plan against cluster: both set → strategy wins; neither → falls back to Percentage 0.1
- [x] CI unit tests pass

