### PR TITLE
NOJIRA - Ensure stale releases from failed runs are removed

### DIFF
--- a/castai/cluster.go
+++ b/castai/cluster.go
@@ -52,7 +52,7 @@ func resourceCastaiClusterDelete(ctx context.Context, data *schema.ResourceData,
 				KeepKubernetesResources: toPtr(true),
 			})
 			if checkErr := sdk.CheckOKResponse(response, err); checkErr != nil {
-				return retry.NonRetryableError(err)
+				return retry.NonRetryableError(checkErr)
 			}
 
 			return retry.RetryableError(fmt.Errorf("triggered agent disconnection cluster status %s agent status %s", clusterStatus, agentStatus))
@@ -66,7 +66,7 @@ func resourceCastaiClusterDelete(ctx context.Context, data *schema.ResourceData,
 			}
 
 			if checkErr := sdk.CheckResponseNoContent(res, err); checkErr != nil {
-				return retry.NonRetryableError(fmt.Errorf("error when deleting cluster status %s agent status %s error: %w", clusterStatus, agentStatus, err))
+				return retry.NonRetryableError(fmt.Errorf("error when deleting cluster status %s agent status %s error: %w", clusterStatus, agentStatus, checkErr))
 			}
 			return retry.RetryableError(fmt.Errorf("triggered cluster deletion"))
 		}

--- a/castai/resource_workload_scaling_policy_test.go
+++ b/castai/resource_workload_scaling_policy_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -32,7 +33,10 @@ func TestAccGKE_ResourceWorkloadScalingPolicy(t *testing.T) {
 	projectID := os.Getenv("GOOGLE_PROJECT_ID")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			cleanupLeftoverHelmReleases(t)
+		},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckScalingPolicyDestroy,
 		Steps: []resource.TestStep{
@@ -528,6 +532,31 @@ func getAPIUrl() string {
 		return "https://api.dev-master.cast.ai"
 	}
 	return apiUrl
+}
+
+// cleanupLeftoverHelmReleases uninstalls any leftover CAST AI Helm releases from
+// previous (possibly failed) test runs. The acceptance tests share a single GKE
+// cluster and install Helm releases with hardcoded names (castai-agent,
+// castai-cluster-controller, castai-workload-autoscaler). When a previous run
+// fails or is cancelled mid-install, the releases can be left in a pending or
+// failed state, causing "cannot re-use a name that is still in use" errors on
+// the next run. The replace = true flag in the helm_release resource only works
+// when the existing release is in a deployed state, so we explicitly uninstall
+// stale releases here before the test begins.
+func cleanupLeftoverHelmReleases(t *testing.T) {
+	t.Helper()
+
+	releases := []string{"castai-agent", "castai-cluster-controller", "castai-workload-autoscaler"}
+
+	for _, release := range releases {
+		// Uninstall the release if it exists in any state. We use --ignore-not-found so
+		// the command succeeds even when the release doesn't exist yet (clean run).
+		cmd := exec.Command("helm", "uninstall", release, "--namespace", "castai-agent", "--ignore-not-found", "--wait", "--timeout", "2m")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Logf("helm uninstall %s: %s", release, string(output))
+		}
+	}
 }
 
 func Test_validateResourcePolicy(t *testing.T) {

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -12850,6 +12850,9 @@ type ServiceAccountsAPIListServiceAccountsParams struct {
 	// PageCursor Cursor that defines token indicating where to start the next page.
 	// Empty value indicates to start from beginning of the dataset.
 	PageCursor *string `form:"page.cursor,omitempty" json:"page.cursor,omitempty"`
+
+	// ServiceAccountName Service account name filter.
+	ServiceAccountName *string `form:"serviceAccountName,omitempty" json:"serviceAccountName,omitempty"`
 }
 
 // ServiceAccountsAPIListOrganizationServiceAccountKeysParams defines parameters for ServiceAccountsAPIListOrganizationServiceAccountKeys.

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -403,6 +403,7 @@ const (
 	PhaseOneOnboarding DboV1RegistrationType = "PhaseOneOnboarding"
 	UninstallCache     DboV1RegistrationType = "UninstallCache"
 	UninstallDBAgent   DboV1RegistrationType = "UninstallDBAgent"
+	UninstallDBO       DboV1RegistrationType = "UninstallDBO"
 )
 
 // Defines values for DboV1RuleType.
@@ -5714,6 +5715,7 @@ type DboV1Registration struct {
 	Type             *DboV1RegistrationType       `json:"type,omitempty"`
 	UninstallCache   *DboV1UninstallCacheParams   `json:"uninstallCache,omitempty"`
 	UninstallDbAgent *DboV1UninstallDBAgentParams `json:"uninstallDbAgent,omitempty"`
+	UninstallDbo     *DboV1UninstallDBOParams     `json:"uninstallDbo,omitempty"`
 }
 
 // DboV1RegistrationStatus - InProgress: Arbitrary number of InProgress states can be emitted
@@ -5776,6 +5778,11 @@ type DboV1UninstallCacheParams struct {
 // DboV1UninstallDBAgentParams defines model for dbo.v1.UninstallDBAgentParams.
 type DboV1UninstallDBAgentParams struct {
 	CacheGroupId string `json:"cacheGroupId"`
+}
+
+// DboV1UninstallDBOParams defines model for dbo.v1.UninstallDBOParams.
+type DboV1UninstallDBOParams struct {
+	DatabaseInstanceId string `json:"databaseInstanceId"`
 }
 
 // ExternalclusterV1AKSClusterParams AKSClusterParams defines AKS-specific arguments.

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -14680,6 +14680,22 @@ func NewServiceAccountsAPIListServiceAccountsRequest(server string, organization
 
 		}
 
+		if params.ServiceAccountName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "serviceAccountName", runtime.ParamLocationQuery, *params.ServiceAccountName); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 


### PR DESCRIPTION
before the test attempts to install them again.

The TestAccGKE_ResourceWorkloadScalingPolicy test installs three Helm releases with hardcoded names (castai-agent, castai-cluster-controller, castai-workload-autoscaler) into a shared GKE cluster (tf-core-acc-20230723). The Helm config uses replace = true,   but that flag only replaces releases in a deployed state. When a previous CI run is cancelled, times out, or crashes mid-install, the releases are left in a pending-install or failed state. On the next run, Helm rejects the re-use.

Error from other pipeline:
```
=== RUN   TestAccGKE_ResourceWorkloadScalingPolicy
    resource_workload_scaling_policy_test.go:34: Step 1/4 error: Error running apply: exit status 1
        
        Error: cannot re-use a name that is still in use
        
          with helm_release.castai_agent,
          on terraform_plugin_test.tf line 85, in resource "helm_release" "castai_agent":
          85: 	resource "helm_release" "castai_agent" ***
        
--- FAIL: TestAccGKE_ResourceWorkloadScalingPolicy (131.37s)
```