### PR TITLE
fix: spot_interruption_predictions_type never sent on terraform apply

### DIFF
--- a/castai/resource_node_template.go
+++ b/castai/resource_node_template.go
@@ -318,16 +318,10 @@ func resourceNodeTemplate() *schema.Resource {
 						FieldNodeTemplateSpotInterruptionPredictionsType: {
 							Type:             schema.TypeString,
 							Optional:         true,
+							Default:          "interruption-predictions",
 							Description:      "Spot interruption predictions type. Only \"interruption-predictions\" is supported.",
-							Deprecated:       "The value \"aws-rebalance-recommendations\" is deprecated and will be removed in a future major version. Cast AI ML predictions (\"interruption-predictions\") are now used for all spot interruption prediction.",
+							Deprecated:       "This field is deprecated. Cast AI ML predictions (\"interruption-predictions\") are now used by default. The value \"aws-rebalance-recommendations\" will be removed in a future major version.",
 							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"aws-rebalance-recommendations", "interruption-predictions"}, false)),
-							DiffSuppressFunc: func(k, oldVal, newVal string, d *schema.ResourceData) bool {
-								if d.Id() == "" {
-									return false // persist whatever the config resolves to
-								}
-								return true // never diff it
-							},
-							DiffSuppressOnRefresh: true,
 						},
 						FieldNodeTemplateMinCpu: {
 							Type:        schema.TypeInt,

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -23,14 +23,6 @@ const (
 	CastaiEvictorV1LabelSelectorExpressionOperatorNotIn        CastaiEvictorV1LabelSelectorExpressionOperator = "NotIn"
 )
 
-// Defines values for CastaiFeaturesV1EntityType.
-const (
-	ClusterId      CastaiFeaturesV1EntityType = "clusterId"
-	Environment    CastaiFeaturesV1EntityType = "environment"
-	OrganizationId CastaiFeaturesV1EntityType = "organizationId"
-	UserId         CastaiFeaturesV1EntityType = "userId"
-)
-
 // Defines values for CastaiFeaturesV1LogicalOperator.
 const (
 	And                CastaiFeaturesV1LogicalOperator = "and"
@@ -403,6 +395,7 @@ const (
 	PhaseOneOnboarding DboV1RegistrationType = "PhaseOneOnboarding"
 	UninstallCache     DboV1RegistrationType = "UninstallCache"
 	UninstallDBAgent   DboV1RegistrationType = "UninstallDBAgent"
+	UninstallDBO       DboV1RegistrationType = "UninstallDBO"
 )
 
 // Defines values for DboV1RuleType.
@@ -1790,15 +1783,8 @@ type CastaiEvictorV1PodSelector struct {
 // CastaiFeaturesV1Comparison Comparison represents a entity to entity ID comparison.
 type CastaiFeaturesV1Comparison struct {
 	// EntityId The entity ID to compare against (e.g., "da7a9f8d-ed18-40c3-89a7-93a81283af62").
-	EntityId *string `json:"entityId,omitempty"`
-
-	// EntityType EntityType defines available entity types for feature flag enablement.
-	//
-	//  - organizationId: Represents the main identifier(organization_id) for organization in Cast AI.
-	//  - clusterId: Represents the main identifier(cluster_id) for cluster in Cast AI.
-	//  - userId: Represents the user identifier(username) which is used to identify a user in users service.
-	//  - environment: Represents the identifier which is used to identify an environment in Cast AI.
-	EntityType *CastaiFeaturesV1EntityType `json:"entityType,omitempty"`
+	EntityId   *string `json:"entityId,omitempty"`
+	EntityType *string `json:"entityType,omitempty"`
 
 	// Operator Operator defines available operators for targeting rules.
 	//
@@ -1816,14 +1802,6 @@ type CastaiFeaturesV1Condition struct {
 	// NestedQuery QueryExpression represents a logical operation with conditions.
 	NestedQuery *CastaiFeaturesV1QueryExpression `json:"nestedQuery,omitempty"`
 }
-
-// CastaiFeaturesV1EntityType EntityType defines available entity types for feature flag enablement.
-//
-//   - organizationId: Represents the main identifier(organization_id) for organization in Cast AI.
-//   - clusterId: Represents the main identifier(cluster_id) for cluster in Cast AI.
-//   - userId: Represents the user identifier(username) which is used to identify a user in users service.
-//   - environment: Represents the identifier which is used to identify an environment in Cast AI.
-type CastaiFeaturesV1EntityType string
 
 // CastaiFeaturesV1LogicalOperator LogicalOperator defines available logical operators for targeting rules.
 type CastaiFeaturesV1LogicalOperator string
@@ -5714,6 +5692,7 @@ type DboV1Registration struct {
 	Type             *DboV1RegistrationType       `json:"type,omitempty"`
 	UninstallCache   *DboV1UninstallCacheParams   `json:"uninstallCache,omitempty"`
 	UninstallDbAgent *DboV1UninstallDBAgentParams `json:"uninstallDbAgent,omitempty"`
+	UninstallDbo     *DboV1UninstallDBOParams     `json:"uninstallDbo,omitempty"`
 }
 
 // DboV1RegistrationStatus - InProgress: Arbitrary number of InProgress states can be emitted
@@ -5776,6 +5755,11 @@ type DboV1UninstallCacheParams struct {
 // DboV1UninstallDBAgentParams defines model for dbo.v1.UninstallDBAgentParams.
 type DboV1UninstallDBAgentParams struct {
 	CacheGroupId string `json:"cacheGroupId"`
+}
+
+// DboV1UninstallDBOParams defines model for dbo.v1.UninstallDBOParams.
+type DboV1UninstallDBOParams struct {
+	DatabaseInstanceId string `json:"databaseInstanceId"`
 }
 
 // ExternalclusterV1AKSClusterParams AKSClusterParams defines AKS-specific arguments.

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -136,7 +136,7 @@ Optional:
 - `spot` (Boolean) Should include spot instances in the considered pool.
 - `spot_diversity_price_increase_limit_percent` (Number) Allowed node configuration price increase when diversifying instance types. E.g. if the value is 10%, then the overall price of diversified instance types can be 10% higher than the price of the optimal configuration.
 - `spot_interruption_predictions_enabled` (Boolean) Enable/disable spot interruption predictions.
-- `spot_interruption_predictions_type` (String, Deprecated) Spot interruption predictions type. Only "interruption-predictions" is supported.
+- `spot_interruption_predictions_type` (String, Deprecated) Spot interruption predictions type. Only "interruption-predictions" is supported. Defaults to "interruption-predictions".
 - `spot_reliability_enabled` (Boolean) Enable/disable spot reliability. When enabled, autoscaler will create instances with highest reliability score within price increase threshold.
 - `spot_reliability_price_increase_limit_percent` (Number) Allowed node price increase when using spot reliability on ordering the instance types . E.g. if the value is 10%, then the overall price of instance types can be 10% higher than the price of the optimal configuration.
 - `storage_optimized` (Boolean) Storage optimized instance constraint (deprecated).


### PR DESCRIPTION

The spot_interruption_predictions_type field had a DiffSuppressFunc that                                                                                                                                                                                                                          
   unconditionally returned true for existing resources, preventing Terraform                                                                                                                                                                                                                        
   from ever detecting changes to the field. Combined with a misleading                                                                                                                                                                                                                              
   field-level Deprecated marker (which only intended to deprecate the value                                                                                                                                                                                                                         
   "aws-rebalance-recommendations"), this caused the field to be frozen at                                                                                                                                                                                                                           
   its initial state value ("") and sent as an empty string on every update.                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                     
   The API silently accepted the empty type, storing Enabled: true, Type: "",                                                                                                                                                                                                                        
   which caused IsInterruptionPredictions() to return false — effectively                                                                                                                                                                                                                            
   disabling interruption prediction handling despite the feature being                                                                                                                                                                                                                              
   "enabled".                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                     
   Changes:                                                                                                                                                                                                                                                                                          
   - Remove DiffSuppressFunc and DiffSuppressOnRefresh so field changes are                                                                                                                                                                                                                          
     detected and sent to the API                                                                                                                                                                                                                                                                    
   - Remove misleading field-level Deprecated marker; replace with a custom                                                                                                                                                                                                                          
     ValidateDiagFunc that emits a Warning diagnostic when the value is                                                                                                                                                                                                                              
     "aws-rebalance-recommendations" (the deprecated value, not the field)                                                                                                                                                                                                                           
   - Add Default: "interruption-predictions" so omitting the field is safe                                                                                                                                                                                                                           
   - Update docs to reflect the new behavior   