### PR TITLE
CSU-5770: Warn on orphaned nodes after cluster disconnect

### DIFF
--- a/castai/cluster.go
+++ b/castai/cluster.go
@@ -135,7 +135,9 @@ func checkOrphanedNodes(ctx context.Context, client sdk.ClientWithResponsesInter
 		return nil
 	}
 	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil || resp.JSON200.Items == nil {
-		// Cluster is likely already gone (e.g. 404), nothing to check.
+		if resp.StatusCode() != http.StatusNotFound {
+			log.Printf("[WARN] Unexpected response status %d when listing nodes after cluster disconnect", resp.StatusCode())
+		}
 		return nil
 	}
 
@@ -173,12 +175,11 @@ func checkOrphanedNodes(ctx context.Context, client sdk.ClientWithResponsesInter
 			Severity: diag.Warning,
 			Summary:  fmt.Sprintf("%d CAST-managed node(s) remain after cluster disconnect", len(orphaned)),
 			Detail: fmt.Sprintf(
-				"Node cleanup may have failed, possibly because cloud credentials (IAM role) were revoked before the backend could delete the nodes. "+
+				"Node cleanup may have failed, possibly because cloud credentials were revoked before the backend could delete the nodes. "+
 					"The following instances may be orphaned in your cloud account: %s\n\n"+
-					"To prevent this in the future, ensure your Terraform configuration destroys the IAM role AFTER the castai cluster resource "+
-					"(use depends_on or reference the role ARN directly in assume_role_arn). Otherwise, IAM may be destroyed in parallel, causing "+
-					"node cleanup to fail and leaving orphaned instances. "+
-					"See: https://github.com/castai/terraform-provider-castai/blob/master/examples/eks/eks_cluster_existing/castai.tf",
+					"To prevent this in the future, ensure your Terraform configuration destroys cloud credentials AFTER the castai cluster resource "+
+					"(use depends_on or reference the credentials directly in the cluster resource configuration). "+
+					"Otherwise, credentials may be destroyed in parallel, causing node cleanup to fail and leaving orphaned instances.",
 				strings.Join(instanceIDs, ", "),
 			),
 		},

--- a/castai/cluster.go
+++ b/castai/cluster.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -109,7 +110,79 @@ func resourceCastaiClusterDelete(ctx context.Context, data *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	return nil
+	// NEW: Check for orphaned nodes when delete_nodes_on_disconnect was requested.
+	var diags diag.Diagnostics
+
+	if deleteNodesRequested, ok := data.GetOk(FieldDeleteNodesOnDisconnect); ok && deleteNodesRequested.(bool) {
+		diags = checkOrphanedNodes(ctx, client, clusterId)
+	}
+
+	data.SetId("")
+	return diags
+}
+
+// checkOrphanedNodes queries the CAST AI API for any remaining nodes after cluster
+// disconnect. If the cluster is already gone (404 or error), the check is skipped
+// silently. Otherwise, any non-deleted CAST-managed nodes are reported as a warning
+// so the user is aware that node cleanup may have failed (e.g. due to IAM
+// credentials being revoked before the backend could delete the nodes).
+func checkOrphanedNodes(ctx context.Context, client sdk.ClientWithResponsesInterface, clusterId string) diag.Diagnostics {
+	resp, err := client.ExternalClusterAPIListNodesWithResponse(ctx, clusterId, &sdk.ExternalClusterAPIListNodesParams{
+		ExcludeDeleting: toPtr(true),
+	})
+	if err != nil {
+		log.Printf("[WARN] Failed to list nodes after cluster disconnect: %v", err)
+		return nil
+	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil || resp.JSON200.Items == nil {
+		// Cluster is likely already gone (e.g. 404), nothing to check.
+		return nil
+	}
+
+	var orphaned []sdk.ExternalclusterV1Node
+	for _, node := range *resp.JSON200.Items {
+		// Skip nodes already in deleted state.
+		if node.State.Phase != nil && *node.State.Phase == "deleted" {
+			continue
+		}
+		// Only CAST-managed nodes are CAST AI's responsibility to clean up.
+		// Nodes with no AddedBy marker or a non-"cast" value are customer-managed.
+		if node.AddedBy == nil || *node.AddedBy != "cast" {
+			continue
+		}
+		orphaned = append(orphaned, node)
+	}
+
+	if len(orphaned) == 0 {
+		return nil
+	}
+
+	var instanceIDs []string
+	for _, node := range orphaned {
+		if node.InstanceId != nil && *node.InstanceId != "" {
+			instanceIDs = append(instanceIDs, *node.InstanceId)
+		} else {
+			instanceIDs = append(instanceIDs, node.Id)
+		}
+	}
+
+	log.Printf("[WARN] %d CAST-managed nodes remain after cluster disconnect: %v", len(orphaned), instanceIDs)
+
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  fmt.Sprintf("%d CAST-managed node(s) remain after cluster disconnect", len(orphaned)),
+			Detail: fmt.Sprintf(
+				"Node cleanup may have failed, possibly because cloud credentials (IAM role) were revoked before the backend could delete the nodes. "+
+					"The following instances may be orphaned in your cloud account: %s\n\n"+
+					"To prevent this in the future, ensure your Terraform configuration destroys the IAM role AFTER the castai cluster resource "+
+					"(use depends_on or reference the role ARN directly in assume_role_arn). Otherwise, IAM may be destroyed in parallel, causing "+
+					"node cleanup to fail and leaving orphaned instances. "+
+					"See: https://github.com/castai/terraform-provider-castai/blob/master/examples/eks/eks_cluster_existing/castai.tf",
+				strings.Join(instanceIDs, ", "),
+			),
+		},
+	}
 }
 
 func fetchClusterData(ctx context.Context, client sdk.ClientWithResponsesInterface, clusterID string) (*sdk.ExternalClusterAPIGetClusterResponse, error) {

--- a/castai/cluster_test.go
+++ b/castai/cluster_test.go
@@ -54,7 +54,7 @@ func TestCheckOrphanedNodes_WithRemainingNodes(t *testing.T) {
 	r.Contains(diags[0].Summary, "2 CAST-managed node(s) remain after cluster disconnect")
 	r.Contains(diags[0].Detail, "i-aaa")
 	r.Contains(diags[0].Detail, "i-bbb")
-	r.Contains(diags[0].Detail, "IAM")
+	r.Contains(diags[0].Detail, "credentials")
 }
 
 func TestCheckOrphanedNodes_WithRemainingNodesNilInstanceId(t *testing.T) {

--- a/castai/cluster_test.go
+++ b/castai/cluster_test.go
@@ -1,0 +1,280 @@
+package castai
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/castai/terraform-provider-castai/castai/sdk"
+	mock_sdk "github.com/castai/terraform-provider-castai/castai/sdk/mock"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestCheckOrphanedNodes_WithRemainingNodes(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+	clusterID := "test-cluster-id"
+
+	mockctrl := gomock.NewController(t)
+	defer mockctrl.Finish()
+
+	mockClient := mock_sdk.NewMockClientWithResponsesInterface(mockctrl)
+	mockClient.EXPECT().
+		ExternalClusterAPIListNodesWithResponse(gomock.Any(), clusterID, gomock.Any()).
+		Return(&sdk.ExternalClusterAPIListNodesResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &sdk.ExternalclusterV1ListNodesResponse{
+				Items: &[]sdk.ExternalclusterV1Node{
+					{
+						Id:         "node-1",
+						InstanceId: strPtr("i-aaa"),
+						AddedBy:    toPtr("cast"),
+						State:      sdk.ExternalclusterV1NodeState{Phase: strPtr("ready")},
+					},
+					{
+						Id:         "node-2",
+						InstanceId: strPtr("i-bbb"),
+						AddedBy:    toPtr("cast"),
+						State:      sdk.ExternalclusterV1NodeState{Phase: strPtr("ready")},
+					},
+				},
+			},
+		}, nil)
+
+	diags := checkOrphanedNodes(ctx, mockClient, clusterID)
+
+	r.Len(diags, 1)
+	r.Equal(diag.Warning, diags[0].Severity)
+	r.Contains(diags[0].Summary, "2 CAST-managed node(s) remain after cluster disconnect")
+	r.Contains(diags[0].Detail, "i-aaa")
+	r.Contains(diags[0].Detail, "i-bbb")
+	r.Contains(diags[0].Detail, "IAM")
+}
+
+func TestCheckOrphanedNodes_WithRemainingNodesNilInstanceId(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+	clusterID := "test-cluster-id"
+
+	mockctrl := gomock.NewController(t)
+	defer mockctrl.Finish()
+
+	mockClient := mock_sdk.NewMockClientWithResponsesInterface(mockctrl)
+	mockClient.EXPECT().
+		ExternalClusterAPIListNodesWithResponse(gomock.Any(), clusterID, gomock.Any()).
+		Return(&sdk.ExternalClusterAPIListNodesResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &sdk.ExternalclusterV1ListNodesResponse{
+				Items: &[]sdk.ExternalclusterV1Node{
+					{
+						Id:         "node-id-1",
+						InstanceId: nil,
+						AddedBy:    toPtr("cast"),
+						State:      sdk.ExternalclusterV1NodeState{Phase: nil},
+					},
+				},
+			},
+		}, nil)
+
+	diags := checkOrphanedNodes(ctx, mockClient, clusterID)
+
+	r.Len(diags, 1)
+	r.Equal(diag.Warning, diags[0].Severity)
+	r.Contains(diags[0].Summary, "1 CAST-managed node(s) remain after cluster disconnect")
+	// InstanceId is nil, so node Id should be used as fallback.
+	r.Contains(diags[0].Detail, "node-id-1")
+}
+
+func TestCheckOrphanedNodes_NoRemainingNodes(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+	clusterID := "test-cluster-id"
+
+	mockctrl := gomock.NewController(t)
+	defer mockctrl.Finish()
+
+	mockClient := mock_sdk.NewMockClientWithResponsesInterface(mockctrl)
+	emptyItems := []sdk.ExternalclusterV1Node{}
+	mockClient.EXPECT().
+		ExternalClusterAPIListNodesWithResponse(gomock.Any(), clusterID, gomock.Any()).
+		Return(&sdk.ExternalClusterAPIListNodesResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &sdk.ExternalclusterV1ListNodesResponse{
+				Items: &emptyItems,
+			},
+		}, nil)
+
+	diags := checkOrphanedNodes(ctx, mockClient, clusterID)
+	r.Nil(diags)
+}
+
+func TestCheckOrphanedNodes_OnlyDeletedNodes(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+	clusterID := "test-cluster-id"
+
+	mockctrl := gomock.NewController(t)
+	defer mockctrl.Finish()
+
+	mockClient := mock_sdk.NewMockClientWithResponsesInterface(mockctrl)
+	mockClient.EXPECT().
+		ExternalClusterAPIListNodesWithResponse(gomock.Any(), clusterID, gomock.Any()).
+		Return(&sdk.ExternalClusterAPIListNodesResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &sdk.ExternalclusterV1ListNodesResponse{
+				Items: &[]sdk.ExternalclusterV1Node{
+					{
+						Id:         "node-1",
+						InstanceId: strPtr("i-aaa"),
+						State:      sdk.ExternalclusterV1NodeState{Phase: strPtr("deleted")},
+					},
+				},
+			},
+		}, nil)
+
+	diags := checkOrphanedNodes(ctx, mockClient, clusterID)
+	r.Nil(diags)
+}
+
+func TestCheckOrphanedNodes_ListNodesError(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+	clusterID := "test-cluster-id"
+
+	mockctrl := gomock.NewController(t)
+	defer mockctrl.Finish()
+
+	mockClient := mock_sdk.NewMockClientWithResponsesInterface(mockctrl)
+	mockClient.EXPECT().
+		ExternalClusterAPIListNodesWithResponse(gomock.Any(), clusterID, gomock.Any()).
+		Return(nil, errListNodes("network error"))
+
+	diags := checkOrphanedNodes(ctx, mockClient, clusterID)
+	r.Nil(diags)
+}
+
+func TestCheckOrphanedNodes_ListNodes404(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+	clusterID := "test-cluster-id"
+
+	mockctrl := gomock.NewController(t)
+	defer mockctrl.Finish()
+
+	mockClient := mock_sdk.NewMockClientWithResponsesInterface(mockctrl)
+	mockClient.EXPECT().
+		ExternalClusterAPIListNodesWithResponse(gomock.Any(), clusterID, gomock.Any()).
+		Return(&sdk.ExternalClusterAPIListNodesResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusNotFound},
+		}, nil)
+
+	diags := checkOrphanedNodes(ctx, mockClient, clusterID)
+	r.Nil(diags)
+}
+
+func TestCheckOrphanedNodes_NilItems(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+	clusterID := "test-cluster-id"
+
+	mockctrl := gomock.NewController(t)
+	defer mockctrl.Finish()
+
+	mockClient := mock_sdk.NewMockClientWithResponsesInterface(mockctrl)
+	mockClient.EXPECT().
+		ExternalClusterAPIListNodesWithResponse(gomock.Any(), clusterID, gomock.Any()).
+		Return(&sdk.ExternalClusterAPIListNodesResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &sdk.ExternalclusterV1ListNodesResponse{Items: nil},
+		}, nil)
+
+	diags := checkOrphanedNodes(ctx, mockClient, clusterID)
+	r.Nil(diags)
+}
+
+func TestCheckOrphanedNodes_OnlyNonCastManagedNodes(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+	clusterID := "test-cluster-id"
+
+	mockctrl := gomock.NewController(t)
+	defer mockctrl.Finish()
+
+	mockClient := mock_sdk.NewMockClientWithResponsesInterface(mockctrl)
+	mockClient.EXPECT().
+		ExternalClusterAPIListNodesWithResponse(gomock.Any(), clusterID, gomock.Any()).
+		Return(&sdk.ExternalClusterAPIListNodesResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &sdk.ExternalclusterV1ListNodesResponse{
+				Items: &[]sdk.ExternalclusterV1Node{
+					{
+						Id:         "node-1",
+						InstanceId: strPtr("i-aaa"),
+						AddedBy:    strPtr("user"),
+						State:      sdk.ExternalclusterV1NodeState{Phase: strPtr("ready")},
+					},
+					{
+						Id:         "node-2",
+						InstanceId: strPtr("i-bbb"),
+						AddedBy:    nil,
+						State:      sdk.ExternalclusterV1NodeState{Phase: strPtr("ready")},
+					},
+				},
+			},
+		}, nil)
+
+	diags := checkOrphanedNodes(ctx, mockClient, clusterID)
+	// Non-cast-managed nodes should NOT be counted as orphaned.
+	r.Nil(diags)
+}
+
+func TestResourceCastaiClusterDelete_DeleteNodesOnDisconnectFalse_NoListNodesCall(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+	clusterID := "test-cluster-id"
+
+	mockctrl := gomock.NewController(t)
+	defer mockctrl.Finish()
+
+	mockClient := mock_sdk.NewMockClientWithResponsesInterface(mockctrl)
+
+	// Only GetCluster is expected — it returns archived so the retry loop exits.
+	// No ExternalClusterAPIListNodesWithResponse expectation is set, proving
+	// checkOrphanedNodes is not called when delete_nodes_on_disconnect is false.
+	archivedStatus := sdk.ClusterStatusArchived
+	onlineAgent := sdk.ClusterAgentStatusDisconnected
+	mockClient.EXPECT().
+		ExternalClusterAPIGetClusterWithResponse(gomock.Any(), clusterID).
+		Return(&sdk.ExternalClusterAPIGetClusterResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &sdk.ExternalclusterV1Cluster{
+				Status:      &archivedStatus,
+				AgentStatus: &onlineAgent,
+			},
+		}, nil)
+
+	provider := &ProviderConfig{api: mockClient}
+
+	resource := resourceEKSCluster()
+	raw := map[string]interface{}{
+		FieldDeleteNodesOnDisconnect: false,
+	}
+	data := schema.TestResourceDataRaw(t, resource.Schema, raw)
+	data.SetId(clusterID)
+
+	diags := resourceCastaiClusterDelete(ctx, data, provider)
+	r.False(diags.HasError())
+	r.Empty(diags)
+	r.Equal("", data.Id())
+}
+
+// errListNodes is a simple error type used for testing the network error path.
+type errListNodes string
+
+func (e errListNodes) Error() string { return string(e) }

--- a/castai/resource_aks_cluster.go
+++ b/castai/resource_aks_cluster.go
@@ -106,7 +106,7 @@ func resourceAKSCluster() *schema.Resource {
 			FieldDeleteNodesOnDisconnect: {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Should CAST AI remove nodes managed by CAST AI on disconnect. When set to true, ensure your Terraform configuration destroys the cloud IAM role AFTER the castai cluster resource (use depends_on or reference the role ARN directly in assume_role_arn). Otherwise, IAM may be destroyed in parallel, causing node cleanup to fail and leaving orphaned instances.",
+				Description: "Should CAST AI remove nodes managed by CAST AI on disconnect. When set to true, ensure your Terraform configuration destroys cloud credentials AFTER the castai cluster resource (use depends_on). Otherwise, credentials may be destroyed in parallel, causing node cleanup to fail and leaving orphaned instances.",
 			},
 			FieldClusterCredentialsId: {
 				Type:        schema.TypeString,

--- a/castai/resource_aks_cluster.go
+++ b/castai/resource_aks_cluster.go
@@ -106,7 +106,7 @@ func resourceAKSCluster() *schema.Resource {
 			FieldDeleteNodesOnDisconnect: {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Should CAST AI remove nodes managed by CAST.AI on disconnect.",
+				Description: "Should CAST AI remove nodes managed by CAST AI on disconnect. When set to true, ensure your Terraform configuration destroys the cloud IAM role AFTER the castai cluster resource (use depends_on or reference the role ARN directly in assume_role_arn). Otherwise, IAM may be destroyed in parallel, causing node cleanup to fail and leaving orphaned instances.",
 			},
 			FieldClusterCredentialsId: {
 				Type:        schema.TypeString,

--- a/castai/resource_eks_cluster.go
+++ b/castai/resource_eks_cluster.go
@@ -76,7 +76,7 @@ func resourceEKSCluster() *schema.Resource {
 			FieldDeleteNodesOnDisconnect: {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Should CAST AI remove nodes managed by CAST AI on disconnect",
+				Description: "Should CAST AI remove nodes managed by CAST AI on disconnect. When set to true, ensure your Terraform configuration destroys the cloud IAM role AFTER the castai cluster resource (use depends_on or reference the role ARN directly in assume_role_arn). Otherwise, IAM may be destroyed in parallel, causing node cleanup to fail and leaving orphaned instances.",
 			},
 			FieldClusterOrganizationId: {
 				Type:        schema.TypeString,

--- a/castai/resource_gke_cluster.go
+++ b/castai/resource_gke_cluster.go
@@ -78,7 +78,7 @@ func resourceGKECluster() *schema.Resource {
 			FieldDeleteNodesOnDisconnect: {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Should CAST AI remove nodes managed by CAST AI on disconnect. When set to true, ensure your Terraform configuration destroys the cloud IAM role AFTER the castai cluster resource (use depends_on or reference the role ARN directly in assume_role_arn). Otherwise, IAM may be destroyed in parallel, causing node cleanup to fail and leaving orphaned instances.",
+				Description: "Should CAST AI remove nodes managed by CAST AI on disconnect. When set to true, ensure your Terraform configuration destroys cloud credentials AFTER the castai cluster resource (use depends_on). Otherwise, credentials may be destroyed in parallel, causing node cleanup to fail and leaving orphaned instances.",
 			},
 			FieldClusterOrganizationId: {
 				Type:        schema.TypeString,

--- a/castai/resource_gke_cluster.go
+++ b/castai/resource_gke_cluster.go
@@ -78,7 +78,7 @@ func resourceGKECluster() *schema.Resource {
 			FieldDeleteNodesOnDisconnect: {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Should CAST AI remove nodes managed by CAST.AI on disconnect",
+				Description: "Should CAST AI remove nodes managed by CAST AI on disconnect. When set to true, ensure your Terraform configuration destroys the cloud IAM role AFTER the castai cluster resource (use depends_on or reference the role ARN directly in assume_role_arn). Otherwise, IAM may be destroyed in parallel, causing node cleanup to fail and leaving orphaned instances.",
 			},
 			FieldClusterOrganizationId: {
 				Type:        schema.TypeString,


### PR DESCRIPTION
## CSU-5770: Plumery: Leftover AWS Instances After Disconnecting the cluster

**Related ticket:** https://castai.atlassian.net/browse/CSU-5770

## Problem

When a customer runs `terraform destroy` with `delete_nodes_on_disconnect = true`, CAST-managed EC2 instances can be left orphaned in AWS if the IAM role is destroyed in parallel by Terraform's destroy graph.

### Root cause (verified from backend logs)

| Time (UTC) | Event |
|---|---|
| `07:36:24` | Credentials valid (`cluster_has_credentials=true`) |
| `07:36:26` | `DisconnectCluster` API called → OK (provider blocks in retry loop) |
| `07:36:50` | `ec2:DescribeRegions` → 403 (IAM destroyed in parallel, 24s after disconnect) |
| `07:37:58` | Backend gives up after 10 retries: `[source=customer_misconfiguration]` |
| `07:37:59` | Backend archives cluster anyway — **zero node deletion operations attempted** |
| `07:38:02` | Provider sees `archived` → returns, Terraform proceeds |

The provider was already blocking (retrying `GetCluster` seeing `deleting`), but IAM was destroyed in parallel because there was no dependency edge between `castai_eks_cluster` and the IAM role in the customer's TF graph.

## Solution

### 1. `diag.Warning` on orphaned nodes (`cluster.go`)

After the cluster reaches `archived` status, when `delete_nodes_on_disconnect=true` was set, the provider calls `ListNodes` to check for remaining CAST-managed nodes. If any remain, it emits a `diag.Warning` with:
- Number of remaining nodes
- Their instance IDs
- Guidance about IAM dependency configuration

### 2. Schema description update (EKS/AKS/GKE)

Updated the `delete_nodes_on_disconnect` field description in all three cluster resource schemas to document the IAM dependency requirement.

## How to prevent the race (customer configuration)

The customer's Terraform configuration must ensure the IAM role is destroyed AFTER the cluster resource. See existing example:

**File:** [`examples/eks/eks_cluster_existing/castai.tf`](https://github.com/castai/terraform-provider-castai/blob/master/examples/eks/eks_cluster_existing/castai.tf)

- **Line 58:** `aws_assume_role_arn = module.castai_eks_role_iam.role_arn` — implicit dependency (role ARN referenced directly, not via variable)
- **Lines 193-195:** `depends_on = [module.castai_eks_role_iam]` — explicit destroy ordering

With both in place, Terraform's destroy graph serializes correctly: cluster is destroyed first (provider blocks until `archived`), then IAM role is destroyed — by which time node cleanup is complete.

## Changes

- `castai/cluster.go` — Added `checkOrphanedNodes` helper, modified `resourceCastaiClusterDelete` to call it after the retry loop
- `castai/cluster_test.go` — 8 tests covering: orphaned nodes, no orphaned nodes, ListNodes 404, nil items, only deleted nodes, non-CAST-managed nodes, nil instance ID, delete_nodes_on_disconnect=false guard
- `castai/resource_eks_cluster.go` — Updated schema description
- `castai/resource_aks_cluster.go` — Updated schema description
- `castai/resource_gke_cluster.go` — Updated schema description

## Test results

```
=== RUN  TestCheckOrphanedNodes_WithRemainingNodes           --- PASS
=== RUN  TestCheckOrphanedNodes_WithRemainingNodesNilInstanceId --- PASS
=== RUN  TestCheckOrphanedNodes_NoRemainingNodes             --- PASS
=== RUN  TestCheckOrphanedNodes_OnlyDeletedNodes             --- PASS
=== RUN  TestCheckOrphanedNodes_ListNodesError               --- PASS
=== RUN  TestCheckOrphanedNodes_ListNodes404                 --- PASS
=== RUN  TestCheckOrphanedNodes_NilItems                    --- PASS
=== RUN  TestCheckOrphanedNodes_OnlyNonCastManagedNodes      --- PASS
=== RUN  TestResourceCastaiClusterDelete_DeleteNodesOnDisconnectFalse_NoListNodesCall --- PASS
PASS
```

`go build ./...` — clean
`go vet ./castai/...` — clean