### PR TITLE
Add retries for resource-commitment

### DIFF
--- a/castai/resource_commitment.go
+++ b/castai/resource_commitment.go
@@ -899,8 +899,7 @@ func (r *genericCommitmentResource) Create(ctx context.Context, req resource.Cre
 		!config.AutoAssignment.ValueBool()
 
 	if commitmentID != "" && needsPatch {
-		patchInput := plan.toUpdateInput()
-		patchResp, patchErr := r.client.pricingClient.CommitmentsAPIUpdateCommitmentWithResponse(ctx, organizationID, commitmentID, patchInput)
+		patchResp, patchErr := r.updateCommitmentWithRetry(ctx, organizationID, commitmentID, plan.toUpdateInput())
 		if patchErr != nil {
 			saveCreatedState(ctx, resp, &plan, organizationID, created)
 			resp.Diagnostics.AddError("Failed to enforce commitment settings after create", patchErr.Error())
@@ -946,10 +945,6 @@ func newCommitmentBackoff(ctx context.Context) backoff.BackOff {
 	return backoff.WithContext(b, ctx)
 }
 
-// getCommitmentWithRetry wraps the GetCommitment API call with exponential
-// backoff to handle transient 5xx errors that the backend occasionally
-// returns under concurrent load (e.g. during terraform refresh/destroy
-// which reads multiple commitments in parallel).
 func (r *genericCommitmentResource) getCommitmentWithRetry(ctx context.Context, organizationID, commitmentID string) (*pricing.CommitmentsAPIGetCommitmentResponse, error) {
 	b := newCommitmentBackoff(ctx)
 	var apiResp *pricing.CommitmentsAPIGetCommitmentResponse
@@ -968,8 +963,6 @@ func (r *genericCommitmentResource) getCommitmentWithRetry(ctx context.Context, 
 	return apiResp, err
 }
 
-// createCommitmentWithRetry wraps the CreateCommitment API call with
-// exponential backoff for the same transient 5xx reason.
 func (r *genericCommitmentResource) createCommitmentWithRetry(ctx context.Context, organizationID string, input pricing.CreateCommitmentInput) (*pricing.CommitmentsAPICreateCommitmentResponse, error) {
 	b := newCommitmentBackoff(ctx)
 	var apiResp *pricing.CommitmentsAPICreateCommitmentResponse
@@ -987,13 +980,28 @@ func (r *genericCommitmentResource) createCommitmentWithRetry(ctx context.Contex
 	return apiResp, err
 }
 
-// deleteCommitmentWithRetry wraps the DeleteCommitment API call with
-// exponential backoff for the same transient 5xx reason.
 func (r *genericCommitmentResource) deleteCommitmentWithRetry(ctx context.Context, organizationID, commitmentID string) (*pricing.CommitmentsAPIDeleteCommitmentResponse, error) {
 	b := newCommitmentBackoff(ctx)
 	var apiResp *pricing.CommitmentsAPIDeleteCommitmentResponse
 	err := backoff.Retry(func() error {
 		resp, err := r.client.pricingClient.CommitmentsAPIDeleteCommitmentWithResponse(ctx, organizationID, commitmentID)
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode() >= 500 {
+			return fmt.Errorf("transient server error: status=%d body=%s", resp.StatusCode(), string(resp.Body))
+		}
+		apiResp = resp
+		return nil
+	}, b)
+	return apiResp, err
+}
+
+func (r *genericCommitmentResource) updateCommitmentWithRetry(ctx context.Context, organizationID, commitmentID string, input pricing.UpdateCommitmentInput) (*pricing.CommitmentsAPIUpdateCommitmentResponse, error) {
+	b := newCommitmentBackoff(ctx)
+	var apiResp *pricing.CommitmentsAPIUpdateCommitmentResponse
+	err := backoff.Retry(func() error {
+		resp, err := r.client.pricingClient.CommitmentsAPIUpdateCommitmentWithResponse(ctx, organizationID, commitmentID, input)
 		if err != nil {
 			return err
 		}
@@ -1139,8 +1147,7 @@ func (r *genericCommitmentResource) Update(ctx context.Context, req resource.Upd
 	// and the user explicitly set auto_assignment=false (to counter
 	// enableAutoAssignments' potential false→true flip).
 	if patchPathChanged(&plan, &state) || (upsertChanged && autoAssignmentExplicitlyFalse) {
-		input := plan.toUpdateInput()
-		apiResp, err := r.client.pricingClient.CommitmentsAPIUpdateCommitmentWithResponse(ctx, organizationID, commitmentID, input)
+		apiResp, err := r.updateCommitmentWithRetry(ctx, organizationID, commitmentID, plan.toUpdateInput())
 		if err != nil {
 			resp.Diagnostics.AddError("Failed to update commitment settings", err.Error())
 			return

--- a/castai/resource_commitment.go
+++ b/castai/resource_commitment.go
@@ -938,12 +938,20 @@ func saveCreatedState(ctx context.Context, resp *resource.CreateResponse, plan *
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
+// newCommitmentBackoff creates an exponential backoff capped at 1 minute and
+// bound to the supplied context.
+func newCommitmentBackoff(ctx context.Context) backoff.BackOff {
+	b := backoff.NewExponentialBackOff()
+	b.MaxElapsedTime = time.Minute
+	return backoff.WithContext(b, ctx)
+}
+
 // getCommitmentWithRetry wraps the GetCommitment API call with exponential
 // backoff to handle transient 5xx errors that the backend occasionally
 // returns under concurrent load (e.g. during terraform refresh/destroy
 // which reads multiple commitments in parallel).
 func (r *genericCommitmentResource) getCommitmentWithRetry(ctx context.Context, organizationID, commitmentID string) (*pricing.CommitmentsAPIGetCommitmentResponse, error) {
-	b := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
+	b := newCommitmentBackoff(ctx)
 	var apiResp *pricing.CommitmentsAPIGetCommitmentResponse
 	err := backoff.Retry(func() error {
 		resp, err := r.client.pricingClient.CommitmentsAPIGetCommitmentWithResponse(ctx, organizationID, commitmentID)
@@ -963,7 +971,7 @@ func (r *genericCommitmentResource) getCommitmentWithRetry(ctx context.Context, 
 // createCommitmentWithRetry wraps the CreateCommitment API call with
 // exponential backoff for the same transient 5xx reason.
 func (r *genericCommitmentResource) createCommitmentWithRetry(ctx context.Context, organizationID string, input pricing.CreateCommitmentInput) (*pricing.CommitmentsAPICreateCommitmentResponse, error) {
-	b := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
+	b := newCommitmentBackoff(ctx)
 	var apiResp *pricing.CommitmentsAPICreateCommitmentResponse
 	err := backoff.Retry(func() error {
 		resp, err := r.client.pricingClient.CommitmentsAPICreateCommitmentWithResponse(ctx, organizationID, input)
@@ -982,7 +990,7 @@ func (r *genericCommitmentResource) createCommitmentWithRetry(ctx context.Contex
 // deleteCommitmentWithRetry wraps the DeleteCommitment API call with
 // exponential backoff for the same transient 5xx reason.
 func (r *genericCommitmentResource) deleteCommitmentWithRetry(ctx context.Context, organizationID, commitmentID string) (*pricing.CommitmentsAPIDeleteCommitmentResponse, error) {
-	b := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
+	b := newCommitmentBackoff(ctx)
 	var apiResp *pricing.CommitmentsAPIDeleteCommitmentResponse
 	err := backoff.Retry(func() error {
 		resp, err := r.client.pricingClient.CommitmentsAPIDeleteCommitmentWithResponse(ctx, organizationID, commitmentID)

--- a/castai/resource_commitment.go
+++ b/castai/resource_commitment.go
@@ -24,6 +24,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	"github.com/cenkalti/backoff/v4"
+
 	"github.com/castai/terraform-provider-castai/castai/sdk/pricing"
 )
 
@@ -871,7 +873,7 @@ func (r *genericCommitmentResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	apiResp, err := r.client.pricingClient.CommitmentsAPICreateCommitmentWithResponse(ctx, organizationID, input)
+	apiResp, err := r.createCommitmentWithRetry(ctx, organizationID, input)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create commitment", err.Error())
 		return
@@ -936,6 +938,66 @@ func saveCreatedState(ctx context.Context, resp *resource.CreateResponse, plan *
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
+// getCommitmentWithRetry wraps the GetCommitment API call with exponential
+// backoff to handle transient 5xx errors that the backend occasionally
+// returns under concurrent load (e.g. during terraform refresh/destroy
+// which reads multiple commitments in parallel).
+func (r *genericCommitmentResource) getCommitmentWithRetry(ctx context.Context, organizationID, commitmentID string) (*pricing.CommitmentsAPIGetCommitmentResponse, error) {
+	b := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
+	var apiResp *pricing.CommitmentsAPIGetCommitmentResponse
+	err := backoff.Retry(func() error {
+		resp, err := r.client.pricingClient.CommitmentsAPIGetCommitmentWithResponse(ctx, organizationID, commitmentID)
+		if err != nil {
+			return err
+		}
+		// Retry on transient server errors (500, 502, 503, 504).
+		if resp.StatusCode() >= 500 {
+			return fmt.Errorf("transient server error: status=%d body=%s", resp.StatusCode(), string(resp.Body))
+		}
+		apiResp = resp
+		return nil
+	}, b)
+	return apiResp, err
+}
+
+// createCommitmentWithRetry wraps the CreateCommitment API call with
+// exponential backoff for the same transient 5xx reason.
+func (r *genericCommitmentResource) createCommitmentWithRetry(ctx context.Context, organizationID string, input pricing.CreateCommitmentInput) (*pricing.CommitmentsAPICreateCommitmentResponse, error) {
+	b := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
+	var apiResp *pricing.CommitmentsAPICreateCommitmentResponse
+	err := backoff.Retry(func() error {
+		resp, err := r.client.pricingClient.CommitmentsAPICreateCommitmentWithResponse(ctx, organizationID, input)
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode() >= 500 {
+			return fmt.Errorf("transient server error: status=%d body=%s", resp.StatusCode(), string(resp.Body))
+		}
+		apiResp = resp
+		return nil
+	}, b)
+	return apiResp, err
+}
+
+// deleteCommitmentWithRetry wraps the DeleteCommitment API call with
+// exponential backoff for the same transient 5xx reason.
+func (r *genericCommitmentResource) deleteCommitmentWithRetry(ctx context.Context, organizationID, commitmentID string) (*pricing.CommitmentsAPIDeleteCommitmentResponse, error) {
+	b := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
+	var apiResp *pricing.CommitmentsAPIDeleteCommitmentResponse
+	err := backoff.Retry(func() error {
+		resp, err := r.client.pricingClient.CommitmentsAPIDeleteCommitmentWithResponse(ctx, organizationID, commitmentID)
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode() >= 500 {
+			return fmt.Errorf("transient server error: status=%d body=%s", resp.StatusCode(), string(resp.Body))
+		}
+		apiResp = resp
+		return nil
+	}, b)
+	return apiResp, err
+}
+
 func (r *genericCommitmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state commitmentModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -949,7 +1011,7 @@ func (r *genericCommitmentResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
-	apiResp, err := r.client.pricingClient.CommitmentsAPIGetCommitmentWithResponse(ctx, organizationID, state.ID.ValueString())
+	apiResp, err := r.getCommitmentWithRetry(ctx, organizationID, state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to read commitment", err.Error())
 		return
@@ -1043,7 +1105,7 @@ func (r *genericCommitmentResource) Update(ctx context.Context, req resource.Upd
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		apiResp, err := r.client.pricingClient.CommitmentsAPICreateCommitmentWithResponse(ctx, organizationID, input)
+		apiResp, err := r.createCommitmentWithRetry(ctx, organizationID, input)
 		if err != nil {
 			resp.Diagnostics.AddError("Failed to update commitment", err.Error())
 			return
@@ -1085,7 +1147,7 @@ func (r *genericCommitmentResource) Update(ctx context.Context, req resource.Upd
 	}
 
 	// Read back for authoritative state.
-	getResp, err := r.client.pricingClient.CommitmentsAPIGetCommitmentWithResponse(ctx, organizationID, commitmentID)
+	getResp, err := r.getCommitmentWithRetry(ctx, organizationID, commitmentID)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to read commitment after update", err.Error())
 		return
@@ -1116,7 +1178,7 @@ func (r *genericCommitmentResource) Delete(ctx context.Context, req resource.Del
 		return
 	}
 
-	apiResp, err := r.client.pricingClient.CommitmentsAPIDeleteCommitmentWithResponse(ctx, organizationID, state.ID.ValueString())
+	apiResp, err := r.deleteCommitmentWithRetry(ctx, organizationID, state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to delete commitment", err.Error())
 		return

--- a/castai/resource_commitment_test.go
+++ b/castai/resource_commitment_test.go
@@ -122,8 +122,7 @@ resource "castai_commitment" "test" {
 }
 
 // ---------------------------------------------------------------------------
-// Retry unit tests — mock-based tests for getCommitmentWithRetry,
-// createCommitmentWithRetry, and deleteCommitmentWithRetry.
+// Retry unit tests
 // ---------------------------------------------------------------------------
 func newCommitmentResourceWithMock(mockClient *mock_pricing.MockClientWithResponsesInterface) *genericCommitmentResource {
 	return &genericCommitmentResource{
@@ -139,10 +138,6 @@ func httpResp(status int) *http.Response {
 		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
 	}
 }
-
-// ---------------------------------------------------------------------------
-// getCommitmentWithRetry
-// ---------------------------------------------------------------------------
 
 func TestGetCommitmentWithRetry_Retries5xxThenSucceeds(t *testing.T) {
 	t.Parallel()
@@ -233,10 +228,6 @@ func TestGetCommitmentWithRetry_ContextCancellationStopsRetries(t *testing.T) {
 	_ = apiResp
 }
 
-// ---------------------------------------------------------------------------
-// createCommitmentWithRetry
-// ---------------------------------------------------------------------------
-
 func TestCreateCommitmentWithRetry_Retries5xxThenSucceeds(t *testing.T) {
 	t.Parallel()
 	r := require.New(t)
@@ -322,10 +313,6 @@ func TestCreateCommitmentWithRetry_ContextCancellationStopsRetries(t *testing.T)
 
 	r.Error(err)
 }
-
-// ---------------------------------------------------------------------------
-// deleteCommitmentWithRetry
-// ---------------------------------------------------------------------------
 
 func TestDeleteCommitmentWithRetry_Retries5xxThenSucceeds(t *testing.T) {
 	t.Parallel()

--- a/castai/resource_commitment_test.go
+++ b/castai/resource_commitment_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -19,6 +20,7 @@ import (
 func TestAccCloudAgnostic_Commitment(t *testing.T) {
 	rName := fmt.Sprintf("%v-commitment-%v", ResourcePrefix, acctest.RandString(8))
 	cudID := acctest.RandStringFromCharSet(12, "0123456789")
+	organizationID := os.Getenv("ACCEPTANCE_TEST_ORGANIZATION_ID")
 	resourceName := "castai_commitment.test"
 
 	resource.Test(t, resource.TestCase{
@@ -27,7 +29,7 @@ func TestAccCloudAgnostic_Commitment(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Create with auto_assignment not set — server decides.
-				Config: testAccCommitmentConfig(rName, cudID, "INACTIVE", 1.0, false, false),
+				Config: testAccCommitmentConfig(rName, cudID, organizationID, "INACTIVE", 1.0, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
@@ -48,7 +50,7 @@ func TestAccCloudAgnostic_Commitment(t *testing.T) {
 			},
 			{
 				// Patch-path update: operational settings only.
-				Config: testAccCommitmentConfig(rName, cudID, "ACTIVE", 0.75, false, false),
+				Config: testAccCommitmentConfig(rName, cudID, organizationID, "ACTIVE", 0.75, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "autoscaling_status", "ACTIVE"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_usage", "0.75"),
@@ -56,21 +58,21 @@ func TestAccCloudAgnostic_Commitment(t *testing.T) {
 			},
 			{
 				// Upsert-path update: rename. ID must be preserved.
-				Config: testAccCommitmentConfig(rName+"-renamed", cudID, "ACTIVE", 0.75, false, false),
+				Config: testAccCommitmentConfig(rName+"-renamed", cudID, organizationID, "ACTIVE", 0.75, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rName+"-renamed"),
 				),
 			},
 			{
 				// Switch to explicit auto_assignment=false.
-				Config: testAccCommitmentConfig(rName+"-renamed", cudID, "ACTIVE", 0.75, true, false),
+				Config: testAccCommitmentConfig(rName+"-renamed", cudID, organizationID, "ACTIVE", 0.75, true, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "auto_assignment", "false"),
 				),
 			},
 			{
 				// Upsert-path update with explicit false: auto_assignment must stay false.
-				Config: testAccCommitmentConfig(rName+"-renamed-2", cudID, "ACTIVE", 0.75, true, false),
+				Config: testAccCommitmentConfig(rName+"-renamed-2", cudID, organizationID, "ACTIVE", 0.75, true, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rName+"-renamed-2"),
 					resource.TestCheckResourceAttr(resourceName, "auto_assignment", "false"),
@@ -92,7 +94,7 @@ func TestAccCloudAgnostic_Commitment(t *testing.T) {
 	})
 }
 
-func testAccCommitmentConfig(name, cudID, autoscalingStatus string, allowedUsage float64, setAutoAssignment bool, autoAssignment bool) string {
+func testAccCommitmentConfig(name, cudID, organizationID, autoscalingStatus string, allowedUsage float64, setAutoAssignment bool, autoAssignment bool) string {
 	autoAssignmentLine := ""
 	if setAutoAssignment {
 		autoAssignmentLine = fmt.Sprintf("auto_assignment = %v", autoAssignment)
@@ -100,6 +102,7 @@ func testAccCommitmentConfig(name, cudID, autoscalingStatus string, allowedUsage
 	return fmt.Sprintf(`
 resource "castai_commitment" "test" {
   name               = %[1]q
+  organization_id    = %[6]q
   cloud              = "GCP"
   region             = "us-central1"
   type               = "RESOURCE_CUD"
@@ -118,7 +121,7 @@ resource "castai_commitment" "test" {
     status    = "ACTIVE"
   }
 }
-`, name, cudID, autoscalingStatus, allowedUsage, autoAssignmentLine)
+`, name, cudID, autoscalingStatus, allowedUsage, autoAssignmentLine, organizationID)
 }
 
 // ---------------------------------------------------------------------------

--- a/castai/resource_commitment_test.go
+++ b/castai/resource_commitment_test.go
@@ -1,12 +1,19 @@
 package castai
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/require"
+
+	"github.com/castai/terraform-provider-castai/castai/sdk/pricing"
+	mock_pricing "github.com/castai/terraform-provider-castai/castai/sdk/pricing/mock"
 )
 
 func TestAccCloudAgnostic_Commitment(t *testing.T) {
@@ -113,3 +120,294 @@ resource "castai_commitment" "test" {
 }
 `, name, cudID, autoscalingStatus, allowedUsage, autoAssignmentLine)
 }
+
+// ---------------------------------------------------------------------------
+// Retry unit tests — mock-based tests for getCommitmentWithRetry,
+// createCommitmentWithRetry, and deleteCommitmentWithRetry.
+// ---------------------------------------------------------------------------
+
+// newCommitmentResourceWithMock creates a genericCommitmentResource whose
+// pricingClient is the supplied mock. All other ProviderConfig fields are
+// left zero — the retry helpers only touch pricingClient.
+func newCommitmentResourceWithMock(mockClient *mock_pricing.MockClientWithResponsesInterface) *genericCommitmentResource {
+	return &genericCommitmentResource{
+		client: &ProviderConfig{
+			pricingClient: mockClient,
+		},
+	}
+}
+
+func httpResp(status int) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getCommitmentWithRetry
+// ---------------------------------------------------------------------------
+
+func TestGetCommitmentWithRetry_Retries5xxThenSucceeds(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	mockClient := mock_pricing.NewMockClientWithResponsesInterface(ctrl)
+
+	orgID, commitmentID := "org-1", "commit-1"
+	commitment := &pricing.Commitment{Id: &commitmentID}
+
+	gomock.InOrder(
+		mockClient.EXPECT().
+			CommitmentsAPIGetCommitmentWithResponse(gomock.Any(), orgID, commitmentID).
+			Return(&pricing.CommitmentsAPIGetCommitmentResponse{
+				HTTPResponse: httpResp(http.StatusInternalServerError),
+				Body:         []byte("server error"),
+			}, nil),
+		mockClient.EXPECT().
+			CommitmentsAPIGetCommitmentWithResponse(gomock.Any(), orgID, commitmentID).
+			Return(&pricing.CommitmentsAPIGetCommitmentResponse{
+				HTTPResponse: httpResp(http.StatusOK),
+				JSON200:      commitment,
+			}, nil),
+	)
+
+	res := newCommitmentResourceWithMock(mockClient)
+	apiResp, err := res.getCommitmentWithRetry(context.Background(), orgID, commitmentID)
+
+	r.NoError(err)
+	r.NotNil(apiResp)
+	r.Equal(http.StatusOK, apiResp.StatusCode())
+	r.Equal(commitment, apiResp.JSON200)
+}
+
+func TestGetCommitmentWithRetry_4xxStopsImmediately(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	mockClient := mock_pricing.NewMockClientWithResponsesInterface(ctrl)
+
+	orgID, commitmentID := "org-1", "commit-1"
+
+	// 404 must NOT be retried — exactly one call.
+	mockClient.EXPECT().
+		CommitmentsAPIGetCommitmentWithResponse(gomock.Any(), orgID, commitmentID).
+		Return(&pricing.CommitmentsAPIGetCommitmentResponse{
+			HTTPResponse: httpResp(http.StatusNotFound),
+			Body:         []byte("not found"),
+		}, nil)
+
+	res := newCommitmentResourceWithMock(mockClient)
+	apiResp, err := res.getCommitmentWithRetry(context.Background(), orgID, commitmentID)
+
+	r.NoError(err)
+	r.NotNil(apiResp)
+	r.Equal(http.StatusNotFound, apiResp.StatusCode())
+}
+
+func TestGetCommitmentWithRetry_ContextCancellationStopsRetries(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	mockClient := mock_pricing.NewMockClientWithResponsesInterface(ctrl)
+
+	orgID, commitmentID := "org-1", "commit-1"
+
+	// Return 500 on every call so the retry loop would be infinite without
+	// context cancellation.
+	mockClient.EXPECT().
+		CommitmentsAPIGetCommitmentWithResponse(gomock.Any(), orgID, commitmentID).
+		Return(&pricing.CommitmentsAPIGetCommitmentResponse{
+			HTTPResponse: httpResp(http.StatusInternalServerError),
+			Body:         []byte("server error"),
+		}, nil).
+		AnyTimes()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately so backoff exits on the first check
+
+	res := newCommitmentResourceWithMock(mockClient)
+	apiResp, err := res.getCommitmentWithRetry(ctx, orgID, commitmentID)
+
+	// The error should be the context cancellation or the last 500 error
+	// wrapped by backoff — either way, the function must return.
+	r.Error(err)
+	// apiResp may be nil (if the retry function never ran) or the last 500
+	// response — the key invariant is that we returned and did not hang.
+	_ = apiResp
+}
+
+// ---------------------------------------------------------------------------
+// createCommitmentWithRetry
+// ---------------------------------------------------------------------------
+
+func TestCreateCommitmentWithRetry_Retries5xxThenSucceeds(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	mockClient := mock_pricing.NewMockClientWithResponsesInterface(ctrl)
+
+	orgID := "org-1"
+	input := pricing.CreateCommitmentInput{}
+	commitmentID := "commit-1"
+	commitment := &pricing.Commitment{Id: &commitmentID}
+
+	gomock.InOrder(
+		mockClient.EXPECT().
+			CommitmentsAPICreateCommitmentWithResponse(gomock.Any(), orgID, input).
+			Return(&pricing.CommitmentsAPICreateCommitmentResponse{
+				HTTPResponse: httpResp(http.StatusBadGateway),
+				Body:         []byte("bad gateway"),
+			}, nil),
+		mockClient.EXPECT().
+			CommitmentsAPICreateCommitmentWithResponse(gomock.Any(), orgID, input).
+			Return(&pricing.CommitmentsAPICreateCommitmentResponse{
+				HTTPResponse: httpResp(http.StatusOK),
+				JSON200:      commitment,
+			}, nil),
+	)
+
+	res := newCommitmentResourceWithMock(mockClient)
+	apiResp, err := res.createCommitmentWithRetry(context.Background(), orgID, input)
+
+	r.NoError(err)
+	r.NotNil(apiResp)
+	r.Equal(http.StatusOK, apiResp.StatusCode())
+	r.Equal(commitment, apiResp.JSON200)
+}
+
+func TestCreateCommitmentWithRetry_4xxStopsImmediately(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	mockClient := mock_pricing.NewMockClientWithResponsesInterface(ctrl)
+
+	orgID := "org-1"
+	input := pricing.CreateCommitmentInput{}
+
+	// 400 must NOT be retried.
+	mockClient.EXPECT().
+		CommitmentsAPICreateCommitmentWithResponse(gomock.Any(), orgID, input).
+		Return(&pricing.CommitmentsAPICreateCommitmentResponse{
+			HTTPResponse: httpResp(http.StatusBadRequest),
+			Body:         []byte("bad request"),
+		}, nil)
+
+	res := newCommitmentResourceWithMock(mockClient)
+	apiResp, err := res.createCommitmentWithRetry(context.Background(), orgID, input)
+
+	r.NoError(err)
+	r.NotNil(apiResp)
+	r.Equal(http.StatusBadRequest, apiResp.StatusCode())
+}
+
+func TestCreateCommitmentWithRetry_ContextCancellationStopsRetries(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	mockClient := mock_pricing.NewMockClientWithResponsesInterface(ctrl)
+
+	orgID := "org-1"
+	input := pricing.CreateCommitmentInput{}
+
+	mockClient.EXPECT().
+		CommitmentsAPICreateCommitmentWithResponse(gomock.Any(), orgID, input).
+		Return(&pricing.CommitmentsAPICreateCommitmentResponse{
+			HTTPResponse: httpResp(http.StatusServiceUnavailable),
+			Body:         []byte("unavailable"),
+		}, nil).
+		AnyTimes()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	res := newCommitmentResourceWithMock(mockClient)
+	_, err := res.createCommitmentWithRetry(ctx, orgID, input)
+
+	r.Error(err)
+}
+
+// ---------------------------------------------------------------------------
+// deleteCommitmentWithRetry
+// ---------------------------------------------------------------------------
+
+func TestDeleteCommitmentWithRetry_Retries5xxThenSucceeds(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	mockClient := mock_pricing.NewMockClientWithResponsesInterface(ctrl)
+
+	orgID, commitmentID := "org-1", "commit-1"
+
+	gomock.InOrder(
+		mockClient.EXPECT().
+			CommitmentsAPIDeleteCommitmentWithResponse(gomock.Any(), orgID, commitmentID).
+			Return(&pricing.CommitmentsAPIDeleteCommitmentResponse{
+				HTTPResponse: httpResp(http.StatusServiceUnavailable),
+				Body:         []byte("unavailable"),
+			}, nil),
+		mockClient.EXPECT().
+			CommitmentsAPIDeleteCommitmentWithResponse(gomock.Any(), orgID, commitmentID).
+			Return(&pricing.CommitmentsAPIDeleteCommitmentResponse{
+				HTTPResponse: httpResp(http.StatusOK),
+			}, nil),
+	)
+
+	res := newCommitmentResourceWithMock(mockClient)
+	apiResp, err := res.deleteCommitmentWithRetry(context.Background(), orgID, commitmentID)
+
+	r.NoError(err)
+	r.NotNil(apiResp)
+	r.Equal(http.StatusOK, apiResp.StatusCode())
+}
+
+func TestDeleteCommitmentWithRetry_4xxStopsImmediately(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	mockClient := mock_pricing.NewMockClientWithResponsesInterface(ctrl)
+
+	orgID, commitmentID := "org-1", "commit-1"
+
+	// 404 must NOT be retried — exactly one call.
+	mockClient.EXPECT().
+		CommitmentsAPIDeleteCommitmentWithResponse(gomock.Any(), orgID, commitmentID).
+		Return(&pricing.CommitmentsAPIDeleteCommitmentResponse{
+			HTTPResponse: httpResp(http.StatusNotFound),
+			Body:         []byte("not found"),
+		}, nil)
+
+	res := newCommitmentResourceWithMock(mockClient)
+	apiResp, err := res.deleteCommitmentWithRetry(context.Background(), orgID, commitmentID)
+
+	r.NoError(err)
+	r.NotNil(apiResp)
+	r.Equal(http.StatusNotFound, apiResp.StatusCode())
+}
+
+func TestDeleteCommitmentWithRetry_ContextCancellationStopsRetries(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	mockClient := mock_pricing.NewMockClientWithResponsesInterface(ctrl)
+
+	orgID, commitmentID := "org-1", "commit-1"
+
+	mockClient.EXPECT().
+		CommitmentsAPIDeleteCommitmentWithResponse(gomock.Any(), orgID, commitmentID).
+		Return(&pricing.CommitmentsAPIDeleteCommitmentResponse{
+			HTTPResponse: httpResp(http.StatusGatewayTimeout),
+			Body:         []byte("gateway timeout"),
+		}, nil).
+		AnyTimes()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	res := newCommitmentResourceWithMock(mockClient)
+	_, err := res.deleteCommitmentWithRetry(ctx, orgID, commitmentID)
+
+	r.Error(err)
+}
+
+

--- a/castai/resource_commitment_test.go
+++ b/castai/resource_commitment_test.go
@@ -125,10 +125,6 @@ resource "castai_commitment" "test" {
 // Retry unit tests — mock-based tests for getCommitmentWithRetry,
 // createCommitmentWithRetry, and deleteCommitmentWithRetry.
 // ---------------------------------------------------------------------------
-
-// newCommitmentResourceWithMock creates a genericCommitmentResource whose
-// pricingClient is the supplied mock. All other ProviderConfig fields are
-// left zero — the retry helpers only touch pricingClient.
 func newCommitmentResourceWithMock(mockClient *mock_pricing.MockClientWithResponsesInterface) *genericCommitmentResource {
 	return &genericCommitmentResource{
 		client: &ProviderConfig{
@@ -410,4 +406,90 @@ func TestDeleteCommitmentWithRetry_ContextCancellationStopsRetries(t *testing.T)
 	r.Error(err)
 }
 
+// ---------------------------------------------------------------------------
+// updateCommitmentWithRetry
+// ---------------------------------------------------------------------------
 
+func TestUpdateCommitmentWithRetry_Retries5xxThenSucceeds(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	mockClient := mock_pricing.NewMockClientWithResponsesInterface(ctrl)
+
+	orgID, commitmentID := "org-1", "commit-1"
+	input := pricing.UpdateCommitmentInput{}
+	commitment := &pricing.Commitment{Id: &commitmentID}
+
+	gomock.InOrder(
+		mockClient.EXPECT().
+			CommitmentsAPIUpdateCommitmentWithResponse(gomock.Any(), orgID, commitmentID, input).
+			Return(&pricing.CommitmentsAPIUpdateCommitmentResponse{
+				HTTPResponse: httpResp(http.StatusInternalServerError),
+				Body:         []byte("server error"),
+			}, nil),
+		mockClient.EXPECT().
+			CommitmentsAPIUpdateCommitmentWithResponse(gomock.Any(), orgID, commitmentID, input).
+			Return(&pricing.CommitmentsAPIUpdateCommitmentResponse{
+				HTTPResponse: httpResp(http.StatusOK),
+				JSON200:      commitment,
+			}, nil),
+	)
+
+	res := newCommitmentResourceWithMock(mockClient)
+	apiResp, err := res.updateCommitmentWithRetry(context.Background(), orgID, commitmentID, input)
+
+	r.NoError(err)
+	r.NotNil(apiResp)
+	r.Equal(http.StatusOK, apiResp.StatusCode())
+	r.Equal(commitment, apiResp.JSON200)
+}
+
+func TestUpdateCommitmentWithRetry_4xxStopsImmediately(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	mockClient := mock_pricing.NewMockClientWithResponsesInterface(ctrl)
+
+	orgID, commitmentID := "org-1", "commit-1"
+	input := pricing.UpdateCommitmentInput{}
+
+	mockClient.EXPECT().
+		CommitmentsAPIUpdateCommitmentWithResponse(gomock.Any(), orgID, commitmentID, input).
+		Return(&pricing.CommitmentsAPIUpdateCommitmentResponse{
+			HTTPResponse: httpResp(http.StatusBadRequest),
+			Body:         []byte("bad request"),
+		}, nil)
+
+	res := newCommitmentResourceWithMock(mockClient)
+	apiResp, err := res.updateCommitmentWithRetry(context.Background(), orgID, commitmentID, input)
+
+	r.NoError(err)
+	r.NotNil(apiResp)
+	r.Equal(http.StatusBadRequest, apiResp.StatusCode())
+}
+
+func TestUpdateCommitmentWithRetry_ContextCancellationStopsRetries(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	mockClient := mock_pricing.NewMockClientWithResponsesInterface(ctrl)
+
+	orgID, commitmentID := "org-1", "commit-1"
+	input := pricing.UpdateCommitmentInput{}
+
+	mockClient.EXPECT().
+		CommitmentsAPIUpdateCommitmentWithResponse(gomock.Any(), orgID, commitmentID, input).
+		Return(&pricing.CommitmentsAPIUpdateCommitmentResponse{
+			HTTPResponse: httpResp(http.StatusServiceUnavailable),
+			Body:         []byte("unavailable"),
+		}, nil).
+		AnyTimes()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	res := newCommitmentResourceWithMock(mockClient)
+	_, err := res.updateCommitmentWithRetry(ctx, orgID, commitmentID, input)
+
+	r.Error(err)
+}

--- a/docs/resources/commitment.md
+++ b/docs/resources/commitment.md
@@ -3,12 +3,12 @@
 page_title: "castai_commitment Resource - terraform-provider-castai"
 subcategory: ""
 description: |-
-  Manages a single CAST AI commitment (reserved instance, savings plan, CUD, capacity block or capacity reservation) via the pricing v1beta Commitments API. For bulk management, use for_each over a decoded JSON/CSV file. Note: the underlying API is in beta. Do not manage commitments with Terraform in organizations where the same commitments are synced automatically via cloud integrations, as the sync will overwrite Terraform-managed values.
+  Manages a single CAST AI commitment (reserved instance, savings plan, CUD, capacity block or capacity reservation) via the pricing v1beta Commitments API. For bulk management, use for_each — see the examples/ directory.
 ---
 
 # castai_commitment (Resource)
 
-Manages a single CAST AI commitment (reserved instance, savings plan, CUD, capacity block or capacity reservation) via the pricing v1beta Commitments API. For bulk management, use for_each over a decoded JSON/CSV file. Note: the underlying API is in beta. Do not manage commitments with Terraform in organizations where the same commitments are synced automatically via cloud integrations, as the sync will overwrite Terraform-managed values.
+Manages a single CAST AI commitment (reserved instance, savings plan, CUD, capacity block or capacity reservation) via the pricing v1beta Commitments API. For bulk management, use for_each — see the examples/ directory.
 
 ## Example Usage
 
@@ -139,7 +139,7 @@ resource "castai_commitment" "bulk_gcp_cuds" {
 ### Optional
 
 - `allowed_usage` (Number) Allowed usage of the commitment (0.0-1.0). 1.0 means 100%. Defaults to 1.0.
-- `auto_assignment` (Boolean) Auto-assign the commitment to all matching clusters in the commitment's region.
+- `auto_assignment` (Boolean) Auto-assign the commitment to all matching clusters in the commitment's region. If not set, the server's auto-assignment logic determines the value at creation time. Set to false to explicitly disable auto-assignment. Not supported for CAPACITY_BLOCK or targeted ON_DEMAND_CAPACITY_RESERVATION commitments.
 - `autoscaling_status` (String) Controls whether the autoscaler can use this commitment. One of: ACTIVE, INACTIVE. Defaults to INACTIVE (matches the API default); set to ACTIVE for the autoscaler to use the commitment.
 - `aws_capacity_block_details` (Attributes) AWS Capacity Block details. Required when type is CAPACITY_BLOCK. (see [below for nested schema](#nestedatt--aws_capacity_block_details))
 - `aws_odcr_details` (Attributes) AWS On-Demand Capacity Reservation details. Required when type is ON_DEMAND_CAPACITY_RESERVATION on AWS. (see [below for nested schema](#nestedatt--aws_odcr_details))
@@ -296,6 +296,7 @@ Optional:
 - `local_ssds` (Attributes List) Local SSD disks reserved VMs must match exactly. (see [below for nested schema](#nestedatt--gcp_capacity_reservation_details--local_ssds))
 - `min_cpu_platform` (String) Minimum CPU platform the reserved VMs require (e.g. Intel Cascade Lake).
 - `project_id` (String) GCP project ID that owns the reservation.
+- `self_link` (String) Server-defined URL for the reservation (e.g. https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/reservations/my-reservation).
 - `share_settings` (Attributes) Reservation sharing settings. (see [below for nested schema](#nestedatt--gcp_capacity_reservation_details--share_settings))
 - `specific_reservation_required` (Boolean) Whether the reservation requires specific reservation affinity.
 - `state` (String) Runtime state of the reservation (e.g. READY).


### PR DESCRIPTION
Without retries requests were occasionally failing  - with retries tested with 2000 commitments and it worked fine.