### PR TITLE
chore: remove apimachinery dependency by using different backoff lib

### DIFF
--- a/castai/resource_autoscaler.go
+++ b/castai/resource_autoscaler.go
@@ -1000,7 +1000,7 @@ func getChangedPolicies(ctx context.Context, data types.ResourceProvider, meta i
 	currentPolicies, err := getCurrentPolicies(ctx, client, clusterId)
 	if err != nil {
 		log.Printf("[WARN] Getting current policies: %v", err)
-		return nil, fmt.Errorf("failed to get policies from API: %v", err)
+		return nil, fmt.Errorf("failed to get policies from API: %w", err)
 	}
 
 	policies, err := jsonpatch.MergePatch(currentPolicies, policyChanges)

--- a/castai/resource_autoscaler.go
+++ b/castai/resource_autoscaler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -12,13 +13,13 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/mitchellh/mapstructure"
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/castai/terraform-provider-castai/castai/sdk"
 	"github.com/castai/terraform-provider-castai/castai/types"
@@ -831,32 +832,35 @@ func updateAutoscalerPolicies(ctx context.Context, data *schema.ResourceData, me
 		return upsertPolicies(ctx, meta, clusterId, changedPoliciesJSON)
 	}
 
-	// Exponential backoff configuration
-	backoff := wait.Backoff{
-		Duration: 100 * time.Millisecond,
-		Factor:   2.0,
-		Jitter:   0.1,
-		Steps:    5,
-		Cap:      2 * time.Second,
-	}
+	// Exponential backoff configuration: 100ms initial, 2.0 multiplier, 0.1 jitter,
+	// capped at 2s, max 5 total attempts (1 initial + 4 retries).
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = 100 * time.Millisecond
+	b.Multiplier = 2.0
+	b.RandomizationFactor = 0.1
+	b.MaxInterval = 2 * time.Second
+	b.MaxElapsedTime = 0 // disable elapsed-time limit; rely on max retries
 
-	retryErr := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (done bool, err error) {
-		err = updatePolicies()
+	bWithCtx := backoff.WithContext(backoff.WithMaxRetries(b, 4), ctx)
+
+	retryErr := backoff.RetryNotify(func() error {
+		err := updatePolicies()
 		if err == nil {
-			return true, nil // Success - stop retrying
+			return nil // Success - stop retrying
 		}
 
-		// Check if error is retryable
+		// Check if error is retryable.
 		if !isNodeTemplateVersionConflict(err) {
-			return false, err // Non-retryable error - stop with error
+			return backoff.Permanent(err) // Non-retryable error - stop with error
 		}
 
+		return err // Retryable error - continue retrying
+	}, bWithCtx, func(err error, _ time.Duration) {
 		log.Printf("[DEBUG] Retry failed with version conflict: %v", err)
-		return false, nil // Retryable error - continue retrying
 	})
 
 	if retryErr != nil {
-		if wait.Interrupted(retryErr) {
+		if errors.Is(retryErr, context.Canceled) || errors.Is(retryErr, context.DeadlineExceeded) {
 			return fmt.Errorf("timeout waiting for autoscaler policy update after version conflicts: %w", retryErr)
 		}
 		return retryErr

--- a/castai/resource_autoscaler_test.go
+++ b/castai/resource_autoscaler_test.go
@@ -995,6 +995,154 @@ func TestAutoscalerResource_GetChangePolicies_AdjustPolicyForDrift(t *testing.T)
 	r.Equal(string(expectedPolicyJSON), string(result))
 }
 
+func TestAutoscalerResource_UpdateAutoscalerPolicies_RetriesOnVersionConflict(t *testing.T) {
+	r := require.New(t)
+	mockCtrl := gomock.NewController(t)
+	mockClient := mock_sdk.NewMockClientInterface(mockCtrl)
+
+	ctx := context.Background()
+	provider := &ProviderConfig{
+		api: &sdk.ClientWithResponses{
+			ClientInterface: mockClient,
+		},
+	}
+
+	currentPolicies := `{"enabled":true,"unschedulablePods":{"enabled":true}}`
+	policyChanges := `{"enabled":true}`
+
+	res := resourceAutoscaler()
+	clusterId := "cluster_id"
+	val := cty.ObjectVal(map[string]cty.Value{
+		FieldAutoscalerPoliciesJSON: cty.StringVal(policyChanges),
+		FieldClusterId:              cty.StringVal(clusterId),
+	})
+	state := terraform.NewInstanceStateShimmedFromValue(val, 0)
+	data := res.Data(state)
+
+	conflictBody := `{"message":"node template has changed; please refetch the policies"}`
+	okBody := `{}`
+
+	// Each Get call needs a fresh body because the reader is consumed.
+	getCalls := 0
+	mockClient.EXPECT().
+		PoliciesAPIGetClusterPolicies(gomock.Any(), clusterId, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ ...sdk.RequestEditorFn) (*http.Response, error) {
+			getCalls++
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader([]byte(currentPolicies))),
+			}, nil
+		}).Times(5)
+
+	// 4 conflicts then success => 5 total attempts.
+	mockClient.EXPECT().
+		PoliciesAPIUpsertClusterPoliciesWithBody(gomock.Any(), clusterId, "application/json", gomock.Any()).
+		Times(4).
+		DoAndReturn(func(_ context.Context, _ string, _ string, _ io.Reader, _ ...sdk.RequestEditorFn) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       io.NopCloser(bytes.NewReader([]byte(conflictBody))),
+			}, nil
+		})
+
+	mockClient.EXPECT().
+		PoliciesAPIUpsertClusterPoliciesWithBody(gomock.Any(), clusterId, "application/json", gomock.Any()).
+		Times(1).
+		DoAndReturn(func(_ context.Context, _ string, _ string, _ io.Reader, _ ...sdk.RequestEditorFn) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader([]byte(okBody))),
+			}, nil
+		})
+
+	err := updateAutoscalerPolicies(ctx, data, provider)
+	r.NoError(err)
+	r.Equal(5, getCalls)
+}
+
+func TestAutoscalerResource_UpdateAutoscalerPolicies_NonRetryableError(t *testing.T) {
+	r := require.New(t)
+	mockCtrl := gomock.NewController(t)
+	mockClient := mock_sdk.NewMockClientInterface(mockCtrl)
+
+	ctx := context.Background()
+	provider := &ProviderConfig{
+		api: &sdk.ClientWithResponses{
+			ClientInterface: mockClient,
+		},
+	}
+
+	currentPolicies := `{"enabled":true}`
+	policyChanges := `{"enabled":true}`
+
+	res := resourceAutoscaler()
+	clusterId := "cluster_id"
+	val := cty.ObjectVal(map[string]cty.Value{
+		FieldAutoscalerPoliciesJSON: cty.StringVal(policyChanges),
+		FieldClusterId:              cty.StringVal(clusterId),
+	})
+	state := terraform.NewInstanceStateShimmedFromValue(val, 0)
+	data := res.Data(state)
+
+	mockClient.EXPECT().
+		PoliciesAPIGetClusterPolicies(gomock.Any(), clusterId, gomock.Any()).
+		Return(&http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader([]byte(currentPolicies)))}, nil).
+		Times(1)
+
+	// Non-retryable error (HTTP 400 with non-conflict message) should NOT be retried.
+	mockClient.EXPECT().
+		PoliciesAPIUpsertClusterPoliciesWithBody(gomock.Any(), clusterId, "application/json", gomock.Any()).
+		Times(1).
+		DoAndReturn(func(_ context.Context, _ string, _ string, _ io.Reader, _ ...sdk.RequestEditorFn) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 400,
+				Body:       io.NopCloser(bytes.NewReader([]byte(`{"message":"invalid request"}`))),
+			}, nil
+		})
+
+	err := updateAutoscalerPolicies(ctx, data, provider)
+	r.Error(err)
+	r.Contains(err.Error(), "status=400")
+}
+
+func TestAutoscalerResource_UpdateAutoscalerPolicies_ContextCanceledWrapsTimeoutMessage(t *testing.T) {
+	r := require.New(t)
+	mockCtrl := gomock.NewController(t)
+	mockClient := mock_sdk.NewMockClientInterface(mockCtrl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	provider := &ProviderConfig{
+		api: &sdk.ClientWithResponses{
+			ClientInterface: mockClient,
+		},
+	}
+
+	policyChanges := `{"enabled":true}`
+
+	res := resourceAutoscaler()
+	clusterId := "cluster_id"
+	val := cty.ObjectVal(map[string]cty.Value{
+		FieldAutoscalerPoliciesJSON: cty.StringVal(policyChanges),
+		FieldClusterId:              cty.StringVal(clusterId),
+	})
+	state := terraform.NewInstanceStateShimmedFromValue(val, 0)
+	data := res.Data(state)
+
+	// When the Get call itself fails because the context was cancelled,
+	// updatePolicies() returns a non-retryable error wrapped with the context error.
+	// The implementation returns this wrapped context error directly (not via the
+	// "timeout waiting for autoscaler policy update..." path), which preserves
+	// the original behavior. We assert here that some error is returned.
+	mockClient.EXPECT().
+		PoliciesAPIGetClusterPolicies(gomock.Any(), clusterId, gomock.Any()).
+		Return(nil, context.Canceled).
+		AnyTimes()
+
+	err := updateAutoscalerPolicies(ctx, data, provider)
+	r.Error(err)
+}
+
 func JSONBytesEqual(a, b []byte) (bool, error) {
 	var j, j2 interface{}
 	if err := json.Unmarshal(a, &j); err != nil {

--- a/castai/resource_autoscaler_test.go
+++ b/castai/resource_autoscaler_test.go
@@ -1131,9 +1131,8 @@ func TestAutoscalerResource_UpdateAutoscalerPolicies_ContextCanceledWrapsTimeout
 
 	// When the Get call itself fails because the context was cancelled,
 	// updatePolicies() returns a non-retryable error wrapped with the context error.
-	// The implementation returns this wrapped context error directly (not via the
-	// "timeout waiting for autoscaler policy update..." path), which preserves
-	// the original behavior. We assert here that some error is returned.
+	// The implementation detects context cancellation/deadline-exceeded and wraps
+	// the error with the timeout message, which preserves the original behavior.
 	mockClient.EXPECT().
 		PoliciesAPIGetClusterPolicies(gomock.Any(), clusterId, gomock.Any()).
 		Return(nil, context.Canceled).
@@ -1141,6 +1140,7 @@ func TestAutoscalerResource_UpdateAutoscalerPolicies_ContextCanceledWrapsTimeout
 
 	err := updateAutoscalerPolicies(ctx, data, provider)
 	r.Error(err)
+	r.Contains(err.Error(), "timeout waiting for autoscaler policy update after version conflicts")
 }
 
 func JSONBytesEqual(a, b []byte) (bool, error) {

--- a/castai/sdk/api.gen.go
+++ b/castai/sdk/api.gen.go
@@ -11131,6 +11131,7 @@ type WorkloadoptimizationV1RecommendationStatusType string
 
 // WorkloadoptimizationV1RecommendationStep RecommendationStep captures a single transformation stage in the recommendation
 // pipeline. The args field contains unstructured step-specific parameters.
+// Deprecated: only used by the deprecated RecommendationSummary.
 type WorkloadoptimizationV1RecommendationStep struct {
 	Args      *map[string]interface{}                          `json:"args,omitempty"`
 	Labels    *[]WorkloadoptimizationV1RecommendationStepLabel `json:"labels,omitempty"`
@@ -11173,6 +11174,7 @@ type WorkloadoptimizationV1RecommendationStopReasonType string
 
 // WorkloadoptimizationV1RecommendationSummary RecommendationSummary describes the overall outcome and per-container calculation steps
 // for a workload recommendation event.
+// Deprecated: no longer populated, always empty. Use debug_data instead.
 type WorkloadoptimizationV1RecommendationSummary struct {
 	ActionType               *WorkloadoptimizationV1ActionType                                `json:"actionType,omitempty"`
 	ApplyType                *WorkloadoptimizationV1ApplyType                                 `json:"applyType,omitempty"`
@@ -11190,6 +11192,7 @@ type WorkloadoptimizationV1RecommendedPodCountChangedEvent struct {
 
 	// Summary RecommendationSummary describes the overall outcome and per-container calculation steps
 	// for a workload recommendation event.
+	// Deprecated: no longer populated, always empty. Use debug_data instead.
 	Summary *WorkloadoptimizationV1RecommendationSummary `json:"summary,omitempty"`
 }
 
@@ -11203,6 +11206,7 @@ type WorkloadoptimizationV1RecommendedRequestsChangedEvent struct {
 
 	// Summary RecommendationSummary describes the overall outcome and per-container calculation steps
 	// for a workload recommendation event.
+	// Deprecated: no longer populated, always empty. Use debug_data instead.
 	Summary *WorkloadoptimizationV1RecommendationSummary `json:"summary,omitempty"`
 }
 
@@ -11584,6 +11588,21 @@ type WorkloadoptimizationV1ScalingPolicyUpdated struct {
 	Previous WorkloadoptimizationV1WorkloadScalingPolicy `json:"previous"`
 }
 
+// WorkloadoptimizationV1SchedulerReasons SchedulerReasons is the parsed blocked-node reason breakdown from the
+// Kubernetes scheduler's PodScheduled condition message.
+type WorkloadoptimizationV1SchedulerReasons struct {
+	// BlockedNodesTotal blocked_nodes_total is the sum of all counters above.
+	BlockedNodesTotal    *int32 `json:"blockedNodesTotal,omitempty"`
+	InsufficientCpu      *int32 `json:"insufficientCpu,omitempty"`
+	InsufficientMemory   *int32 `json:"insufficientMemory,omitempty"`
+	NodeAffinityMismatch *int32 `json:"nodeAffinityMismatch,omitempty"`
+
+	// Other other counts nodes blocked by reasons not covered by the fields above.
+	Other             *int32 `json:"other,omitempty"`
+	TooManyPods       *int32 `json:"tooManyPods,omitempty"`
+	UntoleratedTaints *int32 `json:"untoleratedTaints,omitempty"`
+}
+
 // WorkloadoptimizationV1SetScalingPoliciesOrderResponse defines model for workloadoptimization.v1.SetScalingPoliciesOrderResponse.
 type WorkloadoptimizationV1SetScalingPoliciesOrderResponse = map[string]interface{}
 
@@ -11716,6 +11735,10 @@ type WorkloadoptimizationV1UnschedulableRecommendationEvent struct {
 	// detection pass. A single event covers every unschedulable pod in the workload,
 	// not a separate event per pod.
 	Pods []WorkloadoptimizationV1UnschedulableRecommendationEventUnschedulablePod `json:"pods"`
+
+	// Truncated truncated is set when the per-event pod cap stopped scanning before all
+	// pending pods were examined; more unschedulable pods may exist than listed.
+	Truncated *bool `json:"truncated"`
 }
 
 // WorkloadoptimizationV1UnschedulableRecommendationEventUnschedulablePod UnschedulablePod describes a single unschedulable pod observed for the workload.
@@ -11730,6 +11753,10 @@ type WorkloadoptimizationV1UnschedulableRecommendationEventUnschedulablePod stru
 	PendingDuration    string                                            `json:"pendingDuration"`
 	PodName            string                                            `json:"podName"`
 	RecommendationHash string                                            `json:"recommendationHash"`
+
+	// SchedulerReasons SchedulerReasons is the parsed blocked-node reason breakdown from the
+	// Kubernetes scheduler's PodScheduled condition message.
+	SchedulerReasons *WorkloadoptimizationV1SchedulerReasons `json:"schedulerReasons,omitempty"`
 }
 
 // WorkloadoptimizationV1UpdateCustomMetricsDataSource defines model for workloadoptimization.v1.UpdateCustomMetricsDataSource.

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.55.0
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
-	k8s.io/apimachinery v0.30.0
 )
 
 require (
@@ -128,8 +127,6 @@ require (
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/klog/v2 v2.130.1 // indirect
-	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 )
 
 exclude github.com/satori/go.uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -5588,12 +5588,6 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
-k8s.io/apimachinery v0.30.0 h1:qxVPsyDM5XS96NIh9Oj6LavoVFYff/Pon9cZeDIkHHA=
-k8s.io/apimachinery v0.30.0/go.mod h1:iexa2somDaxdnj7bha06bhb43Zpa6eWH8N8dbqVjTUc=
-k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
-k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
-k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
-k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 lukechampine.com/uint128 v1.2.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 lukechampine.com/uint128 v1.3.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=


### PR DESCRIPTION
We've pulled in `k8s.io/apimachinery` only to use its `wait.Backoff()` function in a single place. In other places we're using `github.com/cenkalti/backoff` for the same.

In this PR I'm replacing that single usage with `github.com/cenkalti/backoff` and drop the no longer necessary dependency on `k8s.io/apimachinery`.