### PR TITLE
feat(examples): add modularized EKS GitOps onboarding example

### DIFF
--- a/examples/eks/eks_cluster_gitops_modularized/README.md
+++ b/examples/eks/eks_cluster_gitops_modularized/README.md
@@ -160,7 +160,7 @@ A flattened object with the same defaults as the original example. Set it to `nu
 | `autoscaler_settings` | `object` | see `variables.tf` | Autoscaler settings; `null` disables management |
 | `castai_api_url` | `string` | `https://api.cast.ai` | CAST AI API URL |
 | `delete_nodes_on_disconnect` | `bool` | `false` | Delete CAST AI nodes on cluster destroy |
-| `profile` | `string` | `"default"` | AWS CLI profile |
+| `profile` | `string` | `null` | AWS CLI profile; unset uses the default AWS credential chain |
 
 ## Outputs
 

--- a/examples/eks/eks_cluster_gitops_modularized/README.md
+++ b/examples/eks/eks_cluster_gitops_modularized/README.md
@@ -1,0 +1,173 @@
+# EKS + CAST AI GitOps onboarding as a reusable module
+
+This is the [`eks_cluster_gitops`](../eks_cluster_gitops) example reshaped into a **reusable module**.
+Instead of hardcoding one node configuration and three node templates in `castai.tf`, the whole
+node configuration / node template surface is driven by two input maps:
+
+- `node_configurations` — `map(object(...))`, keyed by configuration name
+- `node_templates` — `map(object(...))`, keyed by template name
+
+That makes it consumable from any wrapper where each cluster only supplies its own inputs, and the
+module code stays shared.
+
+Like the original example, this covers only the **Terraform half** of GitOps onboarding: it creates
+the IAM resources, connects the cluster to CAST AI, and configures node configurations, node
+templates and the autoscaler. Installing `castai-agent`, `castai-cluster-controller`,
+`castai-evictor`, `castai-spot-handler` and `castai-kvisor` is left to your GitOps tool (Argo CD,
+Flux, …) using the `cluster_id` and `cluster_token` outputs. See the
+[original example's README](../eks_cluster_gitops/README.md) for the Helm chart values and the
+onboarding sequence — this module is a drop-in replacement for its Terraform step.
+
+## Usage
+
+Copy [`terraform.tfvars.example`](./terraform.tfvars.example) to `terraform.tfvars`, fill it in, then:
+
+```sh
+terraform init
+terraform apply
+```
+
+Or reference it as a module:
+
+```hcl
+module "castai" {
+  source = "github.com/castai/terraform-provider-castai//examples/eks/eks_cluster_gitops_modularized?ref=v8.52.0"
+
+  aws_account_id     = "123456789012"
+  aws_cluster_region = "us-east-1"
+  aws_cluster_name   = module.eks.cluster_name
+  vpc_id             = module.vpc.vpc_id
+  castai_api_token   = var.castai_api_token
+
+  subnets = module.vpc.private_subnets
+  security_group_ids = [
+    module.eks.cluster_security_group_id,
+    module.eks.node_security_group_id,
+  ]
+
+  node_configurations = {
+    default = {
+      disk_cpu_ratio = 0
+      min_disk_size  = 100
+    }
+  }
+
+  node_templates = {
+    default-by-castai = {
+      is_default   = true
+      should_taint = false
+      constraints  = { on_demand = true }
+    }
+  }
+}
+```
+
+If your wrapper generates provider blocks, delete `providers.tf` from your vendored copy so the
+generated configuration is the only source of provider settings.
+
+## How the two maps work
+
+### `node_configurations`
+
+The map key becomes the node configuration name. Every attribute is optional; anything you omit
+falls back to the CAST AI default, with three convenience fallbacks:
+
+| Attribute | Falls back to |
+| --- | --- |
+| `subnets` | `var.subnets` |
+| `eks.security_groups` | `var.security_group_ids` |
+| `eks.instance_profile_arn` | instance profile created by the `castai/eks-role-iam/castai` module |
+
+So a minimal single-configuration setup needs nothing but the module-level `subnets` and
+`security_group_ids`, and per-configuration overrides are opt-in:
+
+```hcl
+node_configurations = {
+  default = {
+    disk_cpu_ratio = 0
+    min_disk_size  = 100
+  }
+
+  storage = {
+    min_disk_size = 500
+    subnets       = ["subnet-aaa", "subnet-bbb"] # overrides var.subnets
+
+    eks = {
+      volume_type       = "gp3"
+      volume_iops       = 6000
+      volume_throughput = 250
+    }
+  }
+}
+```
+
+`default_node_configuration` names the key that gets promoted via
+`castai_node_configuration_default` (defaults to `"default"`). A precondition fails the plan if that
+key is missing.
+
+### `node_templates`
+
+The map key becomes the template name. `node_configuration` references a **key of
+`node_configurations`** — not a raw ID — so units never have to thread IDs around; omit it and the
+template attaches to `default_node_configuration`.
+
+```hcl
+node_templates = {
+  spot = {
+    node_configuration = "default"
+    should_taint       = true
+
+    custom_labels = { type = "spot" }
+    custom_taints = [{ key = "dedicated", value = "spot", effect = "NoSchedule" }]
+
+    constraints = {
+      spot                  = true
+      use_spot_fallbacks    = true
+      enable_spot_diversity = true
+      architectures         = ["amd64"]
+
+      instance_families = { exclude = ["m5"] }
+      custom_priority   = [{ instance_families = ["c5"], spot = true }]
+    }
+  }
+}
+```
+
+`constraints` supports the common scalars plus the nested blocks `instance_families`,
+`custom_priority`, `dedicated_node_affinity`, `gpu` and `aws.capacity_reservations`. Blocks are only
+emitted when you supply them, so leaving them out keeps the CAST AI defaults. See
+`variables.tf` for the full object type.
+
+### `autoscaler_settings`
+
+A flattened object with the same defaults as the original example. Set it to `null` to stop managing
+`castai_autoscaler` entirely (useful if the autoscaler is owned by another unit).
+
+## Inputs
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `aws_account_id` | `string` | — | ID of the AWS account the cluster lives in |
+| `aws_cluster_region` | `string` | — | Cluster region |
+| `aws_cluster_name` | `string` | — | Cluster name |
+| `castai_api_token` | `string` | — | CAST AI API token |
+| `vpc_id` | `string` | — | EKS cluster VPC ID |
+| `subnets` | `list(string)` | — | Default subnets for node configurations |
+| `security_group_ids` | `list(string)` | — | Default security groups for node configurations |
+| `node_configurations` | `map(object)` | one `default` configuration | Node configurations to create |
+| `default_node_configuration` | `string` | `"default"` | Which configuration becomes the cluster default |
+| `node_templates` | `map(object)` | one `default-by-castai` template | Node templates to create |
+| `autoscaler_settings` | `object` | see `variables.tf` | Autoscaler settings; `null` disables management |
+| `castai_api_url` | `string` | `https://api.cast.ai` | CAST AI API URL |
+| `delete_nodes_on_disconnect` | `bool` | `false` | Delete CAST AI nodes on cluster destroy |
+| `profile` | `string` | `"default"` | AWS CLI profile |
+
+## Outputs
+
+| Name | Description |
+| --- | --- |
+| `cluster_id` | CAST AI cluster ID (needed by the Helm charts) |
+| `cluster_token` | CAST AI cluster token (sensitive; needed by the Helm charts) |
+| `node_configuration_ids` | Map of configuration name → CAST AI node configuration ID |
+| `node_template_names` | Names of the managed node templates |
+| `instance_profile_arn` / `instance_profile_role_arn` / `cast_role_arn` | IAM resources created for CAST AI |

--- a/examples/eks/eks_cluster_gitops_modularized/castai.tf
+++ b/examples/eks/eks_cluster_gitops_modularized/castai.tf
@@ -1,0 +1,289 @@
+# Create IAM resources required for connecting cluster to CAST AI.
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+data "aws_eks_cluster" "existing_cluster" {
+  name = var.aws_cluster_name
+}
+
+resource "castai_eks_clusterid" "cluster_id" {
+  account_id   = data.aws_caller_identity.current.account_id
+  region       = var.aws_cluster_region
+  cluster_name = var.aws_cluster_name
+}
+
+resource "castai_eks_user_arn" "castai_user_arn" {
+  cluster_id = castai_eks_clusterid.cluster_id.id
+}
+
+module "castai-eks-role-iam" {
+  source  = "castai/eks-role-iam/castai"
+  version = "~> 2.0"
+
+  aws_account_id     = data.aws_caller_identity.current.account_id
+  aws_cluster_region = var.aws_cluster_region
+  aws_cluster_name   = var.aws_cluster_name
+  aws_cluster_vpc_id = var.vpc_id
+
+  castai_user_arn = castai_eks_user_arn.castai_user_arn.arn
+
+  create_iam_resources_per_cluster = true
+}
+
+# Creates access entry if eks auth mode is API/API_CONFIGMAP
+locals {
+  access_entry = can(regex("API", data.aws_eks_cluster.existing_cluster.access_config[0].authentication_mode))
+}
+
+resource "aws_eks_access_entry" "access_entry" {
+  count         = local.access_entry ? 1 : 0
+  cluster_name  = data.aws_eks_cluster.existing_cluster.name
+  principal_arn = module.castai-eks-role-iam.instance_profile_role_arn
+  type          = "EC2_LINUX"
+}
+
+# Connect eks cluster to CAST AI
+resource "castai_eks_cluster" "this" {
+  account_id                 = var.aws_account_id
+  region                     = var.aws_cluster_region
+  name                       = var.aws_cluster_name
+  delete_nodes_on_disconnect = var.delete_nodes_on_disconnect
+  assume_role_arn            = module.castai-eks-role-iam.role_arn
+}
+
+# Node configurations supplied by the caller, keyed by configuration name.
+resource "castai_node_configuration" "this" {
+  for_each = var.node_configurations
+
+  cluster_id = castai_eks_cluster.this.id
+  name       = each.key
+
+  disk_cpu_ratio    = each.value.disk_cpu_ratio
+  min_disk_size     = each.value.min_disk_size
+  drain_timeout_sec = each.value.drain_timeout_sec
+  subnets           = coalesce(each.value.subnets, var.subnets)
+  ssh_public_key    = each.value.ssh_public_key
+  image             = each.value.image
+  init_script       = each.value.init_script
+  container_runtime = each.value.container_runtime
+  docker_config     = each.value.docker_config
+  kubelet_config    = each.value.kubelet_config
+  tags              = each.value.tags
+
+  eks {
+    security_groups      = coalesce(each.value.eks.security_groups, var.security_group_ids)
+    instance_profile_arn = coalesce(each.value.eks.instance_profile_arn, module.castai-eks-role-iam.instance_profile_arn)
+
+    node_group_arn                = each.value.eks.node_group_arn
+    dns_cluster_ip                = each.value.eks.dns_cluster_ip
+    key_pair_id                   = each.value.eks.key_pair_id
+    volume_type                   = each.value.eks.volume_type
+    volume_iops                   = each.value.eks.volume_iops
+    volume_throughput             = each.value.eks.volume_throughput
+    volume_kms_key_arn            = each.value.eks.volume_kms_key_arn
+    imds_v1                       = each.value.eks.imds_v1
+    imds_hop_limit                = each.value.eks.imds_hop_limit
+    max_pods_per_node_formula     = each.value.eks.max_pods_per_node_formula
+    ips_per_prefix                = each.value.eks.ips_per_prefix
+    threads_per_cpu               = each.value.eks.threads_per_cpu
+    eks_image_family              = each.value.eks.eks_image_family
+    ena_queue_count_per_interface = each.value.eks.ena_queue_count_per_interface
+
+    dynamic "target_group" {
+      for_each = each.value.eks.target_group
+
+      content {
+        arn  = target_group.value.arn
+        port = target_group.value.port
+      }
+    }
+  }
+}
+
+# Promotes one of the node configurations as the cluster default.
+resource "castai_node_configuration_default" "this" {
+  cluster_id       = castai_eks_cluster.this.id
+  configuration_id = castai_node_configuration.this[var.default_node_configuration].id
+
+  lifecycle {
+    precondition {
+      condition     = contains(keys(var.node_configurations), var.default_node_configuration)
+      error_message = "default_node_configuration must be a key of var.node_configurations."
+    }
+  }
+}
+
+# Node templates supplied by the caller, keyed by template name.
+resource "castai_node_template" "this" {
+  for_each = var.node_templates
+
+  cluster_id = castai_eks_cluster.this.id
+
+  name             = each.key
+  is_default       = each.value.is_default
+  is_enabled       = each.value.is_enabled
+  should_taint     = each.value.should_taint
+  configuration_id = castai_node_configuration.this[coalesce(each.value.node_configuration, var.default_node_configuration)].id
+
+  custom_labels                = each.value.custom_labels
+  custom_instances_enabled     = each.value.custom_instances_enabled
+  rebalancing_config_min_nodes = each.value.rebalancing_config_min_nodes
+
+  lifecycle {
+    precondition {
+      condition     = each.value.node_configuration == null || contains(keys(var.node_configurations), coalesce(each.value.node_configuration, var.default_node_configuration))
+      error_message = "Node template '${each.key}' references node configuration '${coalesce(each.value.node_configuration, var.default_node_configuration)}' which is not defined in var.node_configurations."
+    }
+  }
+
+  dynamic "custom_taints" {
+    for_each = each.value.custom_taints
+
+    content {
+      key    = custom_taints.value.key
+      value  = custom_taints.value.value
+      effect = custom_taints.value.effect
+    }
+  }
+
+  dynamic "constraints" {
+    for_each = each.value.constraints == null ? [] : [each.value.constraints]
+
+    content {
+      on_demand                                   = constraints.value.on_demand
+      spot                                        = constraints.value.spot
+      use_spot_fallbacks                          = constraints.value.use_spot_fallbacks
+      fallback_restore_rate_seconds               = constraints.value.fallback_restore_rate_seconds
+      enable_spot_diversity                       = constraints.value.enable_spot_diversity
+      spot_diversity_price_increase_limit_percent = constraints.value.spot_diversity_price_increase_limit_percent
+      spot_interruption_predictions_enabled       = constraints.value.spot_interruption_predictions_enabled
+      spot_interruption_predictions_type          = constraints.value.spot_interruption_predictions_type
+      spot_reliability_enabled                    = constraints.value.spot_reliability_enabled
+      compute_optimized_state                     = constraints.value.compute_optimized_state
+      storage_optimized_state                     = constraints.value.storage_optimized_state
+      is_gpu_only                                 = constraints.value.is_gpu_only
+      min_cpu                                     = constraints.value.min_cpu
+      max_cpu                                     = constraints.value.max_cpu
+      min_memory                                  = constraints.value.min_memory
+      max_memory                                  = constraints.value.max_memory
+      architectures                               = constraints.value.architectures
+      os                                          = constraints.value.os
+      azs                                         = constraints.value.azs
+      burstable_instances                         = constraints.value.burstable_instances
+      customer_specific                           = constraints.value.customer_specific
+      bare_metal                                  = constraints.value.bare_metal
+      cpu_manufacturers                           = constraints.value.cpu_manufacturers
+
+      dynamic "instance_families" {
+        for_each = constraints.value.instance_families == null ? [] : [constraints.value.instance_families]
+
+        content {
+          include = instance_families.value.include
+          exclude = instance_families.value.exclude
+        }
+      }
+
+      dynamic "custom_priority" {
+        for_each = constraints.value.custom_priority
+
+        content {
+          instance_families = custom_priority.value.instance_families
+          on_demand         = custom_priority.value.on_demand
+          spot              = custom_priority.value.spot
+        }
+      }
+
+      dynamic "dedicated_node_affinity" {
+        for_each = constraints.value.dedicated_node_affinity
+
+        content {
+          name           = dedicated_node_affinity.value.name
+          az_name        = dedicated_node_affinity.value.az_name
+          instance_types = dedicated_node_affinity.value.instance_types
+
+          dynamic "affinity" {
+            for_each = dedicated_node_affinity.value.affinity
+
+            content {
+              key      = affinity.value.key
+              operator = affinity.value.operator
+              values   = affinity.value.values
+            }
+          }
+        }
+      }
+
+      dynamic "gpu" {
+        for_each = constraints.value.gpu == null ? [] : [constraints.value.gpu]
+
+        content {
+          manufacturers = gpu.value.manufacturers
+          include_names = gpu.value.include_names
+          exclude_names = gpu.value.exclude_names
+          min_count     = gpu.value.min_count
+          max_count     = gpu.value.max_count
+        }
+      }
+
+      dynamic "aws" {
+        for_each = constraints.value.aws == null ? [] : [constraints.value.aws]
+
+        content {
+          dynamic "capacity_reservations" {
+            for_each = aws.value.capacity_reservations
+
+            content {
+              id                          = capacity_reservations.value.id
+              type                        = capacity_reservations.value.type
+              capacity_resource_group_arn = capacity_reservations.value.capacity_resource_group_arn
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "castai_autoscaler" "this" {
+  count = var.autoscaler_settings == null ? 0 : 1
+
+  cluster_id = castai_eks_cluster.this.id
+
+  autoscaler_settings {
+    enabled                                 = var.autoscaler_settings.enabled
+    is_scoped_mode                          = var.autoscaler_settings.is_scoped_mode
+    node_templates_partial_matching_enabled = var.autoscaler_settings.node_templates_partial_matching_enabled
+
+    unschedulable_pods {
+      enabled = var.autoscaler_settings.unschedulable_pods_enabled
+    }
+
+    cluster_limits {
+      enabled = var.autoscaler_settings.cluster_limits_enabled
+
+      cpu {
+        min_cores = var.autoscaler_settings.cluster_limits_min_cpu
+        max_cores = var.autoscaler_settings.cluster_limits_max_cpu
+      }
+    }
+
+    node_downscaler {
+      enabled = var.autoscaler_settings.node_downscaler_enabled
+
+      empty_nodes {
+        enabled = var.autoscaler_settings.empty_nodes_enabled
+      }
+
+      evictor {
+        enabled         = var.autoscaler_settings.evictor_enabled
+        aggressive_mode = var.autoscaler_settings.evictor_aggressive_mode
+        cycle_interval  = var.autoscaler_settings.evictor_cycle_interval
+        dry_run         = var.autoscaler_settings.evictor_dry_run
+
+        node_grace_period_minutes = var.autoscaler_settings.evictor_node_grace_period
+        scoped_mode               = var.autoscaler_settings.evictor_scoped_mode
+      }
+    }
+  }
+}

--- a/examples/eks/eks_cluster_gitops_modularized/outputs.tf
+++ b/examples/eks/eks_cluster_gitops_modularized/outputs.tf
@@ -1,0 +1,35 @@
+output "cluster_id" {
+  value       = castai_eks_clusterid.cluster_id.id
+  description = "CAST AI cluster ID"
+}
+
+output "cluster_token" {
+  value       = castai_eks_cluster.this.cluster_token
+  description = "CAST AI cluster token used by Castware to authenticate to Mothership"
+  sensitive   = true
+}
+
+output "instance_profile_role_arn" {
+  description = "Arn of created cast instance role"
+  value       = module.castai-eks-role-iam.instance_profile_role_arn
+}
+
+output "instance_profile_arn" {
+  description = "Arn of created cast instance profile role"
+  value       = module.castai-eks-role-iam.instance_profile_arn
+}
+
+output "cast_role_arn" {
+  description = "Arn of created cast role"
+  value       = module.castai-eks-role-iam.role_arn
+}
+
+output "node_configuration_ids" {
+  description = "Map of node configuration name to CAST AI node configuration ID"
+  value       = { for name, cfg in castai_node_configuration.this : name => cfg.id }
+}
+
+output "node_template_names" {
+  description = "Names of the node templates managed by this module"
+  value       = keys(castai_node_template.this)
+}

--- a/examples/eks/eks_cluster_gitops_modularized/providers.tf
+++ b/examples/eks/eks_cluster_gitops_modularized/providers.tf
@@ -1,0 +1,9 @@
+provider "castai" {
+  api_url   = var.castai_api_url
+  api_token = var.castai_api_token
+}
+
+provider "aws" {
+  region  = var.aws_cluster_region
+  profile = var.profile
+}

--- a/examples/eks/eks_cluster_gitops_modularized/terraform.tfvars.example
+++ b/examples/eks/eks_cluster_gitops_modularized/terraform.tfvars.example
@@ -1,0 +1,45 @@
+castai_api_token   = "PLACEHOLDER"
+aws_account_id     = "PLACEHOLDER"
+aws_cluster_region = "us-east-1"
+aws_cluster_name   = "PLACEHOLDER"
+vpc_id             = "vpc-PLACEHOLDER"
+subnets            = ["subnet-PLACEHOLDER1", "subnet-PLACEHOLDER2"]
+security_group_ids = ["sg-PLACEHOLDER1", "sg-PLACEHOLDER2"]
+profile            = "default" # default aws cli profile is used, override if needed.
+
+node_configurations = {
+  default = {
+    disk_cpu_ratio = 0
+    min_disk_size  = 100
+  }
+}
+
+default_node_configuration = "default"
+
+node_templates = {
+  default-by-castai = {
+    is_default   = true
+    should_taint = false
+    constraints = {
+      on_demand = true
+    }
+  }
+
+  spot = {
+    should_taint = true
+    custom_labels = {
+      type = "spot"
+    }
+    custom_taints = [{
+      key    = "dedicated"
+      value  = "spot"
+      effect = "NoSchedule"
+    }]
+    constraints = {
+      spot                  = true
+      use_spot_fallbacks    = true
+      enable_spot_diversity = true
+      architectures         = ["amd64"]
+    }
+  }
+}

--- a/examples/eks/eks_cluster_gitops_modularized/variables.tf
+++ b/examples/eks/eks_cluster_gitops_modularized/variables.tf
@@ -40,8 +40,8 @@ variable "vpc_id" {
 
 variable "profile" {
   type        = string
-  description = "Profile used with AWS CLI"
-  default     = "default"
+  description = "AWS CLI profile to use. Leave unset to use the default AWS credential chain (env vars, SSO, IRSA, instance profile)."
+  default     = null
 }
 
 variable "castai_api_url" {

--- a/examples/eks/eks_cluster_gitops_modularized/variables.tf
+++ b/examples/eks/eks_cluster_gitops_modularized/variables.tf
@@ -1,0 +1,253 @@
+## Required variables.
+
+variable "aws_account_id" {
+  type        = string
+  description = "ID of AWS account the cluster is located in."
+}
+
+variable "aws_cluster_region" {
+  type        = string
+  description = "Region of the cluster to be connected to CAST AI."
+}
+
+variable "aws_cluster_name" {
+  type        = string
+  description = "Name of the cluster to be connected to CAST AI."
+}
+
+variable "castai_api_token" {
+  type        = string
+  sensitive   = true
+  description = "CAST AI API token created in console.cast.ai API Access keys section"
+}
+
+variable "subnets" {
+  type        = list(string)
+  description = "Subnet IDs used by CAST AI to provision nodes. Used as the default for any node configuration that does not set its own `subnets`."
+}
+
+variable "security_group_ids" {
+  type        = list(string)
+  description = "Security group IDs (usually the EKS cluster and node security groups) attached to CAST AI provisioned nodes. Used as the default for any node configuration that does not set its own `eks.security_groups`."
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "EKS cluster VPC ID"
+}
+
+## Optional variables.
+
+variable "profile" {
+  type        = string
+  description = "Profile used with AWS CLI"
+  default     = "default"
+}
+
+variable "castai_api_url" {
+  type        = string
+  description = "CAST AI url to API, default value is https://api.cast.ai"
+  default     = "https://api.cast.ai"
+}
+
+variable "delete_nodes_on_disconnect" {
+  type        = bool
+  description = "Optionally delete CAST AI created nodes when the cluster is destroyed"
+  default     = false
+}
+
+## Node configurations.
+
+variable "node_configurations" {
+  description = <<-EOT
+    Node configurations to create, keyed by configuration name. Every attribute is optional;
+    omitted attributes fall back to the CAST AI defaults, except for `subnets` and
+    `eks.security_groups` / `eks.instance_profile_arn` which fall back to `var.subnets`,
+    `var.security_group_ids` and the instance profile created by the castai-eks-role-iam module.
+  EOT
+
+  type = map(object({
+    disk_cpu_ratio    = optional(number)
+    min_disk_size     = optional(number)
+    drain_timeout_sec = optional(number)
+    subnets           = optional(list(string))
+    ssh_public_key    = optional(string)
+    image             = optional(string)
+    init_script       = optional(string)
+    container_runtime = optional(string)
+    docker_config     = optional(string)
+    kubelet_config    = optional(string)
+    tags              = optional(map(string))
+
+    eks = optional(object({
+      security_groups               = optional(list(string))
+      instance_profile_arn          = optional(string)
+      node_group_arn                = optional(string)
+      dns_cluster_ip                = optional(string)
+      key_pair_id                   = optional(string)
+      volume_type                   = optional(string)
+      volume_iops                   = optional(number)
+      volume_throughput             = optional(number)
+      volume_kms_key_arn            = optional(string)
+      imds_v1                       = optional(bool)
+      imds_hop_limit                = optional(number)
+      max_pods_per_node_formula     = optional(string)
+      ips_per_prefix                = optional(number)
+      threads_per_cpu               = optional(number)
+      eks_image_family              = optional(string)
+      ena_queue_count_per_interface = optional(number)
+
+      target_group = optional(list(object({
+        arn  = string
+        port = optional(number)
+      })), [])
+    }), {})
+  }))
+
+  default = {
+    default = {
+      disk_cpu_ratio = 0
+      min_disk_size  = 100
+    }
+  }
+
+  validation {
+    condition     = length(var.node_configurations) > 0
+    error_message = "At least one node configuration must be defined."
+  }
+}
+
+variable "default_node_configuration" {
+  type        = string
+  description = "Key of the entry in `var.node_configurations` that is promoted to the cluster's default node configuration."
+  default     = "default"
+}
+
+## Node templates.
+
+variable "node_templates" {
+  description = <<-EOT
+    Node templates to create, keyed by template name. `node_configuration` references a key of
+    `var.node_configurations`; when omitted, the template is attached to
+    `var.default_node_configuration`.
+  EOT
+
+  type = map(object({
+    node_configuration           = optional(string)
+    is_default                   = optional(bool, false)
+    is_enabled                   = optional(bool, true)
+    should_taint                 = optional(bool, true)
+    custom_labels                = optional(map(string), {})
+    custom_instances_enabled     = optional(bool)
+    rebalancing_config_min_nodes = optional(number)
+
+    custom_taints = optional(list(object({
+      key    = string
+      value  = optional(string)
+      effect = optional(string, "NoSchedule")
+    })), [])
+
+    constraints = optional(object({
+      on_demand                                   = optional(bool)
+      spot                                        = optional(bool)
+      use_spot_fallbacks                          = optional(bool)
+      fallback_restore_rate_seconds               = optional(number)
+      enable_spot_diversity                       = optional(bool)
+      spot_diversity_price_increase_limit_percent = optional(number)
+      spot_interruption_predictions_enabled       = optional(bool)
+      spot_interruption_predictions_type          = optional(string)
+      spot_reliability_enabled                    = optional(bool)
+      compute_optimized_state                     = optional(string)
+      storage_optimized_state                     = optional(string)
+      is_gpu_only                                 = optional(bool)
+      min_cpu                                     = optional(number)
+      max_cpu                                     = optional(number)
+      min_memory                                  = optional(number)
+      max_memory                                  = optional(number)
+      architectures                               = optional(list(string))
+      os                                          = optional(list(string))
+      azs                                         = optional(list(string))
+      burstable_instances                         = optional(string)
+      customer_specific                           = optional(string)
+      bare_metal                                  = optional(string)
+      cpu_manufacturers                           = optional(list(string))
+
+      instance_families = optional(object({
+        include = optional(list(string), [])
+        exclude = optional(list(string), [])
+      }))
+
+      custom_priority = optional(list(object({
+        instance_families = optional(list(string), [])
+        on_demand         = optional(bool)
+        spot              = optional(bool)
+      })), [])
+
+      dedicated_node_affinity = optional(list(object({
+        name           = string
+        az_name        = string
+        instance_types = optional(list(string), [])
+        affinity = optional(list(object({
+          key      = string
+          operator = string
+          values   = list(string)
+        })), [])
+      })), [])
+
+      gpu = optional(object({
+        manufacturers = optional(list(string))
+        include_names = optional(list(string))
+        exclude_names = optional(list(string))
+        min_count     = optional(number)
+        max_count     = optional(number)
+      }))
+
+      aws = optional(object({
+        capacity_reservations = optional(list(object({
+          id                          = optional(string)
+          type                        = optional(string)
+          capacity_resource_group_arn = optional(string)
+        })), [])
+      }))
+    }))
+  }))
+
+  default = {
+    default-by-castai = {
+      is_default   = true
+      should_taint = false
+      constraints = {
+        on_demand = true
+      }
+    }
+  }
+}
+
+## Autoscaler.
+
+variable "autoscaler_settings" {
+  description = "CAST AI autoscaler settings. Set to null to skip managing the castai_autoscaler resource."
+
+  type = object({
+    enabled                                 = optional(bool, true)
+    is_scoped_mode                          = optional(bool, false)
+    node_templates_partial_matching_enabled = optional(bool, false)
+
+    unschedulable_pods_enabled = optional(bool, true)
+
+    cluster_limits_enabled = optional(bool, false)
+    cluster_limits_min_cpu = optional(number, 1)
+    cluster_limits_max_cpu = optional(number, 200)
+
+    node_downscaler_enabled   = optional(bool, true)
+    empty_nodes_enabled       = optional(bool, true)
+    evictor_enabled           = optional(bool, true)
+    evictor_aggressive_mode   = optional(bool, false)
+    evictor_cycle_interval    = optional(string, "60s")
+    evictor_dry_run           = optional(bool, false)
+    evictor_node_grace_period = optional(number, 10)
+    evictor_scoped_mode       = optional(bool, false)
+  })
+
+  default = {}
+}

--- a/examples/eks/eks_cluster_gitops_modularized/versions.tf
+++ b/examples/eks/eks_cluster_gitops_modularized/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.2"
+
+  required_providers {
+    castai = {
+      source  = "castai/castai"
+      version = ">= 3.11.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds `examples/eks/eks_cluster_gitops_modularized/` — the existing [`eks_cluster_gitops`](../examples/eks/eks_cluster_gitops) example reshaped into a **reusable module**.

Instead of hardcoding one node configuration and three node templates in `castai.tf`, the whole node configuration / node template surface is driven by two input maps:

- `node_configurations` — `map(object(...))`, keyed by configuration name
- `node_templates` — `map(object(...))`, keyed by template name

Each cluster only supplies its own inputs while the module code stays shared. `node_templates[*].node_configuration` references a *key* of `node_configurations` rather than a raw ID, so callers never have to thread IDs around.

Like the original example, this covers only the Terraform half of GitOps onboarding — installing the CAST AI charts is left to Argo CD / Flux using the `cluster_id` and `cluster_token` outputs.

## Testing

- `terraform fmt -recursive -diff` — clean
- `terraform validate` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)