### PR TITLE
FIX - child_organization_id passing logic

### DIFF
--- a/castai/resource_enterprise_role_binding.go
+++ b/castai/resource_enterprise_role_binding.go
@@ -470,8 +470,12 @@ func buildRoleBindingDefinition(roleBinding EnterpriseRoleBinding, enterpriseID 
 
 	// When the role binding targets a child organization, set ChildOrganizationId so the
 	// API validates role_id against the child org's roles instead of the enterprise's roles.
-	if roleBinding.OrganizationID != enterpriseID {
-		definition.ChildOrganizationId = lo.ToPtr(roleBinding.OrganizationID)
+	if roleBinding.OrganizationID == enterpriseID {
+		if len(scopes) > 0 {
+			if scopes[0].Organization != nil {
+				definition.ChildOrganizationId = lo.ToPtr(scopes[0].Organization.Id)
+			}
+		}
 	}
 
 	if len(subjects) > 0 {

--- a/castai/resource_enterprise_role_binding.go
+++ b/castai/resource_enterprise_role_binding.go
@@ -470,12 +470,8 @@ func buildRoleBindingDefinition(roleBinding EnterpriseRoleBinding, enterpriseID 
 
 	// When the role binding targets a child organization, set ChildOrganizationId so the
 	// API validates role_id against the child org's roles instead of the enterprise's roles.
-	if roleBinding.OrganizationID == enterpriseID {
-		if len(scopes) > 0 {
-			if scopes[0].Organization != nil {
-				definition.ChildOrganizationId = lo.ToPtr(scopes[0].Organization.Id)
-			}
-		}
+	if roleBinding.OrganizationID == enterpriseID && len(scopes) > 0 && scopes[0].Organization != nil {
+		definition.ChildOrganizationId = lo.ToPtr(scopes[0].Organization.Id)
 	}
 
 	if len(subjects) > 0 {

--- a/castai/resource_enterprise_role_binding_test.go
+++ b/castai/resource_enterprise_role_binding_test.go
@@ -129,8 +129,7 @@ func TestResourceEnterpriseRoleBindingCreateContext(t *testing.T) {
 						Name:        "engineering-viewer",
 						Description: lo.ToPtr("Engineering viewer role binding"),
 						Definition: organization_management.RoleBindingDefinition{
-							RoleId:              lo.ToPtr(roleID),
-							ChildOrganizationId: lo.ToPtr(organizationID1),
+							RoleId: lo.ToPtr(roleID),
 							Subjects: &[]organization_management.Subject{
 								{
 									User: &organization_management.UserSubject{
@@ -513,7 +512,7 @@ func TestResourceEnterpriseRoleBindingCreateContext(t *testing.T) {
 		r.Contains(result[0].Summary, "at least one scope (organization or cluster) must be defined")
 	})
 
-	t.Run("when organization_id differs from enterprise_id then ChildOrganizationId is set in definition", func(t *testing.T) {
+	t.Run("when organization_id differs from enterprise_id then ChildOrganizationId is not set in definition", func(t *testing.T) {
 		t.Parallel()
 		r := require.New(t)
 		mockClient := mockOrganizationManagement.NewMockClientWithResponsesInterface(gomock.NewController(t))
@@ -538,8 +537,7 @@ func TestResourceEnterpriseRoleBindingCreateContext(t *testing.T) {
 						Name:        "child-org-binding",
 						Description: lo.ToPtr(""),
 						Definition: organization_management.RoleBindingDefinition{
-							RoleId:              lo.ToPtr(roleID),
-							ChildOrganizationId: lo.ToPtr(childOrgID),
+							RoleId: lo.ToPtr(roleID),
 							Subjects: &[]organization_management.Subject{
 								{
 									User: &organization_management.UserSubject{Id: userID},
@@ -585,6 +583,121 @@ func TestResourceEnterpriseRoleBindingCreateContext(t *testing.T) {
 		stateValue := cty.ObjectVal(map[string]cty.Value{
 			FieldEnterpriseRoleBindingEnterpriseID:   cty.StringVal(enterpriseID),
 			FieldEnterpriseRoleBindingOrganizationID: cty.StringVal(childOrgID),
+			FieldEnterpriseRoleBindingName:           cty.StringVal("child-org-binding"),
+			FieldEnterpriseRoleBindingDescription:    cty.StringVal(""),
+			FieldEnterpriseRoleBindingRoleID:         cty.StringVal(roleID),
+			FieldEnterpriseRoleBindingSubjects: cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					FieldEnterpriseRoleBindingSubjectUser: cty.ListVal([]cty.Value{
+						cty.ObjectVal(map[string]cty.Value{
+							FieldEnterpriseRoleBindingSubjectID: cty.StringVal(userID),
+						}),
+					}),
+					FieldEnterpriseRoleBindingSubjectServiceAccount: cty.ListValEmpty(cty.Object(map[string]cty.Type{
+						FieldEnterpriseRoleBindingSubjectID: cty.String,
+					})),
+					FieldEnterpriseRoleBindingSubjectGroup: cty.ListValEmpty(cty.Object(map[string]cty.Type{
+						FieldEnterpriseRoleBindingSubjectID: cty.String,
+					})),
+				}),
+			}),
+			FieldEnterpriseRoleBindingScopes: cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					FieldEnterpriseRoleBindingScopeOrganization: cty.ListVal([]cty.Value{
+						cty.ObjectVal(map[string]cty.Value{
+							FieldEnterpriseRoleBindingScopeID: cty.StringVal(childOrgID),
+						}),
+					}),
+					FieldEnterpriseRoleBindingScopeCluster: cty.ListValEmpty(cty.Object(map[string]cty.Type{
+						FieldEnterpriseRoleBindingScopeID: cty.String,
+					})),
+				}),
+			}),
+		})
+		state := terraform.NewInstanceStateShimmedFromValue(stateValue, 0)
+
+		resource := resourceEnterpriseRoleBinding()
+		data := resource.Data(state)
+
+		result := resource.CreateContext(ctx, data, provider)
+
+		r.Nil(result)
+		r.False(result.HasError())
+		r.Equal(roleBindingID, data.Id())
+	})
+
+	t.Run("when organization_id is the same as enterprise_id but scoped organization is different then ChildOrganizationId is set in definition", func(t *testing.T) {
+		t.Parallel()
+		r := require.New(t)
+		mockClient := mockOrganizationManagement.NewMockClientWithResponsesInterface(gomock.NewController(t))
+
+		ctx := context.Background()
+		provider := &ProviderConfig{
+			organizationManagementClient: mockClient,
+		}
+
+		enterpriseID := uuid.NewString()
+		childOrgID := uuid.NewString() // different from enterpriseID
+		roleBindingID := uuid.NewString()
+		roleID := uuid.NewString()
+		userID := uuid.NewString()
+
+		expectedCreateRequest := organization_management.BatchCreateEnterpriseRoleBindingsRequest{
+			EnterpriseId: enterpriseID,
+			Requests: []organization_management.BatchCreateEnterpriseRoleBindingsRequestCreateRoleBindingRequest{
+				{
+					OrganizationId: enterpriseID,
+					RoleBinding: organization_management.BatchCreateEnterpriseRoleBindingsRequestRoleBinding{
+						Name:        "child-org-binding",
+						Description: lo.ToPtr(""),
+						Definition: organization_management.RoleBindingDefinition{
+							ChildOrganizationId: lo.ToPtr(childOrgID),
+							RoleId:              lo.ToPtr(roleID),
+							Subjects: &[]organization_management.Subject{
+								{
+									User: &organization_management.UserSubject{Id: userID},
+								},
+							},
+							Scopes: &[]organization_management.Scope{
+								{
+									Organization: &organization_management.OrganizationScope{Id: childOrgID},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		mockClient.EXPECT().
+			EnterpriseAPIBatchCreateEnterpriseRoleBindingsWithResponse(gomock.Any(), enterpriseID, expectedCreateRequest).
+			Return(&organization_management.EnterpriseAPIBatchCreateEnterpriseRoleBindingsResponse{
+				Body:         nil,
+				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+				JSON200: &organization_management.BatchCreateEnterpriseRoleBindingsResponse{
+					RoleBindings: &[]organization_management.RoleBinding{
+						{
+							Id:             lo.ToPtr(roleBindingID),
+							Name:           lo.ToPtr("child-org-binding"),
+							OrganizationId: lo.ToPtr(enterpriseID),
+							Definition: &organization_management.RoleBindingDefinition{
+								RoleId:              lo.ToPtr(roleID),
+								ChildOrganizationId: lo.ToPtr(childOrgID),
+								Subjects: &[]organization_management.Subject{
+									{User: &organization_management.UserSubject{Id: userID}},
+								},
+								Scopes: &[]organization_management.Scope{
+									{Organization: &organization_management.OrganizationScope{Id: childOrgID}},
+								},
+							},
+						},
+					},
+				},
+			}, nil)
+
+		stateValue := cty.ObjectVal(map[string]cty.Value{
+			FieldEnterpriseRoleBindingEnterpriseID:   cty.StringVal(enterpriseID),
+			FieldEnterpriseRoleBindingOrganizationID: cty.StringVal(enterpriseID),
 			FieldEnterpriseRoleBindingName:           cty.StringVal("child-org-binding"),
 			FieldEnterpriseRoleBindingDescription:    cty.StringVal(""),
 			FieldEnterpriseRoleBindingRoleID:         cty.StringVal(roleID),
@@ -1099,7 +1212,7 @@ func TestResourceEnterpriseRoleBindingUpdateContext(t *testing.T) {
 					Description:    lo.ToPtr("Updated description"),
 					Definition: organization_management.RoleBindingDefinition{
 						RoleId:              lo.ToPtr(newRoleID),
-						ChildOrganizationId: lo.ToPtr(organizationID),
+						ChildOrganizationId: nil,
 						Subjects: &[]organization_management.Subject{
 							{
 								User: &organization_management.UserSubject{
@@ -1355,8 +1468,7 @@ func TestResourceEnterpriseRoleBindingUpdateContext(t *testing.T) {
 					OrganizationId: organizationID,
 					Description:    lo.ToPtr("Test description"),
 					Definition: organization_management.RoleBindingDefinition{
-						RoleId:              lo.ToPtr(roleID),
-						ChildOrganizationId: lo.ToPtr(organizationID),
+						RoleId: lo.ToPtr(roleID),
 						Subjects: &[]organization_management.Subject{
 							{
 								User: &organization_management.UserSubject{
@@ -1537,8 +1649,7 @@ func TestResourceEnterpriseRoleBindingUpdateContext(t *testing.T) {
 					OrganizationId: organizationID,
 					Description:    lo.ToPtr("Test description"),
 					Definition: organization_management.RoleBindingDefinition{
-						RoleId:              lo.ToPtr(roleID),
-						ChildOrganizationId: lo.ToPtr(organizationID),
+						RoleId: lo.ToPtr(roleID),
 						Subjects: &[]organization_management.Subject{
 							{
 								User: &organization_management.UserSubject{


### PR DESCRIPTION
should be set only when organization is enterprise and scope organization id is different from enterprise_id