### PR TITLE
CID-1090 clean up stale SSO connections in acceptance test

### DIFF
--- a/castai/resource_sso_connection_test.go
+++ b/castai/resource_sso_connection_test.go
@@ -64,7 +64,11 @@ func TestAccCloudAgnostic_ResourceSSOConnection(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
-			client := testAccProvider.Meta().(*ProviderConfig).api
+			meta := testAccProvider.Meta()
+			if meta == nil {
+				return
+			}
+			client := meta.(*ProviderConfig).api
 			if err := sweepSSOConnection(ctx, client); err != nil {
 				t.Logf("warning: failed to sweep SSO connection before test: %v", err)
 			}
@@ -92,7 +96,7 @@ func TestAccCloudAgnostic_ResourceSSOConnection(t *testing.T) {
 // run and is removed to avoid exhausting the quota.
 func sweepSSOConnection(ctx context.Context, client sdk.ClientWithResponsesInterface) error {
 	resp, err := client.SSOAPIListSSOConnectionsWithResponse(ctx)
-	if err != nil {
+	if err := sdk.CheckOKResponse(resp, err); err != nil {
 		return err
 	}
 	if resp.JSON200 == nil || len(resp.JSON200.Connections) == 0 {

--- a/castai/resource_sso_connection_test.go
+++ b/castai/resource_sso_connection_test.go
@@ -36,8 +36,39 @@ func TestAccCloudAgnostic_ResourceSSOConnection(t *testing.T) {
 	clientSecret := os.Getenv("SSO_CLIENT_SECRET")
 	domain := os.Getenv("SSO_DOMAIN")
 
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		meta := testAccProvider.Meta()
+		if meta == nil {
+			return
+		}
+		client := meta.(*ProviderConfig).api
+		if err := sweepSSOConnection(ctx, client); err != nil {
+			t.Logf("warning: failed to sweep SSO connection after test: %v", err)
+		}
+	})
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if clientID == "" {
+				t.Skipf("missing required env var: SSO_CLIENT_ID")
+			}
+			if clientSecret == "" {
+				t.Skipf("missing required env var: SSO_CLIENT_SECRET")
+			}
+			if domain == "" {
+				t.Skipf("missing required env var: SSO_DOMAIN")
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			client := testAccProvider.Meta().(*ProviderConfig).api
+			if err := sweepSSOConnection(ctx, client); err != nil {
+				t.Logf("warning: failed to sweep SSO connection before test: %v", err)
+			}
+		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccSSOConnectionConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -53,6 +84,31 @@ func TestAccCloudAgnostic_ResourceSSOConnection(t *testing.T) {
 			},
 		},
 	})
+}
+
+// sweepSSOConnection lists SSO connections and deletes the first one found.
+// The CAST AI test org enforces a quota of 1 SSO connection, so at most one can
+// exist. Any connection present before the test runs is stale from a previous
+// run and is removed to avoid exhausting the quota.
+func sweepSSOConnection(ctx context.Context, client sdk.ClientWithResponsesInterface) error {
+	resp, err := client.SSOAPIListSSOConnectionsWithResponse(ctx)
+	if err != nil {
+		return err
+	}
+	if resp.JSON200 == nil || len(resp.JSON200.Connections) == 0 {
+		return nil
+	}
+
+	conn := resp.JSON200.Connections[0]
+	if conn.Id == nil {
+		return fmt.Errorf("sso connection has nil id")
+	}
+
+	delResp, err := client.SSOAPIDeleteSSOConnectionWithResponse(ctx, *conn.Id)
+	if err := sdk.CheckOKResponse(delResp, err); err != nil {
+		return err
+	}
+	return nil
 }
 
 func TestSSOConnection_ReadContext(t *testing.T) {


### PR DESCRIPTION
The `TestAccCloudAgnostic_ResourceSSOConnection` test was flaky because we enforces a quota of 1 SSO connection per org, so a leftover connection from a previous failed run would block new creation. Added `sweepSSOConnection` helper that runs in PreCheck to clear stale connections before the test and in t.Cleanup as a safety net on failure.