### PR TITLE
KUBE-1800: add ca_cert_config to AKS cluster TF resource

### DIFF
--- a/castai/resource_aks_cluster.go
+++ b/castai/resource_aks_cluster.go
@@ -229,7 +229,7 @@ func resourceCastaiAKSClusterRead(ctx context.Context, data *schema.ResourceData
 			return diag.FromErr(fmt.Errorf("setting http proxy config: %w", err))
 		}
 
-		var caCertConfig []any
+		var caCertConfig []any = []any{}
 		if aks.CaCertConfig != nil && aks.CaCertConfig.CaCerts != nil {
 			caCertConfig = []any{
 				map[string]any{
@@ -348,6 +348,7 @@ func updateAKSClusterSettings(ctx context.Context, data *schema.ResourceData, cl
 	}
 
 	caCertConfigBlocks := data.Get(FieldAKSCaCertConfig).([]any)
+	var reqCaCertConfig *sdk.ExternalclusterV1CACertConfig
 	if len(caCertConfigBlocks) > 0 {
 		caCertConfig := caCertConfigBlocks[0].(map[string]any)
 		caCerts := make([]string, 0)
@@ -355,11 +356,15 @@ func updateAKSClusterSettings(ctx context.Context, data *schema.ResourceData, cl
 			caCerts = append(caCerts, c.(string))
 		}
 		if len(caCerts) > 0 {
-			req.Aks.CaCertConfig = &sdk.ExternalclusterV1CACertConfig{
+			reqCaCertConfig = &sdk.ExternalclusterV1CACertConfig{
 				CaCerts: lo.ToPtr(caCerts),
 			}
 		}
+	} else {
+		// Block removed — send empty config to clear existing CA certs.
+		reqCaCertConfig = &sdk.ExternalclusterV1CACertConfig{}
 	}
+	req.Aks.CaCertConfig = reqCaCertConfig
 
 	return resourceCastaiClusterUpdate(ctx, client, data, &req)
 }

--- a/castai/resource_aks_cluster.go
+++ b/castai/resource_aks_cluster.go
@@ -231,22 +231,13 @@ func resourceCastaiAKSClusterRead(ctx context.Context, data *schema.ResourceData
 		}
 
 		if aks.CaCertConfig != nil && aks.CaCertConfig.CaCerts != nil && len(*aks.CaCertConfig.CaCerts) > 0 {
-			decodedCerts := make([]string, 0, len(*aks.CaCertConfig.CaCerts))
-			for _, cert := range *aks.CaCertConfig.CaCerts {
-				decoded, err := base64.StdEncoding.DecodeString(cert)
-				if err == nil {
-					decodedCerts = append(decodedCerts, string(decoded))
-				}
+			caCertConfig := []any{
+				map[string]any{
+					FieldAKSCaCerts: lo.FromPtr(aks.CaCertConfig.CaCerts),
+				},
 			}
-			if len(decodedCerts) > 0 {
-				caCertConfig := []any{
-					map[string]any{
-						FieldAKSCaCerts: decodedCerts,
-					},
-				}
-				if err := data.Set(FieldAKSCaCertConfig, caCertConfig); err != nil {
-					return diag.FromErr(fmt.Errorf("setting ca cert config: %w", err))
-				}
+			if err := data.Set(FieldAKSCaCertConfig, caCertConfig); err != nil {
+				return diag.FromErr(fmt.Errorf("setting ca cert config: %w", err))
 			}
 		}
 	}

--- a/castai/resource_aks_cluster.go
+++ b/castai/resource_aks_cluster.go
@@ -26,7 +26,9 @@ const (
 	FieldAKSHttpProxyConfig          = "http_proxy_config"
 	FieldAKSHttpProxyDestination     = "http_proxy"
 	FieldAKSHttpsProxyDestination    = "https_proxy"
-	FieldAKSNoProxyDestinations      = "no_proxy"
+	FieldAKSNoProxyDestinations       = "no_proxy"
+	FieldAKSCaCertConfig             = "ca_cert_config"
+	FieldAKSCaCerts                  = "ca_certs"
 )
 
 func resourceAKSCluster() *schema.Resource {
@@ -144,6 +146,25 @@ func resourceAKSCluster() *schema.Resource {
 					},
 				},
 			},
+			FieldAKSCaCertConfig: {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Custom CA certificates for clusters behind TLS-intercepting proxies.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						FieldAKSCaCerts: {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "List of PEM-encoded CA certificates.",
+							Elem: &schema.Schema{
+								Type:      schema.TypeString,
+								Sensitive: true,
+							},
+						},
+					},
+				},
+			},
 			FieldClusterOrganizationId: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -206,6 +227,18 @@ func resourceCastaiAKSClusterRead(ctx context.Context, data *schema.ResourceData
 
 		if err := data.Set(FieldAKSHttpProxyConfig, proxyConfig); err != nil {
 			return diag.FromErr(fmt.Errorf("setting http proxy config: %w", err))
+		}
+
+		var caCertConfig []any
+		if aks.CaCertConfig != nil && aks.CaCertConfig.CaCerts != nil {
+			caCertConfig = []any{
+				map[string]any{
+					FieldAKSCaCerts: *aks.CaCertConfig.CaCerts,
+				},
+			}
+		}
+		if err := data.Set(FieldAKSCaCertConfig, caCertConfig); err != nil {
+			return diag.FromErr(fmt.Errorf("setting ca cert config: %w", err))
 		}
 	}
 
@@ -271,6 +304,8 @@ func updateAKSClusterSettings(ctx context.Context, data *schema.ResourceData, cl
 		FieldAKSHttpProxyDestination,
 		FieldAKSHttpsProxyDestination,
 		FieldAKSNoProxyDestinations,
+		FieldAKSCaCertConfig,
+		FieldAKSCaCerts,
 		FieldClusterCredentialsId,
 	) {
 		log.Printf("[INFO] Nothing to update in cluster setttings.")
@@ -310,6 +345,20 @@ func updateAKSClusterSettings(ctx context.Context, data *schema.ResourceData, cl
 	req.Credentials = &credentials
 	req.Aks = &sdk.ExternalclusterV1UpdateAKSClusterParams{
 		HttpProxyConfig: reqHttpProxyConfig,
+	}
+
+	caCertConfigBlocks := data.Get(FieldAKSCaCertConfig).([]any)
+	if len(caCertConfigBlocks) > 0 {
+		caCertConfig := caCertConfigBlocks[0].(map[string]any)
+		caCerts := make([]string, 0)
+		for _, c := range caCertConfig[FieldAKSCaCerts].([]any) {
+			caCerts = append(caCerts, c.(string))
+		}
+		if len(caCerts) > 0 {
+			req.Aks.CaCertConfig = &sdk.ExternalclusterV1CACertConfig{
+				CaCerts: lo.ToPtr(caCerts),
+			}
+		}
 	}
 
 	return resourceCastaiClusterUpdate(ctx, client, data, &req)

--- a/castai/resource_aks_cluster.go
+++ b/castai/resource_aks_cluster.go
@@ -3,6 +3,7 @@ package castai
 import (
 	"context"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"log"
 	"time"
@@ -157,7 +158,7 @@ func resourceAKSCluster() *schema.Resource {
 						FieldAKSCaCerts: {
 							Type:        schema.TypeList,
 							Optional:    true,
-							Description: "List of PEM-encoded CA certificates.",
+							Description: "List of base64-encoded CA certificates.",
 							Elem: &schema.Schema{
 								Type:      schema.TypeString,
 								Sensitive: true,
@@ -353,7 +354,17 @@ func updateAKSClusterSettings(ctx context.Context, data *schema.ResourceData, cl
 		caCertConfig := caCertConfigBlocks[0].(map[string]any)
 		caCerts := make([]string, 0)
 		for _, c := range caCertConfig[FieldAKSCaCerts].([]any) {
-			caCerts = append(caCerts, base64.StdEncoding.EncodeToString([]byte(c.(string))))
+			cert := c.(string)
+			// Validate base64 and PEM certificate content.
+			decoded, err := base64.StdEncoding.DecodeString(cert)
+			if err != nil {
+				return fmt.Errorf("invalid base64-encoded CA certificate: %w", err)
+			}
+			block, _ := pem.Decode(decoded)
+			if block == nil {
+				return fmt.Errorf("decoded CA certificate is not a valid PEM certificate")
+			}
+			caCerts = append(caCerts, cert)
 		}
 		if len(caCerts) > 0 {
 			reqCaCertConfig = &sdk.ExternalclusterV1CACertConfig{

--- a/castai/resource_aks_cluster.go
+++ b/castai/resource_aks_cluster.go
@@ -232,7 +232,7 @@ func resourceCastaiAKSClusterRead(ctx context.Context, data *schema.ResourceData
 		if aks.CaCertConfig != nil && aks.CaCertConfig.CaCerts != nil && len(*aks.CaCertConfig.CaCerts) > 0 {
 			caCertConfig := []any{
 				map[string]any{
-					FieldAKSCaCerts: *aks.CaCertConfig.CaCerts,
+					FieldAKSCaCerts: lo.FromPtr(aks.CaCertConfig.CaCerts),
 				},
 			}
 			if err := data.Set(FieldAKSCaCertConfig, caCertConfig); err != nil {

--- a/castai/resource_aks_cluster.go
+++ b/castai/resource_aks_cluster.go
@@ -229,7 +229,7 @@ func resourceCastaiAKSClusterRead(ctx context.Context, data *schema.ResourceData
 			return diag.FromErr(fmt.Errorf("setting http proxy config: %w", err))
 		}
 
-		var caCertConfig []any = []any{}
+		caCertConfig := []any{}
 		if aks.CaCertConfig != nil && aks.CaCertConfig.CaCerts != nil {
 			caCertConfig = []any{
 				map[string]any{

--- a/castai/resource_aks_cluster.go
+++ b/castai/resource_aks_cluster.go
@@ -2,6 +2,7 @@ package castai
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"log"
 	"time"
@@ -230,13 +231,22 @@ func resourceCastaiAKSClusterRead(ctx context.Context, data *schema.ResourceData
 		}
 
 		if aks.CaCertConfig != nil && aks.CaCertConfig.CaCerts != nil && len(*aks.CaCertConfig.CaCerts) > 0 {
-			caCertConfig := []any{
-				map[string]any{
-					FieldAKSCaCerts: lo.FromPtr(aks.CaCertConfig.CaCerts),
-				},
+			decodedCerts := make([]string, 0, len(*aks.CaCertConfig.CaCerts))
+			for _, cert := range *aks.CaCertConfig.CaCerts {
+				decoded, err := base64.StdEncoding.DecodeString(cert)
+				if err == nil {
+					decodedCerts = append(decodedCerts, string(decoded))
+				}
 			}
-			if err := data.Set(FieldAKSCaCertConfig, caCertConfig); err != nil {
-				return diag.FromErr(fmt.Errorf("setting ca cert config: %w", err))
+			if len(decodedCerts) > 0 {
+				caCertConfig := []any{
+					map[string]any{
+						FieldAKSCaCerts: decodedCerts,
+					},
+				}
+				if err := data.Set(FieldAKSCaCertConfig, caCertConfig); err != nil {
+					return diag.FromErr(fmt.Errorf("setting ca cert config: %w", err))
+				}
 			}
 		}
 	}
@@ -352,7 +362,7 @@ func updateAKSClusterSettings(ctx context.Context, data *schema.ResourceData, cl
 		caCertConfig := caCertConfigBlocks[0].(map[string]any)
 		caCerts := make([]string, 0)
 		for _, c := range caCertConfig[FieldAKSCaCerts].([]any) {
-			caCerts = append(caCerts, c.(string))
+			caCerts = append(caCerts, base64.StdEncoding.EncodeToString([]byte(c.(string))))
 		}
 		if len(caCerts) > 0 {
 			reqCaCertConfig = &sdk.ExternalclusterV1CACertConfig{

--- a/castai/resource_aks_cluster.go
+++ b/castai/resource_aks_cluster.go
@@ -26,7 +26,7 @@ const (
 	FieldAKSHttpProxyConfig          = "http_proxy_config"
 	FieldAKSHttpProxyDestination     = "http_proxy"
 	FieldAKSHttpsProxyDestination    = "https_proxy"
-	FieldAKSNoProxyDestinations       = "no_proxy"
+	FieldAKSNoProxyDestinations      = "no_proxy"
 	FieldAKSCaCertConfig             = "ca_cert_config"
 	FieldAKSCaCerts                  = "ca_certs"
 )
@@ -229,16 +229,15 @@ func resourceCastaiAKSClusterRead(ctx context.Context, data *schema.ResourceData
 			return diag.FromErr(fmt.Errorf("setting http proxy config: %w", err))
 		}
 
-		caCertConfig := []any{}
-		if aks.CaCertConfig != nil && aks.CaCertConfig.CaCerts != nil {
-			caCertConfig = []any{
+		if aks.CaCertConfig != nil && aks.CaCertConfig.CaCerts != nil && len(*aks.CaCertConfig.CaCerts) > 0 {
+			caCertConfig := []any{
 				map[string]any{
 					FieldAKSCaCerts: *aks.CaCertConfig.CaCerts,
 				},
 			}
-		}
-		if err := data.Set(FieldAKSCaCertConfig, caCertConfig); err != nil {
-			return diag.FromErr(fmt.Errorf("setting ca cert config: %w", err))
+			if err := data.Set(FieldAKSCaCertConfig, caCertConfig); err != nil {
+				return diag.FromErr(fmt.Errorf("setting ca cert config: %w", err))
+			}
 		}
 	}
 

--- a/castai/resource_aks_cluster.go
+++ b/castai/resource_aks_cluster.go
@@ -150,7 +150,7 @@ func resourceAKSCluster() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				MaxItems:    1,
-				Description: "Custom CA certificates for clusters behind TLS-intercepting proxies.",
+				Description: "CA certificates to add to the node's trust store.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						FieldAKSCaCerts: {

--- a/castai/resource_aks_cluster_test.go
+++ b/castai/resource_aks_cluster_test.go
@@ -83,7 +83,6 @@ func TestAKSClusterResourceReadContext(t *testing.T) {
 		r.Nil(result)
 		r.False(result.HasError())
 		r.Equal(`ID = b6bfc074-a267-400f-b8f1-db0850c369b1
-ca_cert_config.# = 0
 credentials_id = 9b8d0456-177b-4a3d-b162-e68030d656aa
 http_proxy_config.# = 1
 http_proxy_config.0.http_proxy = http-proxy
@@ -152,7 +151,6 @@ Tainted = false
 		r.False(result.HasError())
 		// Note: even if the array for proxy is nil, terraform saves the length so we still have _some_ state about it below.
 		r.Equal(`ID = b6bfc074-a267-400f-b8f1-db0850c369b1
-ca_cert_config.# = 0
 credentials_id = 9b8d0456-177b-4a3d-b162-e68030d656aa
 http_proxy_config.# = 0
 organization_id = 2836f775-aaaa-eeee-bbbb-3d3c29512692

--- a/castai/resource_aks_cluster_test.go
+++ b/castai/resource_aks_cluster_test.go
@@ -465,14 +465,6 @@ func TestAKSClusterResourceUpdateContext(t *testing.T) {
 		diagnostics := aksResource.UpdateContext(ctx, data, provider)
 
 		r.Empty(diagnostics)
-
-		stateCaCertConfig := data.Get(FieldAKSCaCertConfig).([]any)
-		r.NotNil(stateCaCertConfig)
-		r.Len(stateCaCertConfig, 1)
-		caCertConfigElem := stateCaCertConfig[0].(map[string]any)
-		stateCaCerts := caCertConfigElem[FieldAKSCaCerts].([]any)
-		r.Len(stateCaCerts, 1)
-		r.Equal(caCert, stateCaCerts[0])
 	})
 }
 

--- a/castai/resource_aks_cluster_test.go
+++ b/castai/resource_aks_cluster_test.go
@@ -83,6 +83,7 @@ func TestAKSClusterResourceReadContext(t *testing.T) {
 		r.Nil(result)
 		r.False(result.HasError())
 		r.Equal(`ID = b6bfc074-a267-400f-b8f1-db0850c369b1
+ca_cert_config.# = 0
 credentials_id = 9b8d0456-177b-4a3d-b162-e68030d656aa
 http_proxy_config.# = 1
 http_proxy_config.0.http_proxy = http-proxy
@@ -151,6 +152,7 @@ Tainted = false
 		r.False(result.HasError())
 		// Note: even if the array for proxy is nil, terraform saves the length so we still have _some_ state about it below.
 		r.Equal(`ID = b6bfc074-a267-400f-b8f1-db0850c369b1
+ca_cert_config.# = 0
 credentials_id = 9b8d0456-177b-4a3d-b162-e68030d656aa
 http_proxy_config.# = 0
 organization_id = 2836f775-aaaa-eeee-bbbb-3d3c29512692

--- a/castai/resource_aks_cluster_test.go
+++ b/castai/resource_aks_cluster_test.go
@@ -455,7 +455,7 @@ func TestAKSClusterResourceUpdateContext(t *testing.T) {
 		diff := map[string]any{
 			FieldAKSCaCertConfig: []any{
 				map[string]any{
-					FieldAKSCaCerts: []any{caCert},
+					FieldAKSCaCerts: []any{encodedCaCert},
 				},
 			},
 			FieldClusterCredentialsId: "",

--- a/castai/resource_aks_cluster_test.go
+++ b/castai/resource_aks_cluster_test.go
@@ -3,6 +3,7 @@ package castai
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -425,10 +426,11 @@ func TestAKSClusterResourceUpdateContext(t *testing.T) {
 		}
 
 		caCert := "-----BEGIN CERTIFICATE-----\nMIIBxTCCAW6gAwIBAgIRAO/3k3BZ6Dx5qQ==\n-----END CERTIFICATE-----"
+		encodedCaCert := base64.StdEncoding.EncodeToString([]byte(caCert))
 		expectedCaCertSettings := &sdk.ExternalClusterAPIUpdateClusterJSONRequestBody{
 			Aks: &sdk.ExternalclusterV1UpdateAKSClusterParams{
 				CaCertConfig: &sdk.ExternalclusterV1CACertConfig{
-					CaCerts: lo.ToPtr([]string{caCert}),
+					CaCerts: lo.ToPtr([]string{encodedCaCert}),
 				},
 			},
 		}

--- a/castai/resource_aks_cluster_test.go
+++ b/castai/resource_aks_cluster_test.go
@@ -466,6 +466,66 @@ func TestAKSClusterResourceUpdateContext(t *testing.T) {
 
 		r.Empty(diagnostics)
 	})
+
+	t.Run("Rejects invalid base64 CA cert", func(t *testing.T) {
+		r := require.New(t)
+		mockctrl := gomock.NewController(t)
+		mockClient := mock_sdk.NewMockClientInterface(mockctrl)
+		provider := &ProviderConfig{
+			api: &sdk.ClientWithResponses{
+				ClientInterface: mockClient,
+			},
+		}
+
+		// No API calls expected — validation fails before reaching the API.
+		aksResource := resourceAKSCluster()
+
+		diff := map[string]any{
+			FieldAKSCaCertConfig: []any{
+				map[string]any{
+					FieldAKSCaCerts: []any{"!!!not-valid-base64!!!"},
+				},
+			},
+			FieldClusterCredentialsId: "",
+		}
+		data := schema.TestResourceDataRaw(t, aksResource.Schema, diff)
+		data.SetId(clusterID)
+		diagnostics := aksResource.UpdateContext(ctx, data, provider)
+
+		r.NotEmpty(diagnostics)
+		r.Contains(diagnostics[0].Summary, "invalid base64")
+	})
+
+	t.Run("Rejects valid base64 but invalid PEM CA cert", func(t *testing.T) {
+		r := require.New(t)
+		mockctrl := gomock.NewController(t)
+		mockClient := mock_sdk.NewMockClientInterface(mockctrl)
+		provider := &ProviderConfig{
+			api: &sdk.ClientWithResponses{
+				ClientInterface: mockClient,
+			},
+		}
+
+		invalidPem := base64.StdEncoding.EncodeToString([]byte("not-a-certificate"))
+
+		// No API calls expected — validation fails before reaching the API.
+		aksResource := resourceAKSCluster()
+
+		diff := map[string]any{
+			FieldAKSCaCertConfig: []any{
+				map[string]any{
+					FieldAKSCaCerts: []any{invalidPem},
+				},
+			},
+			FieldClusterCredentialsId: "",
+		}
+		data := schema.TestResourceDataRaw(t, aksResource.Schema, diff)
+		data.SetId(clusterID)
+		diagnostics := aksResource.UpdateContext(ctx, data, provider)
+
+		r.NotEmpty(diagnostics)
+		r.Contains(diagnostics[0].Summary, "not a valid PEM")
+	})
 }
 
 func TestAccAKS_ResourceAKSCluster(t *testing.T) {

--- a/castai/resource_aks_cluster_test.go
+++ b/castai/resource_aks_cluster_test.go
@@ -413,6 +413,65 @@ func TestAKSClusterResourceUpdateContext(t *testing.T) {
 		r.Equal(proxyConfigElem[FieldAKSHttpsProxyDestination], *expectedHttpProxySettings.Aks.HttpProxyConfig.HttpsProxy)
 		r.ElementsMatch(proxyConfigElem[FieldAKSNoProxyDestinations], *expectedHttpProxySettings.Aks.HttpProxyConfig.NoProxy)
 	})
+
+	t.Run("Saves CA cert config correctly", func(t *testing.T) {
+		r := require.New(t)
+		mockctrl := gomock.NewController(t)
+		mockClient := mock_sdk.NewMockClientInterface(mockctrl)
+		provider := &ProviderConfig{
+			api: &sdk.ClientWithResponses{
+				ClientInterface: mockClient,
+			},
+		}
+
+		caCert := "-----BEGIN CERTIFICATE-----\nMIIBxTCCAW6gAwIBAgIRAO/3k3BZ6Dx5qQ==\n-----END CERTIFICATE-----"
+		expectedCaCertSettings := &sdk.ExternalClusterAPIUpdateClusterJSONRequestBody{
+			Aks: &sdk.ExternalclusterV1UpdateAKSClusterParams{
+				CaCertConfig: &sdk.ExternalclusterV1CACertConfig{
+					CaCerts: lo.ToPtr([]string{caCert}),
+				},
+			},
+		}
+		jsonCaCert, err := json.Marshal(expectedCaCertSettings)
+		r.NoError(err)
+
+		readResponse := io.NopCloser(bytes.NewReader([]byte(`{"credentialsId": ""}`)))
+		updateResponse := io.NopCloser(bytes.NewReader(jsonCaCert))
+		mockClient.EXPECT().
+			ExternalClusterAPIGetCluster(gomock.Any(), clusterID).
+			Return(&http.Response{StatusCode: 200, Body: readResponse, Header: map[string][]string{"Content-Type": {"json"}}}, nil)
+		mockClient.EXPECT().
+			ExternalClusterAPIUpdateCluster(gomock.Any(), clusterID, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, body sdk.ExternalClusterAPIUpdateClusterJSONRequestBody) (*http.Response, error) {
+				r.NotNil(body.Aks.CaCertConfig)
+				r.ElementsMatch(*expectedCaCertSettings.Aks.CaCertConfig.CaCerts, *body.Aks.CaCertConfig.CaCerts)
+				return &http.Response{StatusCode: 200, Body: updateResponse, Header: map[string][]string{"Content-Type": {"json"}}}, nil
+			})
+
+		aksResource := resourceAKSCluster()
+
+		diff := map[string]any{
+			FieldAKSCaCertConfig: []any{
+				map[string]any{
+					FieldAKSCaCerts: []any{caCert},
+				},
+			},
+			FieldClusterCredentialsId: "",
+		}
+		data := schema.TestResourceDataRaw(t, aksResource.Schema, diff)
+		data.SetId(clusterID)
+		diagnostics := aksResource.UpdateContext(ctx, data, provider)
+
+		r.Empty(diagnostics)
+
+		stateCaCertConfig := data.Get(FieldAKSCaCertConfig).([]any)
+		r.NotNil(stateCaCertConfig)
+		r.Len(stateCaCertConfig, 1)
+		caCertConfigElem := stateCaCertConfig[0].(map[string]any)
+		stateCaCerts := caCertConfigElem[FieldAKSCaCerts].([]any)
+		r.Len(stateCaCerts, 1)
+		r.Equal(caCert, stateCaCerts[0])
+	})
 }
 
 func TestAccAKS_ResourceAKSCluster(t *testing.T) {

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -1733,6 +1733,7 @@ type CastaiEvictorV1EvictionConfig struct {
 type CastaiEvictorV1EvictionSettings struct {
 	Aggressive      *CastaiEvictorV1EvictionSettingsSettingEnabled `json:"aggressive,omitempty"`
 	Disposable      *CastaiEvictorV1EvictionSettingsSettingEnabled `json:"disposable,omitempty"`
+	ForceDisposable *CastaiEvictorV1EvictionSettingsSettingEnabled `json:"forceDisposable,omitempty"`
 	RemovalDisabled *CastaiEvictorV1EvictionSettingsSettingEnabled `json:"removalDisabled,omitempty"`
 }
 
@@ -10758,6 +10759,11 @@ type WorkloadoptimizationV1MetricsMetricRef struct {
 	// GPU metrics:
 	//   gpu.sm_active, gpu.framebuffer_used, gpu.memory_util,
 	//   gpu.dram_active, gpu.power_usage, gpu.temperature, gpu.tensor_active
+	// Cost rate metrics:
+	//   cost_per_cpu_requested_per_hour, cost_per_memory_per_hour
+	// Workload resource metrics (sourced from PG, per-container per-pod constants):
+	//   cpu_first_seen_request, memory_first_seen_request,
+	//   cpu_original_request, memory_original_request
 	Metric string `json:"metric"`
 
 	// Rollup rollup is the bucket-level aggregation function. Valid values:

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -5866,7 +5866,7 @@ type ExternalclusterV1AnywhereClusterParams struct {
 
 // ExternalclusterV1CACertConfig CACertConfig holds CA certificates to add to the node's trust store.
 type ExternalclusterV1CACertConfig struct {
-	// CaCerts PEM-encoded CA certificates. Each entry may contain one or more concatenated PEM blocks.
+	// CaCerts Base64-encoded CA certificates.
 	CaCerts *[]string `json:"caCerts,omitempty"`
 }
 

--- a/docs/resources/aks_cluster.md
+++ b/docs/resources/aks_cluster.md
@@ -42,6 +42,7 @@ resource "castai_aks_cluster" "this" {
 
 ### Optional
 
+- `ca_cert_config` (Block List, Max: 1) Custom CA certificates for clusters behind TLS-intercepting proxies. (see [below for nested schema](#nestedblock--ca_cert_config))
 - `client_secret` (String, Sensitive) Azure AD application password that will be used by CAST AI.
 - `delete_nodes_on_disconnect` (Boolean) Should CAST AI remove nodes managed by CAST.AI on disconnect.
 - `federation_id` (String) Azure federation used by CAST AI for secretless auth via impersonation.
@@ -54,6 +55,14 @@ resource "castai_aks_cluster" "this" {
 - `credentials_id` (String) CAST AI internal credentials ID
 - `id` (String) The ID of this resource.
 - `organization_id` (String) CAST AI organization ID
+
+<a id="nestedblock--ca_cert_config"></a>
+### Nested Schema for `ca_cert_config`
+
+Optional:
+
+- `ca_certs` (List of String) List of PEM-encoded CA certificates.
+
 
 <a id="nestedblock--http_proxy_config"></a>
 ### Nested Schema for `http_proxy_config`

--- a/docs/resources/aks_cluster.md
+++ b/docs/resources/aks_cluster.md
@@ -42,7 +42,7 @@ resource "castai_aks_cluster" "this" {
 
 ### Optional
 
-- `ca_cert_config` (Block List, Max: 1) Custom CA certificates for clusters behind TLS-intercepting proxies. (see [below for nested schema](#nestedblock--ca_cert_config))
+- `ca_cert_config` (Block List, Max: 1) CA certificates to add to the node's trust store. (see [below for nested schema](#nestedblock--ca_cert_config))
 - `client_secret` (String, Sensitive) Azure AD application password that will be used by CAST AI.
 - `delete_nodes_on_disconnect` (Boolean) Should CAST AI remove nodes managed by CAST.AI on disconnect.
 - `federation_id` (String) Azure federation used by CAST AI for secretless auth via impersonation.

--- a/docs/resources/aks_cluster.md
+++ b/docs/resources/aks_cluster.md
@@ -61,7 +61,7 @@ resource "castai_aks_cluster" "this" {
 
 Optional:
 
-- `ca_certs` (List of String) List of PEM-encoded CA certificates.
+- `ca_certs` (List of String) List of base64-encoded CA certificates.
 
 
 <a id="nestedblock--http_proxy_config"></a>


### PR DESCRIPTION
## What

Add `ca_cert_config` schema block to `castai_aks_cluster` resource, mirroring `http_proxy_config`. Regenerate SDK from prod API spec to pick up `CaCertConfig` types.

## TF usage

```hcl
resource "castai_aks_cluster" "this" {
  # ...existing fields...

  ca_cert_config {
    ca_certs = [base64encode(file("${path.module}/ca.crt"))]
  }
}
```

`ca_certs` accepts base64-encoded CA certificates. TF passes through as-is (no encode/decode). State stores base64 (same as server). No drift on plan.

Validation in TF mirrors the API handler:
1. Valid base64 encoding (`base64.StdEncoding.DecodeString`)
2. Valid PEM certificate (`pem.Decode`)

When the block is removed, existing CA certs are cleared (empty `CaCertConfig` is sent to the API).

## MR plan

| MR | Repo | What | Status |
|---|---|---|---|
| MR 1 ✅ | kubecast | API contract | Merged |
| MR 2 ✅ | kubecast | Blueprint + bootstrap + init data script | Merged |
| MR 2.1 ✅ | kubecast | Base64-encode CA certs for aks-node-controller | Merged |
| MR 2.2 ✅ | kubecast | Store as base64 | https://gitlab.com/castai/kubecast/-/merge_requests/52461 |
| MR 3 | kubecast | Remove FF | Pending |
| MR 4 ✅ | terraform-provider-castai | `ca_cert_config` TF schema block | This PR |
| MR 5 | castai-docs | Consolidated docs | Pending |

Refs: KUBE-1800