### PR TITLE
fix: resource_commitment - prevent inconsistent result and perpetual diffs on commitment detail fields

### DIFF
--- a/castai/commitment_mapping_test.go
+++ b/castai/commitment_mapping_test.go
@@ -873,6 +873,170 @@ func TestCommitmentModel_ApplyDetails_AllDetailBlocks(t *testing.T) {
 	}
 }
 
+func TestApplyCommitment_ComputedFieldsPopulatedFromAPI(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		commitment   *pricing.Commitment
+		initialState *commitmentModel // plan state with Computed fields null/unknown
+		checkFunc    func(t *testing.T, m *commitmentModel)
+	}{
+		{
+			name: "GCP capacity reservation: Computed fields null in plan, API returns zero",
+			commitment: &pricing.Commitment{
+				Id:        ptr("gcr-id"),
+				Name:      ptr("gcr"),
+				Cloud:     ptr(pricing.CommitmentCloudGCP),
+				Region:    ptr("us-central1"),
+				Type:      ptr(pricing.CommitmentTypeONDEMANDCAPACITYRESERVATION),
+				StartTime: &start,
+				GcpCapacityReservationDetails: &pricing.GCPCapacityReservationDetails{
+					Id:                          ptr("res-1"),
+					InstanceType:                ptr("n2-standard-8"),
+					TotalInstanceCount:          ptr("1"),
+					InUseInstanceCount:          ptr("0"),
+					AssuredInstanceCount:        ptr("0"),
+					State:                       ptr("READY"),
+					SpecificReservationRequired: ptr(false),
+				},
+			},
+			// Simulates the Create path: user omitted Computed fields,
+			// so they are null in the plan.
+			initialState: &commitmentModel{
+				GCPCapacityReservationDetails: &gcpCapacityReservationDetailsModel{
+					ID:                          types.StringValue("res-1"),
+					InstanceType:                types.StringValue("n2-standard-8"),
+					TotalInstanceCount:          types.Int64Value(1),
+					SpecificReservationRequired: types.BoolValue(false),
+					InUseInstanceCount:           types.Int64Null(),
+					AssuredInstanceCount:         types.Int64Null(),
+				},
+			},
+			checkFunc: func(t *testing.T, m *commitmentModel) {
+				require.NotNil(t, m.GCPCapacityReservationDetails)
+				d := m.GCPCapacityReservationDetails
+				// Computed fields must be populated from API, not left null.
+				assert.False(t, d.InUseInstanceCount.IsNull(), "in_use_instance_count should be populated from API")
+				assert.False(t, d.AssuredInstanceCount.IsNull(), "assured_instance_count should be populated from API")
+				assert.Equal(t, int64(0), d.InUseInstanceCount.ValueInt64())
+				assert.Equal(t, int64(0), d.AssuredInstanceCount.ValueInt64())
+			},
+		},
+		{
+			name: "GCP capacity reservation: Computed fields null in plan, API returns non-zero",
+			commitment: &pricing.Commitment{
+				Id:        ptr("gcr-id"),
+				Name:      ptr("gcr"),
+				Cloud:     ptr(pricing.CommitmentCloudGCP),
+				Region:    ptr("us-central1"),
+				Type:      ptr(pricing.CommitmentTypeONDEMANDCAPACITYRESERVATION),
+				StartTime: &start,
+				GcpCapacityReservationDetails: &pricing.GCPCapacityReservationDetails{
+					Id:                          ptr("res-1"),
+					InstanceType:                ptr("n2-standard-8"),
+					TotalInstanceCount:          ptr("4"),
+					InUseInstanceCount:          ptr("2"),
+					AssuredInstanceCount:        ptr("3"),
+					State:                       ptr("READY"),
+					SpecificReservationRequired: ptr(true),
+				},
+			},
+			initialState: &commitmentModel{
+				GCPCapacityReservationDetails: &gcpCapacityReservationDetailsModel{
+					ID:                          types.StringValue("res-1"),
+					InstanceType:                types.StringValue("n2-standard-8"),
+					TotalInstanceCount:          types.Int64Value(4),
+					SpecificReservationRequired: types.BoolValue(true),
+					InUseInstanceCount:           types.Int64Null(),
+					AssuredInstanceCount:         types.Int64Null(),
+				},
+			},
+			checkFunc: func(t *testing.T, m *commitmentModel) {
+				require.NotNil(t, m.GCPCapacityReservationDetails)
+				d := m.GCPCapacityReservationDetails
+				assert.Equal(t, int64(2), d.InUseInstanceCount.ValueInt64())
+				assert.Equal(t, int64(3), d.AssuredInstanceCount.ValueInt64())
+			},
+		},
+		{
+			name: "AWS capacity block: available_instance_count null in plan, API returns zero",
+			commitment: &pricing.Commitment{
+				Id:        ptr("cb-id"),
+				Name:      ptr("cb"),
+				Cloud:     ptr(pricing.CommitmentCloudAWS),
+				Region:    ptr("us-east-1"),
+				Type:      ptr(pricing.CommitmentTypeCAPACITYBLOCK),
+				StartTime: &start,
+				AwsCapacityBlockDetails: &pricing.AWSCapacityBlockDetails{
+					Id:                     ptr("cb-1"),
+					InstanceType:           ptr("p4d.24xlarge"),
+					TotalInstanceCount:     ptr("2"),
+					AvailableInstanceCount: ptr("0"),
+					State:                  ptr("active"),
+				},
+			},
+			initialState: &commitmentModel{
+				AWSCapacityBlockDetails: &awsCapacityBlockDetailsModel{
+					ID:                     types.StringValue("cb-1"),
+					InstanceType:           types.StringValue("p4d.24xlarge"),
+					TotalInstanceCount:     types.Int64Value(2),
+					AvailableInstanceCount: types.Int64Null(),
+				},
+			},
+			checkFunc: func(t *testing.T, m *commitmentModel) {
+				require.NotNil(t, m.AWSCapacityBlockDetails)
+				assert.False(t, m.AWSCapacityBlockDetails.AvailableInstanceCount.IsNull())
+				assert.Equal(t, int64(0), m.AWSCapacityBlockDetails.AvailableInstanceCount.ValueInt64())
+			},
+		},
+		{
+			name: "AWS ODCR: available_instance_count null in plan, API returns value",
+			commitment: &pricing.Commitment{
+				Id:        ptr("odcr-id"),
+				Name:      ptr("odcr"),
+				Cloud:     ptr(pricing.CommitmentCloudAWS),
+				Region:    ptr("us-east-1"),
+				Type:      ptr(pricing.CommitmentTypeONDEMANDCAPACITYRESERVATION),
+				StartTime: &start,
+				AwsOdcrDetails: &pricing.AWSODCRDetails{
+					Id:                     ptr("odcr-1"),
+					InstanceType:           ptr("m5.xlarge"),
+					TotalInstanceCount:     ptr("4"),
+					AvailableInstanceCount: ptr("2"),
+					Interruptible:          ptr(false),
+				},
+			},
+			initialState: &commitmentModel{
+				AWSODCRDetails: &awsODCRDetailsModel{
+					ID:                     types.StringValue("odcr-1"),
+					InstanceType:           types.StringValue("m5.xlarge"),
+					TotalInstanceCount:     types.Int64Value(4),
+					Interruptible:          types.BoolValue(false),
+					AvailableInstanceCount: types.Int64Null(),
+				},
+			},
+			checkFunc: func(t *testing.T, m *commitmentModel) {
+				require.NotNil(t, m.AWSODCRDetails)
+				assert.False(t, m.AWSODCRDetails.AvailableInstanceCount.IsNull())
+				assert.Equal(t, int64(2), m.AWSODCRDetails.AvailableInstanceCount.ValueInt64())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.initialState
+			if m == nil {
+				m = &commitmentModel{}
+			}
+			diags := m.applyCommitment(context.Background(), tt.commitment)
+			require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+			tt.checkFunc(t, m)
+		})
+	}
+}
+
 func TestUpsertAndPatchChangeDetection(t *testing.T) {
 	base := func() commitmentModel {
 		return commitmentModel{

--- a/castai/resource_commitment.go
+++ b/castai/resource_commitment.go
@@ -446,6 +446,7 @@ func (r *genericCommitmentResource) Schema(_ context.Context, _ resource.SchemaR
 					},
 					"available_instance_count": schema.Int64Attribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "Available (unused) instance count.",
 					},
 					"state": schema.StringAttribute{
@@ -489,6 +490,7 @@ func (r *genericCommitmentResource) Schema(_ context.Context, _ resource.SchemaR
 					},
 					"available_instance_count": schema.Int64Attribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "Available (unused) instance count.",
 					},
 					"state": schema.StringAttribute{
@@ -504,8 +506,8 @@ func (r *genericCommitmentResource) Schema(_ context.Context, _ resource.SchemaR
 						Description: "Instance match criteria (open, targeted).",
 					},
 					"interruptible": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Whether this reservation is interruptible.",
+						Required:    true,
+						Description: "Whether this reservation is interruptible. Set to true for interruptible ODCRs, false otherwise.",
 					},
 				},
 			},
@@ -642,10 +644,12 @@ func (r *genericCommitmentResource) Schema(_ context.Context, _ resource.SchemaR
 					},
 					"in_use_instance_count": schema.Int64Attribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "Number of instances currently in use.",
 					},
 					"assured_instance_count": schema.Int64Attribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "Assured count for the reservation.",
 					},
 					"state": schema.StringAttribute{
@@ -653,8 +657,8 @@ func (r *genericCommitmentResource) Schema(_ context.Context, _ resource.SchemaR
 						Description: "Runtime state of the reservation (e.g. READY).",
 					},
 					"specific_reservation_required": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Whether the reservation requires specific reservation affinity.",
+						Required:    true,
+						Description: "Whether the reservation requires specific reservation affinity. Set to true for targeted reservations, false for automatic (open) reservations.",
 					},
 					"min_cpu_platform": schema.StringAttribute{
 						Optional:    true,
@@ -934,6 +938,10 @@ func saveCreatedState(ctx context.Context, resp *resource.CreateResponse, plan *
 	plan.AutoAssignment = syncBool(plan.AutoAssignment, created.AutoAssignment)
 	plan.CreateTime = syncTime(plan.CreateTime, created.CreateTime)
 	plan.UpdateTime = syncTime(plan.UpdateTime, created.UpdateTime)
+	// Sync detail fields from the API response so that Computed fields
+	// (which are unknown in the plan when omitted by the user) are
+	// populated with concrete values in state.
+	resp.Diagnostics.Append(plan.applyCommitment(ctx, created)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -253,6 +253,12 @@ const (
 	CastaiRbacV1beta1LabelSelectorOperatorNOTIN        CastaiRbacV1beta1LabelSelectorOperator = "NOT_IN"
 )
 
+// Defines values for CastaiRbacV1beta1MemberActions.
+const (
+	ADD    CastaiRbacV1beta1MemberActions = "ADD"
+	REMOVE CastaiRbacV1beta1MemberActions = "REMOVE"
+)
+
 // Defines values for CastaiRbacV1beta1PoliciesState.
 const (
 	CastaiRbacV1beta1PoliciesStateACCEPTED CastaiRbacV1beta1PoliciesState = "ACCEPTED"
@@ -835,6 +841,8 @@ const (
 	WorkloadoptimizationV1EventTypeEVENTTYPESYSTEMOVERRIDERESET           WorkloadoptimizationV1EventType = "EVENT_TYPE_SYSTEM_OVERRIDE_RESET"
 	WorkloadoptimizationV1EventTypeEVENTTYPESYSTEMOVERRIDETRIGGERED       WorkloadoptimizationV1EventType = "EVENT_TYPE_SYSTEM_OVERRIDE_TRIGGERED"
 	WorkloadoptimizationV1EventTypeEVENTTYPEUNBOUNDMEMORYGROWTH           WorkloadoptimizationV1EventType = "EVENT_TYPE_UNBOUND_MEMORY_GROWTH"
+	WorkloadoptimizationV1EventTypeEVENTTYPEWORKLOADAUTOSCALERINSTALLED   WorkloadoptimizationV1EventType = "EVENT_TYPE_WORKLOAD_AUTOSCALER_INSTALLED"
+	WorkloadoptimizationV1EventTypeEVENTTYPEWORKLOADAUTOSCALERUNINSTALLED WorkloadoptimizationV1EventType = "EVENT_TYPE_WORKLOAD_AUTOSCALER_UNINSTALLED"
 )
 
 // Defines values for WorkloadoptimizationV1GetAgentStatusResponseAgentStatus.
@@ -1429,6 +1437,8 @@ const (
 	WorkloadOptimizationAPIListWorkloadEventsParamsTypeEVENTTYPESYSTEMOVERRIDERESET           WorkloadOptimizationAPIListWorkloadEventsParamsType = "EVENT_TYPE_SYSTEM_OVERRIDE_RESET"
 	WorkloadOptimizationAPIListWorkloadEventsParamsTypeEVENTTYPESYSTEMOVERRIDETRIGGERED       WorkloadOptimizationAPIListWorkloadEventsParamsType = "EVENT_TYPE_SYSTEM_OVERRIDE_TRIGGERED"
 	WorkloadOptimizationAPIListWorkloadEventsParamsTypeEVENTTYPEUNBOUNDMEMORYGROWTH           WorkloadOptimizationAPIListWorkloadEventsParamsType = "EVENT_TYPE_UNBOUND_MEMORY_GROWTH"
+	WorkloadOptimizationAPIListWorkloadEventsParamsTypeEVENTTYPEWORKLOADAUTOSCALERINSTALLED   WorkloadOptimizationAPIListWorkloadEventsParamsType = "EVENT_TYPE_WORKLOAD_AUTOSCALER_INSTALLED"
+	WorkloadOptimizationAPIListWorkloadEventsParamsTypeEVENTTYPEWORKLOADAUTOSCALERUNINSTALLED WorkloadOptimizationAPIListWorkloadEventsParamsType = "EVENT_TYPE_WORKLOAD_AUTOSCALER_UNINSTALLED"
 )
 
 // Defines values for WorkloadOptimizationAPIGetWorkloadEventsSummaryParamsType.
@@ -1456,6 +1466,8 @@ const (
 	EVENTTYPESYSTEMOVERRIDERESET           WorkloadOptimizationAPIGetWorkloadEventsSummaryParamsType = "EVENT_TYPE_SYSTEM_OVERRIDE_RESET"
 	EVENTTYPESYSTEMOVERRIDETRIGGERED       WorkloadOptimizationAPIGetWorkloadEventsSummaryParamsType = "EVENT_TYPE_SYSTEM_OVERRIDE_TRIGGERED"
 	EVENTTYPEUNBOUNDMEMORYGROWTH           WorkloadOptimizationAPIGetWorkloadEventsSummaryParamsType = "EVENT_TYPE_UNBOUND_MEMORY_GROWTH"
+	EVENTTYPEWORKLOADAUTOSCALERINSTALLED   WorkloadOptimizationAPIGetWorkloadEventsSummaryParamsType = "EVENT_TYPE_WORKLOAD_AUTOSCALER_INSTALLED"
+	EVENTTYPEWORKLOADAUTOSCALERUNINSTALLED WorkloadOptimizationAPIGetWorkloadEventsSummaryParamsType = "EVENT_TYPE_WORKLOAD_AUTOSCALER_UNINSTALLED"
 )
 
 // Defines values for WorkloadOptimizationAPIListWorkloadsParamsManagementOptions.
@@ -3290,6 +3302,21 @@ type CastaiRbacV1beta1GroupSubject struct {
 	Name *string `json:"name,omitempty"`
 }
 
+// CastaiRbacV1beta1GroupUpdate defines model for castai.rbac.v1beta1.GroupUpdate.
+type CastaiRbacV1beta1GroupUpdate struct {
+	// Description Description is the description of the group.
+	Description *string `json:"description,omitempty"`
+
+	// Id ID is the unique identifier of the group.
+	Id string `json:"id"`
+
+	// Members Members is a list of members.
+	Members *[]CastaiRbacV1beta1MemberUpdate `json:"members,omitempty"`
+
+	// Name Name is the name of the group.
+	Name string `json:"name"`
+}
+
 // CastaiRbacV1beta1Kind Kind represents the type of the member.
 type CastaiRbacV1beta1Kind string
 
@@ -3318,6 +3345,15 @@ type CastaiRbacV1beta1LabelSelectorRequirement struct {
 
 	// Values Values is the list of label values that the requirement applies to.
 	Values *[]string `json:"values,omitempty"`
+}
+
+// CastaiRbacV1beta1ListGroupsResponse defines model for castai.rbac.v1beta1.ListGroupsResponse.
+type CastaiRbacV1beta1ListGroupsResponse struct {
+	Groups *[]CastaiRbacV1beta1Group `json:"groups,omitempty"`
+
+	// NextPage Page defines how many and which fields should be returned.
+	NextPage   *CastaiPaginationV1beta1Page `json:"nextPage,omitempty"`
+	TotalCount *string                      `json:"totalCount,omitempty"`
 }
 
 // CastaiRbacV1beta1ListPermissionGroupsResponse ListPermissionGroupsResponse is the response message for listing available permission groups.
@@ -3361,6 +3397,24 @@ type CastaiRbacV1beta1Member struct {
 
 	// LastLoginAt LastLoginAt is the timestamp of the time when the user last time logged in.
 	LastLoginAt *time.Time `json:"lastLoginAt,omitempty"`
+}
+
+// CastaiRbacV1beta1MemberActions MemberActions represents the action that can be performed on a member.
+type CastaiRbacV1beta1MemberActions string
+
+// CastaiRbacV1beta1MemberUpdate defines model for castai.rbac.v1beta1.MemberUpdate.
+type CastaiRbacV1beta1MemberUpdate struct {
+	// Action MemberActions represents the action that can be performed on a member.
+	Action CastaiRbacV1beta1MemberActions `json:"action"`
+
+	// Email Email is the email of the member.
+	Email *string `json:"email,omitempty"`
+
+	// Id ID is the unique identifier of the member.
+	Id string `json:"id"`
+
+	// Kind Kind represents the type of the member.
+	Kind CastaiRbacV1beta1Kind `json:"kind"`
 }
 
 // CastaiRbacV1beta1OrganizationScope OrganizationScope represents the organization scope.
@@ -7749,7 +7803,8 @@ type NodetemplatesV1NewNodeTemplate struct {
 	ShouldTaint *bool `json:"shouldTaint"`
 
 	// StopEnabled Nodes in this node-template have Storage Optimization (STOP) enabled.
-	StopEnabled *bool `json:"stopEnabled"`
+	StopEnabled                  *bool                                        `json:"stopEnabled"`
+	StuckPodResizeReconciliation *NodetemplatesV1StuckPodResizeReconciliation `json:"stuckPodResizeReconciliation,omitempty"`
 }
 
 // NodetemplatesV1NodeTemplate defines model for nodetemplates.v1.NodeTemplate.
@@ -7791,8 +7846,9 @@ type NodetemplatesV1NodeTemplate struct {
 	ShouldTaint *bool `json:"shouldTaint,omitempty"`
 
 	// StopEnabled Nodes in this node-template have Storage Optimization (STOP) enabled.
-	StopEnabled *bool   `json:"stopEnabled,omitempty"`
-	Version     *string `json:"version,omitempty"`
+	StopEnabled                  *bool                                        `json:"stopEnabled,omitempty"`
+	StuckPodResizeReconciliation *NodetemplatesV1StuckPodResizeReconciliation `json:"stuckPodResizeReconciliation,omitempty"`
+	Version                      *string                                      `json:"version,omitempty"`
 }
 
 // NodetemplatesV1NodeTemplateListItem defines model for nodetemplates.v1.NodeTemplateListItem.
@@ -7824,6 +7880,13 @@ type NodetemplatesV1RebalancingConfiguration struct {
 // NodetemplatesV1SharedGPU defines model for nodetemplates.v1.SharedGPU.
 type NodetemplatesV1SharedGPU struct {
 	SharedClientsPerGpu *int32 `json:"sharedClientsPerGpu"`
+}
+
+// NodetemplatesV1StuckPodResizeReconciliation defines model for nodetemplates.v1.StuckPodResizeReconciliation.
+type NodetemplatesV1StuckPodResizeReconciliation struct {
+	// Enabled When enabled, the autoscaler discovers pods whose woop-initiated in-place resize failed or got stuck,
+	// protects them from woop's eviction fallback, and live-migrates them via a rebalancing plan.
+	Enabled *bool `json:"enabled"`
 }
 
 // NodetemplatesV1Taint Taint is used in responses.
@@ -8092,7 +8155,8 @@ type NodetemplatesV1UpdateNodeTemplate struct {
 	ShouldTaint *bool `json:"shouldTaint"`
 
 	// StopEnabled Nodes in this node-template have Storage Optimization (STOP) enabled.
-	StopEnabled *bool `json:"stopEnabled"`
+	StopEnabled                  *bool                                        `json:"stopEnabled"`
+	StuckPodResizeReconciliation *NodetemplatesV1StuckPodResizeReconciliation `json:"stuckPodResizeReconciliation,omitempty"`
 }
 
 // PoliciesV1ClusterLimitsCpu Defines the minimum and maximum amount of vCPUs for cluster's worker nodes.
@@ -9576,8 +9640,10 @@ type WorkloadoptimizationV1Event struct {
 	SystemOverrideReset *WorkloadoptimizationV1SystemOverrideResetEvent `json:"systemOverrideReset,omitempty"`
 
 	// SystemOverrideTriggered SystemOverrideTriggeredEvent is emitted when CAST AI activates a system override on a workload.
-	SystemOverrideTriggered *WorkloadoptimizationV1SystemOverrideTriggeredEvent `json:"systemOverrideTriggered,omitempty"`
-	UnboundMemoryGrowth     *WorkloadoptimizationV1UnboundMemoryGrowthEvent     `json:"unboundMemoryGrowth,omitempty"`
+	SystemOverrideTriggered       *WorkloadoptimizationV1SystemOverrideTriggeredEvent       `json:"systemOverrideTriggered,omitempty"`
+	UnboundMemoryGrowth           *WorkloadoptimizationV1UnboundMemoryGrowthEvent           `json:"unboundMemoryGrowth,omitempty"`
+	WorkloadAutoscalerInstalled   *WorkloadoptimizationV1WorkloadAutoscalerInstalledEvent   `json:"workloadAutoscalerInstalled,omitempty"`
+	WorkloadAutoscalerUninstalled *WorkloadoptimizationV1WorkloadAutoscalerUninstalledEvent `json:"workloadAutoscalerUninstalled,omitempty"`
 }
 
 // WorkloadoptimizationV1EventContainer defines model for workloadoptimization.v1.EventContainer.
@@ -11840,6 +11906,16 @@ type WorkloadoptimizationV1Workload struct {
 	WorkloadOverrides        *WorkloadoptimizationV1WorkloadOverrides `json:"workloadOverrides,omitempty"`
 }
 
+// WorkloadoptimizationV1WorkloadAutoscalerInstalledEvent defines model for workloadoptimization.v1.WorkloadAutoscalerInstalledEvent.
+type WorkloadoptimizationV1WorkloadAutoscalerInstalledEvent struct {
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// WorkloadoptimizationV1WorkloadAutoscalerUninstalledEvent defines model for workloadoptimization.v1.WorkloadAutoscalerUninstalledEvent.
+type WorkloadoptimizationV1WorkloadAutoscalerUninstalledEvent struct {
+	Timestamp time.Time `json:"timestamp"`
+}
+
 // WorkloadoptimizationV1WorkloadConfigUpdateV2 defines model for workloadoptimization.v1.WorkloadConfigUpdateV2.
 type WorkloadoptimizationV1WorkloadConfigUpdateV2 struct {
 	HpaConfig *WorkloadoptimizationV1HPAConfigUpdate `json:"hpaConfig,omitempty"`
@@ -12770,6 +12846,24 @@ type ExternalClusterAPITriggerResumeClusterParamsMode string
 // ExternalClusterAPIUpdateClusterTagsJSONBody defines parameters for ExternalClusterAPIUpdateClusterTags.
 type ExternalClusterAPIUpdateClusterTagsJSONBody map[string]string
 
+// RbacServiceAPIListGroupsParams defines parameters for RbacServiceAPIListGroups.
+type RbacServiceAPIListGroupsParams struct {
+	PageLimit *string `form:"page.limit,omitempty" json:"page.limit,omitempty"`
+
+	// PageCursor Cursor that defines token indicating where to start the next page.
+	// Empty value indicates to start from beginning of the dataset.
+	PageCursor *string `form:"page.cursor,omitempty" json:"page.cursor,omitempty"`
+	MemberId   *string `form:"memberId,omitempty" json:"memberId,omitempty"`
+
+	// ManagedBy managed_by filters groups by how they are managed.
+	// Valid filter values are: "console", "terraform", "idp-sync", "sso-default" and "" (empty string).
+	// Empty string matches legacy groups created before the managed_by column was introduced.
+	ManagedBy *[]string `form:"managedBy,omitempty" json:"managedBy,omitempty"`
+}
+
+// RbacServiceAPIUpdateGroupsJSONBody defines parameters for RbacServiceAPIUpdateGroups.
+type RbacServiceAPIUpdateGroupsJSONBody = []CastaiRbacV1beta1GroupUpdate
+
 // RbacServiceAPIListRoleBindingsParams defines parameters for RbacServiceAPIListRoleBindings.
 type RbacServiceAPIListRoleBindingsParams struct {
 	PageLimit *string `form:"page.limit,omitempty" json:"page.limit,omitempty"`
@@ -13596,6 +13690,9 @@ type UsersAPICreateOrganizationJSONRequestBody = CastaiUsersV1beta1Organization
 
 // UsersAPIEditOrganizationJSONRequestBody defines body for UsersAPIEditOrganization for application/json ContentType.
 type UsersAPIEditOrganizationJSONRequestBody = CastaiUsersV1beta1Organization
+
+// RbacServiceAPIUpdateGroupsJSONRequestBody defines body for RbacServiceAPIUpdateGroups for application/json ContentType.
+type RbacServiceAPIUpdateGroupsJSONRequestBody = RbacServiceAPIUpdateGroupsJSONBody
 
 // RbacServiceAPICreateGroupJSONRequestBody defines body for RbacServiceAPICreateGroup for application/json ContentType.
 type RbacServiceAPICreateGroupJSONRequestBody = CastaiRbacV1beta1CreateGroupRequestGroup

--- a/castai/sdk/client.gen.go
+++ b/castai/sdk/client.gen.go
@@ -583,6 +583,14 @@ type ClientInterface interface {
 	// InventoryAPISyncClusterResources request
 	InventoryAPISyncClusterResources(ctx context.Context, organizationId string, clusterId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// RbacServiceAPIListGroups request
+	RbacServiceAPIListGroups(ctx context.Context, organizationId string, params *RbacServiceAPIListGroupsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RbacServiceAPIUpdateGroupsWithBody request with any body
+	RbacServiceAPIUpdateGroupsWithBody(ctx context.Context, organizationId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RbacServiceAPIUpdateGroups(ctx context.Context, organizationId string, body RbacServiceAPIUpdateGroupsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// RbacServiceAPICreateGroupWithBody request with any body
 	RbacServiceAPICreateGroupWithBody(ctx context.Context, organizationId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -3201,6 +3209,42 @@ func (c *Client) UsersAPIEditOrganization(ctx context.Context, id string, body U
 
 func (c *Client) InventoryAPISyncClusterResources(ctx context.Context, organizationId string, clusterId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewInventoryAPISyncClusterResourcesRequest(c.Server, organizationId, clusterId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RbacServiceAPIListGroups(ctx context.Context, organizationId string, params *RbacServiceAPIListGroupsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRbacServiceAPIListGroupsRequest(c.Server, organizationId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RbacServiceAPIUpdateGroupsWithBody(ctx context.Context, organizationId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRbacServiceAPIUpdateGroupsRequestWithBody(c.Server, organizationId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RbacServiceAPIUpdateGroups(ctx context.Context, organizationId string, body RbacServiceAPIUpdateGroupsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRbacServiceAPIUpdateGroupsRequest(c.Server, organizationId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -13708,6 +13752,157 @@ func NewInventoryAPISyncClusterResourcesRequest(server string, organizationId st
 	return req, nil
 }
 
+// NewRbacServiceAPIListGroupsRequest generates requests for RbacServiceAPIListGroups
+func NewRbacServiceAPIListGroupsRequest(server string, organizationId string, params *RbacServiceAPIListGroupsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "organizationId", runtime.ParamLocationPath, organizationId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/organizations/%s/groups", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PageLimit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.limit", runtime.ParamLocationQuery, *params.PageLimit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PageCursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page.cursor", runtime.ParamLocationQuery, *params.PageCursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.MemberId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "memberId", runtime.ParamLocationQuery, *params.MemberId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ManagedBy != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "managedBy", runtime.ParamLocationQuery, *params.ManagedBy); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewRbacServiceAPIUpdateGroupsRequest calls the generic RbacServiceAPIUpdateGroups builder with application/json body
+func NewRbacServiceAPIUpdateGroupsRequest(server string, organizationId string, body RbacServiceAPIUpdateGroupsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewRbacServiceAPIUpdateGroupsRequestWithBody(server, organizationId, "application/json", bodyReader)
+}
+
+// NewRbacServiceAPIUpdateGroupsRequestWithBody generates requests for RbacServiceAPIUpdateGroups with any type of body
+func NewRbacServiceAPIUpdateGroupsRequestWithBody(server string, organizationId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "organizationId", runtime.ParamLocationPath, organizationId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/organizations/%s/groups", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewRbacServiceAPICreateGroupRequest calls the generic RbacServiceAPICreateGroup builder with application/json body
 func NewRbacServiceAPICreateGroupRequest(server string, organizationId string, body RbacServiceAPICreateGroupJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -22562,6 +22757,14 @@ type ClientWithResponsesInterface interface {
 	// InventoryAPISyncClusterResources request
 	InventoryAPISyncClusterResourcesWithResponse(ctx context.Context, organizationId string, clusterId string) (*InventoryAPISyncClusterResourcesResponse, error)
 
+	// RbacServiceAPIListGroups request
+	RbacServiceAPIListGroupsWithResponse(ctx context.Context, organizationId string, params *RbacServiceAPIListGroupsParams) (*RbacServiceAPIListGroupsResponse, error)
+
+	// RbacServiceAPIUpdateGroups request  with any body
+	RbacServiceAPIUpdateGroupsWithBodyWithResponse(ctx context.Context, organizationId string, contentType string, body io.Reader) (*RbacServiceAPIUpdateGroupsResponse, error)
+
+	RbacServiceAPIUpdateGroupsWithResponse(ctx context.Context, organizationId string, body RbacServiceAPIUpdateGroupsJSONRequestBody) (*RbacServiceAPIUpdateGroupsResponse, error)
+
 	// RbacServiceAPICreateGroup request  with any body
 	RbacServiceAPICreateGroupWithBodyWithResponse(ctx context.Context, organizationId string, contentType string, body io.Reader) (*RbacServiceAPICreateGroupResponse, error)
 
@@ -27094,6 +27297,66 @@ func (r InventoryAPISyncClusterResourcesResponse) StatusCode() int {
 // TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
 // Body returns body of byte array
 func (r InventoryAPISyncClusterResourcesResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
+type RbacServiceAPIListGroupsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CastaiRbacV1beta1ListGroupsResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r RbacServiceAPIListGroupsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RbacServiceAPIListGroupsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r RbacServiceAPIListGroupsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// TODO: </castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+
+type RbacServiceAPIUpdateGroupsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]CastaiRbacV1beta1Group
+}
+
+// Status returns HTTPResponse.Status
+func (r RbacServiceAPIUpdateGroupsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RbacServiceAPIUpdateGroupsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// TODO: <castai customization> to have common interface. https://github.com/deepmap/oapi-codegen/issues/240
+// Body returns body of byte array
+func (r RbacServiceAPIUpdateGroupsResponse) GetBody() []byte {
 	return r.Body
 }
 
@@ -32596,6 +32859,32 @@ func (c *ClientWithResponses) InventoryAPISyncClusterResourcesWithResponse(ctx c
 	return ParseInventoryAPISyncClusterResourcesResponse(rsp)
 }
 
+// RbacServiceAPIListGroupsWithResponse request returning *RbacServiceAPIListGroupsResponse
+func (c *ClientWithResponses) RbacServiceAPIListGroupsWithResponse(ctx context.Context, organizationId string, params *RbacServiceAPIListGroupsParams) (*RbacServiceAPIListGroupsResponse, error) {
+	rsp, err := c.RbacServiceAPIListGroups(ctx, organizationId, params)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRbacServiceAPIListGroupsResponse(rsp)
+}
+
+// RbacServiceAPIUpdateGroupsWithBodyWithResponse request with arbitrary body returning *RbacServiceAPIUpdateGroupsResponse
+func (c *ClientWithResponses) RbacServiceAPIUpdateGroupsWithBodyWithResponse(ctx context.Context, organizationId string, contentType string, body io.Reader) (*RbacServiceAPIUpdateGroupsResponse, error) {
+	rsp, err := c.RbacServiceAPIUpdateGroupsWithBody(ctx, organizationId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRbacServiceAPIUpdateGroupsResponse(rsp)
+}
+
+func (c *ClientWithResponses) RbacServiceAPIUpdateGroupsWithResponse(ctx context.Context, organizationId string, body RbacServiceAPIUpdateGroupsJSONRequestBody) (*RbacServiceAPIUpdateGroupsResponse, error) {
+	rsp, err := c.RbacServiceAPIUpdateGroups(ctx, organizationId, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRbacServiceAPIUpdateGroupsResponse(rsp)
+}
+
 // RbacServiceAPICreateGroupWithBodyWithResponse request with arbitrary body returning *RbacServiceAPICreateGroupResponse
 func (c *ClientWithResponses) RbacServiceAPICreateGroupWithBodyWithResponse(ctx context.Context, organizationId string, contentType string, body io.Reader) (*RbacServiceAPICreateGroupResponse, error) {
 	rsp, err := c.RbacServiceAPICreateGroupWithBody(ctx, organizationId, contentType, body)
@@ -37599,6 +37888,58 @@ func ParseInventoryAPISyncClusterResourcesResponse(rsp *http.Response) (*Invento
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRbacServiceAPIListGroupsResponse parses an HTTP response from a RbacServiceAPIListGroupsWithResponse call
+func ParseRbacServiceAPIListGroupsResponse(rsp *http.Response) (*RbacServiceAPIListGroupsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RbacServiceAPIListGroupsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CastaiRbacV1beta1ListGroupsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRbacServiceAPIUpdateGroupsResponse parses an HTTP response from a RbacServiceAPIUpdateGroupsWithResponse call
+func ParseRbacServiceAPIUpdateGroupsResponse(rsp *http.Response) (*RbacServiceAPIUpdateGroupsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RbacServiceAPIUpdateGroupsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []CastaiRbacV1beta1Group
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/castai/sdk/mock/client.go
+++ b/castai/sdk/mock/client.go
@@ -3875,6 +3875,26 @@ func (mr *MockClientInterfaceMockRecorder) RbacServiceAPIGetRoleBinding(ctx, org
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIGetRoleBinding", reflect.TypeOf((*MockClientInterface)(nil).RbacServiceAPIGetRoleBinding), varargs...)
 }
 
+// RbacServiceAPIListGroups mocks base method.
+func (m *MockClientInterface) RbacServiceAPIListGroups(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListGroupsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIListGroups", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListGroups indicates an expected call of RbacServiceAPIListGroups.
+func (mr *MockClientInterfaceMockRecorder) RbacServiceAPIListGroups(ctx, organizationId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListGroups", reflect.TypeOf((*MockClientInterface)(nil).RbacServiceAPIListGroups), varargs...)
+}
+
 // RbacServiceAPIListPermissionGroups mocks base method.
 func (m *MockClientInterface) RbacServiceAPIListPermissionGroups(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListPermissionGroupsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -3973,6 +3993,46 @@ func (mr *MockClientInterfaceMockRecorder) RbacServiceAPIUpdateGroupWithBody(ctx
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, organizationId, groupId, contentType, body}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIUpdateGroupWithBody", reflect.TypeOf((*MockClientInterface)(nil).RbacServiceAPIUpdateGroupWithBody), varargs...)
+}
+
+// RbacServiceAPIUpdateGroups mocks base method.
+func (m *MockClientInterface) RbacServiceAPIUpdateGroups(ctx context.Context, organizationId string, body sdk.RbacServiceAPIUpdateGroupsJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIUpdateGroups", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIUpdateGroups indicates an expected call of RbacServiceAPIUpdateGroups.
+func (mr *MockClientInterfaceMockRecorder) RbacServiceAPIUpdateGroups(ctx, organizationId, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIUpdateGroups", reflect.TypeOf((*MockClientInterface)(nil).RbacServiceAPIUpdateGroups), varargs...)
+}
+
+// RbacServiceAPIUpdateGroupsWithBody mocks base method.
+func (m *MockClientInterface) RbacServiceAPIUpdateGroupsWithBody(ctx context.Context, organizationId, contentType string, body io.Reader, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIUpdateGroupsWithBody", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIUpdateGroupsWithBody indicates an expected call of RbacServiceAPIUpdateGroupsWithBody.
+func (mr *MockClientInterfaceMockRecorder) RbacServiceAPIUpdateGroupsWithBody(ctx, organizationId, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIUpdateGroupsWithBody", reflect.TypeOf((*MockClientInterface)(nil).RbacServiceAPIUpdateGroupsWithBody), varargs...)
 }
 
 // RbacServiceAPIUpdateRoleBinding mocks base method.
@@ -13808,6 +13868,41 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIGetRoleBin
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIGetRoleBindingWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIGetRoleBindingWithResponse), ctx, organizationId, id)
 }
 
+// RbacServiceAPIListGroups mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIListGroups(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListGroupsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, params}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIListGroups", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListGroups indicates an expected call of RbacServiceAPIListGroups.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIListGroups(ctx, organizationId, params interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, params}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListGroups", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIListGroups), varargs...)
+}
+
+// RbacServiceAPIListGroupsWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIListGroupsWithResponse(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListGroupsParams) (*sdk.RbacServiceAPIListGroupsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RbacServiceAPIListGroupsWithResponse", ctx, organizationId, params)
+	ret0, _ := ret[0].(*sdk.RbacServiceAPIListGroupsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIListGroupsWithResponse indicates an expected call of RbacServiceAPIListGroupsWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIListGroupsWithResponse(ctx, organizationId, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIListGroupsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIListGroupsWithResponse), ctx, organizationId, params)
+}
+
 // RbacServiceAPIListPermissionGroups mocks base method.
 func (m *MockClientWithResponsesInterface) RbacServiceAPIListPermissionGroups(ctx context.Context, organizationId string, params *sdk.RbacServiceAPIListPermissionGroupsParams, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -13981,6 +14076,76 @@ func (m *MockClientWithResponsesInterface) RbacServiceAPIUpdateGroupWithResponse
 func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIUpdateGroupWithResponse(ctx, organizationId, groupId, body interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIUpdateGroupWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIUpdateGroupWithResponse), ctx, organizationId, groupId, body)
+}
+
+// RbacServiceAPIUpdateGroups mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIUpdateGroups(ctx context.Context, organizationId string, body sdk.RbacServiceAPIUpdateGroupsJSONRequestBody, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIUpdateGroups", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIUpdateGroups indicates an expected call of RbacServiceAPIUpdateGroups.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIUpdateGroups(ctx, organizationId, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIUpdateGroups", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIUpdateGroups), varargs...)
+}
+
+// RbacServiceAPIUpdateGroupsWithBody mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIUpdateGroupsWithBody(ctx context.Context, organizationId, contentType string, body io.Reader, reqEditors ...sdk.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, organizationId, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RbacServiceAPIUpdateGroupsWithBody", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIUpdateGroupsWithBody indicates an expected call of RbacServiceAPIUpdateGroupsWithBody.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIUpdateGroupsWithBody(ctx, organizationId, contentType, body interface{}, reqEditors ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, organizationId, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIUpdateGroupsWithBody", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIUpdateGroupsWithBody), varargs...)
+}
+
+// RbacServiceAPIUpdateGroupsWithBodyWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIUpdateGroupsWithBodyWithResponse(ctx context.Context, organizationId, contentType string, body io.Reader) (*sdk.RbacServiceAPIUpdateGroupsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RbacServiceAPIUpdateGroupsWithBodyWithResponse", ctx, organizationId, contentType, body)
+	ret0, _ := ret[0].(*sdk.RbacServiceAPIUpdateGroupsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIUpdateGroupsWithBodyWithResponse indicates an expected call of RbacServiceAPIUpdateGroupsWithBodyWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIUpdateGroupsWithBodyWithResponse(ctx, organizationId, contentType, body interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIUpdateGroupsWithBodyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIUpdateGroupsWithBodyWithResponse), ctx, organizationId, contentType, body)
+}
+
+// RbacServiceAPIUpdateGroupsWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) RbacServiceAPIUpdateGroupsWithResponse(ctx context.Context, organizationId string, body sdk.RbacServiceAPIUpdateGroupsJSONRequestBody) (*sdk.RbacServiceAPIUpdateGroupsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RbacServiceAPIUpdateGroupsWithResponse", ctx, organizationId, body)
+	ret0, _ := ret[0].(*sdk.RbacServiceAPIUpdateGroupsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RbacServiceAPIUpdateGroupsWithResponse indicates an expected call of RbacServiceAPIUpdateGroupsWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) RbacServiceAPIUpdateGroupsWithResponse(ctx, organizationId, body interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RbacServiceAPIUpdateGroupsWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).RbacServiceAPIUpdateGroupsWithResponse), ctx, organizationId, body)
 }
 
 // RbacServiceAPIUpdateRoleBinding mocks base method.

--- a/castai/sdk/patching_engine/api.gen.go
+++ b/castai/sdk/patching_engine/api.gen.go
@@ -524,7 +524,7 @@ type PodMutation struct {
 	// PodEviction Eviction settings for enforcement of pod mutations.
 	PodEviction *PodEviction `json:"podEviction,omitempty"`
 
-	// RestartMatchingWorkloads Restart matching workloads when the pod mutation is applied.
+	// RestartMatchingWorkloads Deprecated: restart_matching_workloads is deprecated.
 	RestartMatchingWorkloads *bool `json:"restartMatchingWorkloads,omitempty"`
 
 	// Source The source of the pod mutation.

--- a/docs/resources/commitment.md
+++ b/docs/resources/commitment.md
@@ -213,6 +213,7 @@ Required:
 
 - `id` (String) Capacity reservation ID.
 - `instance_type` (String) EC2 instance type.
+- `interruptible` (Boolean) Whether this reservation is interruptible. Set to true for interruptible ODCRs, false otherwise.
 - `total_instance_count` (Number) Total reserved instance count.
 
 Optional:
@@ -223,7 +224,6 @@ Optional:
 - `end_date_type` (String) End date type (unlimited, limited).
 - `instance_match_criteria` (String) Instance match criteria (open, targeted).
 - `instance_platform` (String) Instance platform (e.g. Linux/UNIX).
-- `interruptible` (Boolean) Whether this reservation is interruptible.
 - `state` (String) Capacity reservation state.
 - `tenancy` (String) Tenancy (default, dedicated).
 
@@ -312,6 +312,7 @@ Required:
 
 - `id` (String) Reservation ID.
 - `instance_type` (String) Instance type covered by the reservation.
+- `specific_reservation_required` (Boolean) Whether the reservation requires specific reservation affinity. Set to true for targeted reservations, false for automatic (open) reservations.
 - `total_instance_count` (Number) Total number of instances reserved.
 
 Optional:
@@ -324,7 +325,6 @@ Optional:
 - `project_id` (String) GCP project ID that owns the reservation.
 - `self_link` (String) Server-defined URL for the reservation (e.g. https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/reservations/my-reservation).
 - `share_settings` (Attributes) Reservation sharing settings. (see [below for nested schema](#nestedatt--gcp_capacity_reservation_details--share_settings))
-- `specific_reservation_required` (Boolean) Whether the reservation requires specific reservation affinity.
 - `state` (String) Runtime state of the reservation (e.g. READY).
 - `zone` (String) GCP zone of the reservation.
 

--- a/docs/resources/commitment.md
+++ b/docs/resources/commitment.md
@@ -81,14 +81,14 @@ resource "castai_commitment" "gcp_capacity_reservation" {
   start_time = "2026-01-01T00:00:00Z"
 
   gcp_capacity_reservation_details = {
-    id                              = "my-reservation"
-    self_link                       = "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/reservations/my-reservation"
-    project_id                      = "my-project"
-    zone                            = "us-central1-a"
-    instance_type                   = "a2-highgpu-1g"
-    total_instance_count            = 4
-    specific_reservation_required   = true
-    state                           = "READY"
+    id                            = "my-reservation"
+    self_link                     = "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/reservations/my-reservation"
+    project_id                    = "my-project"
+    zone                          = "us-central1-a"
+    instance_type                 = "a2-highgpu-1g"
+    total_instance_count          = 4
+    specific_reservation_required = true
+    state                         = "READY"
 
     accelerators = [
       {

--- a/docs/resources/commitment.md
+++ b/docs/resources/commitment.md
@@ -81,13 +81,14 @@ resource "castai_commitment" "gcp_capacity_reservation" {
   start_time = "2026-01-01T00:00:00Z"
 
   gcp_capacity_reservation_details = {
-    id                   = "my-reservation"
-    self_link            = "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/reservations/my-reservation"
-    project_id           = "my-project"
-    zone                 = "us-central1-a"
-    instance_type        = "a2-highgpu-1g"
-    total_instance_count = 4
-    state                = "READY"
+    id                              = "my-reservation"
+    self_link                       = "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/reservations/my-reservation"
+    project_id                      = "my-project"
+    zone                            = "us-central1-a"
+    instance_type                   = "a2-highgpu-1g"
+    total_instance_count            = 4
+    specific_reservation_required   = true
+    state                           = "READY"
 
     accelerators = [
       {

--- a/examples/resources/castai_commitment/resource.tf
+++ b/examples/resources/castai_commitment/resource.tf
@@ -66,13 +66,14 @@ resource "castai_commitment" "gcp_capacity_reservation" {
   start_time = "2026-01-01T00:00:00Z"
 
   gcp_capacity_reservation_details = {
-    id                   = "my-reservation"
-    self_link            = "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/reservations/my-reservation"
-    project_id           = "my-project"
-    zone                 = "us-central1-a"
-    instance_type        = "a2-highgpu-1g"
-    total_instance_count = 4
-    state                = "READY"
+    id                              = "my-reservation"
+    self_link                       = "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/reservations/my-reservation"
+    project_id                      = "my-project"
+    zone                            = "us-central1-a"
+    instance_type                   = "a2-highgpu-1g"
+    total_instance_count            = 4
+    specific_reservation_required   = true
+    state                           = "READY"
 
     accelerators = [
       {

--- a/examples/resources/castai_commitment/resource.tf
+++ b/examples/resources/castai_commitment/resource.tf
@@ -66,14 +66,14 @@ resource "castai_commitment" "gcp_capacity_reservation" {
   start_time = "2026-01-01T00:00:00Z"
 
   gcp_capacity_reservation_details = {
-    id                              = "my-reservation"
-    self_link                       = "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/reservations/my-reservation"
-    project_id                      = "my-project"
-    zone                            = "us-central1-a"
-    instance_type                   = "a2-highgpu-1g"
-    total_instance_count            = 4
-    specific_reservation_required   = true
-    state                           = "READY"
+    id                            = "my-reservation"
+    self_link                     = "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/reservations/my-reservation"
+    project_id                    = "my-project"
+    zone                          = "us-central1-a"
+    instance_type                 = "a2-highgpu-1g"
+    total_instance_count          = 4
+    specific_reservation_required = true
+    state                         = "READY"
 
     accelerators = [
       {


### PR DESCRIPTION
Proto3 non-optional scalars always serialize in JSON even when unset (0/false). Fields that users can omit must be Computed so Terraform accepts the API-returned value instead of flagging a null→0 mismatch. Fields that directly affect  autoscaler matching (specific_reservation_required, interruptible) are made Required to prevent silent behavioral mismatches when omitted.  